### PR TITLE
fix: read documented Anthropic API key

### DIFF
--- a/src/bosshunter/ai/credentials.py
+++ b/src/bosshunter/ai/credentials.py
@@ -1,0 +1,13 @@
+"""Credential helpers for AI providers."""
+
+import os
+
+
+def get_anthropic_api_key(config: dict) -> str | None:
+    """Resolve the Anthropic API key from env or config."""
+    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
+    return (
+        os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+        or ai_cfg.get("api_key")
+    )

--- a/src/bosshunter/ai/greeter.py
+++ b/src/bosshunter/ai/greeter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from bosshunter.ai.credentials import get_anthropic_api_key
 from bosshunter.db import get_db, get_jobs_by_status, update_job_greeting, update_job_status
 
 console = Console()
@@ -76,7 +77,7 @@ def _call_claude(prompt: str, config: dict) -> str | None:
         return None
 
     ai_cfg = config.get("ai", {})
-    api_key = os.environ.get("ANTHROPIC_AUTH_TOKEN") or ai_cfg.get("api_key")
+    api_key = get_anthropic_api_key(config)
     if not api_key:
         return None
 

--- a/src/bosshunter/ai/resume.py
+++ b/src/bosshunter/ai/resume.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from rich.console import Console
 
+from bosshunter.ai.credentials import get_anthropic_api_key
 from bosshunter.db import get_db, get_jobs_by_status
 
 console = Console()
@@ -40,7 +41,7 @@ def _call_claude(prompt: str, config: dict) -> str | None:
         return None
 
     ai_cfg = config.get("ai", {})
-    api_key = os.environ.get("ANTHROPIC_AUTH_TOKEN") or ai_cfg.get("api_key")
+    api_key = get_anthropic_api_key(config)
     if not api_key:
         return None
 

--- a/src/bosshunter/ai/scorer.py
+++ b/src/bosshunter/ai/scorer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from bosshunter.ai.credentials import get_anthropic_api_key
 from bosshunter.db import get_db, get_jobs_by_status, update_job_score, update_job_status, update_job_quick_score
 from bosshunter.ai.prefilter import quick_score
 
@@ -55,7 +56,7 @@ def _call_claude(prompt: str, config: dict) -> str | None:
         return None
 
     ai_cfg = config.get("ai", {})
-    api_key = os.environ.get("ANTHROPIC_AUTH_TOKEN") or ai_cfg.get("api_key")
+    api_key = get_anthropic_api_key(config)
     if not api_key:
         console.print("[red]未设置 ANTHROPIC_API_KEY 环境变量或 config.yaml ai.api_key[/red]")
         return None

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -6,6 +6,7 @@ import os
 
 from rich.console import Console
 
+from bosshunter.ai.credentials import get_anthropic_api_key
 from bosshunter.browser import new_tab, close_tab, evaluate, click, navigate, wait_for_load, get_page_info
 from bosshunter.db import (
     get_db, get_jobs_by_status,
@@ -115,7 +116,7 @@ def _call_claude(prompt: str, config: dict) -> str | None:
         return None
 
     ai_cfg = config.get("ai", {})
-    api_key = os.environ.get("ANTHROPIC_AUTH_TOKEN") or ai_cfg.get("api_key")
+    api_key = get_anthropic_api_key(config)
     if not api_key:
         return None
 

--- a/tests/test_ai_credentials.py
+++ b/tests/test_ai_credentials.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch
+
+from bosshunter.ai.credentials import get_anthropic_api_key
+
+
+class AnthropicCredentialTests(unittest.TestCase):
+    def test_prefers_documented_api_key_env_var(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "ANTHROPIC_API_KEY": "from-api-key",
+                "ANTHROPIC_AUTH_TOKEN": "from-auth-token",
+            },
+            clear=True,
+        ):
+            result = get_anthropic_api_key({"ai": {"api_key": "from-config"}})
+
+        self.assertEqual(result, "from-api-key")
+
+    def test_keeps_auth_token_as_backward_compatible_fallback(self):
+        with patch.dict("os.environ", {"ANTHROPIC_AUTH_TOKEN": "from-auth-token"}, clear=True):
+            result = get_anthropic_api_key({"ai": {"api_key": "from-config"}})
+
+        self.assertEqual(result, "from-auth-token")
+
+    def test_falls_back_to_config_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_anthropic_api_key({"ai": {"api_key": "from-config"}})
+
+        self.assertEqual(result, "from-config")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared Anthropic credential resolver
- prefer the documented ANTHROPIC_API_KEY environment variable
- keep ANTHROPIC_AUTH_TOKEN as a backward-compatible fallback
- use the same lookup in scoring, greeting, resume, and monitor AI calls

## Tests
- PYTHONPATH=src python -m unittest discover -s tests
- python -m compileall -q src tests
- ruff check src/bosshunter/ai/credentials.py tests/test_ai_credentials.py
- bosshunter --help
- bosshunter --version
- python -c "import bosshunter; print(bosshunter.__version__)"
- git diff --check

Fixes #1
