### PR TITLE
fix: make PDF fallback optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ cd BossHunter
 # 2. 安装 Python 依赖
 pip install -e .
 
+# 可选：仅在需要 xhtml2pdf fallback 渲染时安装
+pip install -e ".[pdf]"
+
 # 3. 复制并编辑配置（或通过 Web 面板配置）
 cp config.example.yaml config.yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,12 @@ dependencies = [
     "pyyaml>=6.0",
     "anthropic>=0.40",
     "markdown2>=2.4",
-    "xhtml2pdf>=0.2.11",
     "bottle>=0.13",
+]
+
+[project.optional-dependencies]
+pdf = [
+    "xhtml2pdf>=0.2.11",
 ]
 
 [project.scripts]

--- a/src/bosshunter/ai/greeter.py
+++ b/src/bosshunter/ai/greeter.py
@@ -200,7 +200,6 @@ def generate_greetings(config: dict) -> int:
         for job in jobs:
             # Generate with self-review loop
             best_greeting = None
-            best_score = 0.0
 
             for iteration in range(max_iterations + 1):
                 critique = ""

--- a/src/bosshunter/ai/resume.py
+++ b/src/bosshunter/ai/resume.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from rich.console import Console
 
-from bosshunter.db import get_db, get_jobs_by_status
+from bosshunter.db import get_db
 
 console = Console()
 
@@ -255,7 +255,7 @@ def generate_tailored_resume(job_id: str, config: dict) -> Path | None:
         return pdf_path
     else:
         console.print(f"[yellow]PDF 渲染库未安装，已保存为 Markdown: {md_path}[/yellow]")
