### PR TITLE
fix: align manual greet flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,16 +186,16 @@ bosshunter connect
 bosshunter run
 ```
 
-自动执行：采集 → 评分 → 招呼语 → 确认 → 发送 → 自动监测
+自动执行：采集 → 评分 → 确认 → 招呼语 → 发送 → 自动监测
 
 ### 分步执行
 
 ```bash
 bosshunter scrape -k "Python开发" -l 30   # 采集
 bosshunter score                            # AI 评分
-bosshunter greet                            # 生成招呼语
 bosshunter confirm                          # 人工确认（交互式）
-bosshunter send                             # 发送已确认的招呼语
+bosshunter greet                            # 为已确认岗位生成招呼语
+bosshunter send                             # 发送已生成的招呼语
 ```
 
 ### 监听模式

--- a/src/bosshunter/ai/greeter.py
+++ b/src/bosshunter/ai/greeter.py
@@ -176,7 +176,7 @@ def generate_greetings(config: dict) -> int:
     jobs = get_jobs_by_status(db, "approved")
 
     if not jobs:
-        console.print("[yellow]没有需要生成招呼语的岗位[/yellow]")
+        console.print("[yellow]没有已确认的岗位可生成招呼语。请先运行 `bosshunter confirm`，或使用 `bosshunter run` 执行完整流程。[/yellow]")
         return 0
 
     resume_summary = _get_resume_summary(config)

--- a/src/bosshunter/main.py
+++ b/src/bosshunter/main.py
@@ -119,7 +119,7 @@ def score(ctx: click.Context) -> None:
 @cli.command()
 @click.pass_context
 def greet(ctx: click.Context) -> None:
-    """为通过评分的岗位生成招呼语"""
+    """为已确认的岗位生成招呼语"""
     from bosshunter.ai.greeter import generate_greetings
 
     config = ctx.obj["config"]
@@ -142,7 +142,7 @@ def confirm(ctx: click.Context) -> None:
 @click.option("--force", is_flag=True, help="跳过随机休息日检查")
 @click.pass_context
 def send(ctx: click.Context, force: bool) -> None:
-    """自动发送已确认的招呼语"""
+    """自动发送已生成的招呼语"""
     from bosshunter.executor.sender import send_greetings
 
     config = ctx.obj["config"]
@@ -168,7 +168,7 @@ def status(ctx: click.Context, full: bool) -> None:
 @cli.command()
 @click.pass_context
 def run(ctx: click.Context) -> None:
-    """一键运行完整流程: 采集→评分→招呼语→确认→发送"""
+    """一键运行完整流程: 采集→评分→确认→招呼语→发送"""
     from bosshunter.pipeline import run_pipeline
 
     config = ctx.obj["config"]

--- a/src/bosshunter/pipeline.py
+++ b/src/bosshunter/pipeline.py
@@ -8,7 +8,7 @@ console = Console()
 
 
 def run_pipeline(config: dict) -> None:
-    """Run the full pipeline: scrape → score → greet → confirm → send → monitor."""
+    """Run the full pipeline: scrape → score → confirm → greet → send → monitor."""
     # Step 1: Check Chrome connection
     console.print("[bold]Step 1/6: 检测浏览器连接[/bold]")
     version_info = check_chrome_connection()


### PR DESCRIPTION
## Summary
- update the README manual flow to run confirm before greet
- align the CLI help text for run, greet, and send with the actual status flow
- make the empty greet command explain how to get approved jobs first
- update the pipeline docstring to match the implementation

## Tests
- python -m compileall -q src
- bosshunter greet --help
- bosshunter run --help
- bosshunter send --help
- git diff --check

Fixes #4