-        console.print("[dim]  安装 PDF 支持: pip install markdown2 xhtml2pdf[/dim]")
+        console.print('[dim]  安装 PDF fallback 支持: pip install -e ".[pdf]"[/dim]')
         db.execute(
             "UPDATE jobs SET resume_path = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
             (str(md_path), job_id)

--- a/src/bosshunter/browser/__init__.py
+++ b/src/bosshunter/browser/__init__.py
@@ -1,6 +1,5 @@
 """Browser connection module - CDP Proxy connection to user's Chrome."""
 
-import json
 import time
 from typing import Any
 

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -6,12 +6,12 @@ import os
 
 from rich.console import Console
 
-from bosshunter.browser import new_tab, close_tab, evaluate, click, navigate, wait_for_load, get_page_info
+from bosshunter.browser import new_tab, close_tab, evaluate, click, wait_for_load, get_page_info
 from bosshunter.db import (
     get_db, get_jobs_by_status,
     update_job_status, add_history,
 )
-from bosshunter.throttle import RequestThrottle, SendWindowChecker, ProgressiveBackoff, should_take_day_off
+from bosshunter.throttle import RequestThrottle, SendWindowChecker
 
 console = Console()
 
@@ -829,7 +829,6 @@ def monitor_and_send_resumes(config: dict) -> dict:
     Returns summary dict with counts.
     """
     throttle_config = config.get("throttle", {})
-    monitor_cfg = config.get("monitor", {})
 
     # Time window check (09:00-16:00)
     window_checker = SendWindowChecker(throttle_config.get("send_windows", ["09:00-16:00"]))
@@ -873,7 +872,7 @@ def monitor_and_send_resumes(config: dict) -> dict:
 
             throttle.wait()
 
-        console.print(f"\n[bold green]═══ 回复处理完成 ═══[/bold green]")
+        console.print("\n[bold green]═══ 回复处理完成 ═══[/bold green]")
         console.print(f"  跳过(已手动回复): {summary['skipped']}")
         console.print(f"  自动回复: {summary['replied']}")
         if summary.get("needs_resume"):

--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -5,7 +5,7 @@ import json
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
 
-from bosshunter.browser import new_tab, close_tab, evaluate, click, wait_for_load
+from bosshunter.browser import new_tab, close_tab, evaluate
 from bosshunter.db import get_db, get_jobs_by_status, update_job_status, add_history, add_risk_event
 from bosshunter.throttle import RequestThrottle, SendWindowChecker, ProgressiveBackoff, should_take_day_off
 
@@ -67,7 +67,7 @@ def send_greetings(config: dict, force: bool = False) -> int:
     window_checker = SendWindowChecker(send_windows)
     if not window_checker.is_active():
         info = window_checker.next_window_info()
-        console.print(f"[yellow]⏰ 当前不在发送时间窗口内，暂不发送[/yellow]")
+        console.print("[yellow]⏰ 当前不在发送时间窗口内，暂不发送[/yellow]")
         console.print(f"[dim]  {info}[/dim]")
         add_risk_event(db, "outside_window", info)
         db.close()

--- a/src/bosshunter/main.py
+++ b/src/bosshunter/main.py
@@ -242,7 +242,7 @@ def web(ctx: click.Context, port: int, no_open: bool) -> None:
     """启动 Web Dashboard（本地看板 + 配置管理）"""
     from bosshunter.web.server import run_server
 
-    console.print(f"[bold cyan]═══ BossHunter Web Dashboard ═══[/bold cyan]")
+    console.print("[bold cyan]═══ BossHunter Web Dashboard ═══[/bold cyan]")
     console.print(f"[dim]http://127.0.0.1:{port}[/dim]\n")
     run_server(host="127.0.0.1", port=port, open_browser=not no_open)
 

--- a/src/bosshunter/pipeline.py
+++ b/src/bosshunter/pipeline.py
@@ -60,7 +60,7 @@ def run_pipeline(config: dict) -> None:
     console.print(f"\n[bold green]═══ 发送完成！{sent} 条招呼语 ═══[/bold green]")
 
     # Step 6: Auto-start monitor loop
-    console.print(f"\n[bold]Step 6/6: 启动持续监测[/bold]")
+    console.print("\n[bold]Step 6/6: 启动持续监测[/bold]")
     interval_min = config.get("monitor", {}).get("interval", 30)
     interval_sec = interval_min * 60
     console.print(f"[dim]每 {interval_min} 分钟检查一次HR回复和跟进，按 Ctrl+C 停止[/dim]\n")

--- a/src/bosshunter/scraper/jobs.py
+++ b/src/bosshunter/scraper/jobs.py
@@ -5,14 +5,13 @@ import random
 import re
 import time
 import hashlib
-from typing import Any
 from urllib.parse import quote
 
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from bosshunter.browser import (
-    new_tab, close_tab, evaluate, scroll, wait_for_load, get_page_info
+    new_tab, close_tab, evaluate, scroll, wait_for_load
 )
 from bosshunter.config import CITY_CODES
 from bosshunter.db import get_db, job_exists, insert_job

--- a/src/bosshunter/tracker/status.py
+++ b/src/bosshunter/tracker/status.py
@@ -4,8 +4,6 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich.columns import Columns
-from rich.text import Text
-from rich.layout import Layout
 
 from bosshunter.db import (
     get_db, get_stats, get_funnel_stats,

--- a/src/bosshunter/ui/confirm.py
+++ b/src/bosshunter/ui/confirm.py
@@ -2,7 +2,6 @@
 
 from rich.console import Console
 from rich.table import Table
-from rich.panel import Panel
 from rich.prompt import Prompt
 
 from bosshunter.db import get_db, get_jobs_by_status, update_job_status, add_history

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -6,7 +6,6 @@ Serves:
 """
 
 import json
-import os
 import time
 from pathlib import Path
 


### PR DESCRIPTION
## What changed

- moved `xhtml2pdf` into a `pdf` optional extra
- kept the default install focused on the CLI/runtime path
- updated the README and fallback message to point to `pip install -e ".[pdf]"`
- cleaned up existing ruff warnings so the CI lint step is clean once install reaches it

## Why

The current CI fails during `pip install -e .` because `xhtml2pdf` pulls in the `pycairo` build chain, which needs Cairo system libraries on the Ubuntu runner. The CLI smoke test does not need the xhtml2pdf fallback path, so the base install should not require those native PDF dependencies.

Chrome/CDP PDF rendering remains the preferred path. Users who need the xhtml2pdf fallback can still install it explicitly through the `pdf` extra.

Fixes #5.

## Checks

- `ruff check src\`
- `python -m compileall -q src`
- `bosshunter --help`
- `bosshunter --version`
- `C:\Users\gioia.zheng\anaconda3\python.exe -c "import bosshunter; print(bosshunter.__version__)"`
- clean venv: `pip install -e .` completed without installing `xhtml2pdf` or `pycairo`
