### PR TITLE
fix: split ready job selection

### DIFF
--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -130,6 +130,29 @@ def get_jobs_by_status(conn: sqlite3.Connection, status: str) -> list[dict]:
     return [dict(row) for row in rows]
 
 
+def get_jobs_pending_confirmation(conn: sqlite3.Connection) -> list[dict]:
+    """Get scored jobs that still need manual confirmation."""
+    rows = conn.execute("""
+        SELECT * FROM jobs
+        WHERE status = 'ready'
+          AND (greeting IS NULL OR TRIM(greeting) = '')
+        ORDER BY score DESC
+    """).fetchall()
+    return [dict(row) for row in rows]
+
+
+def get_jobs_ready_to_send(conn: sqlite3.Connection) -> list[dict]:
+    """Get jobs that have generated greetings and are ready to send."""
+    rows = conn.execute("""
+        SELECT * FROM jobs
+        WHERE status = 'ready'
+          AND greeting IS NOT NULL
+          AND TRIM(greeting) != ''
+        ORDER BY score DESC
+    """).fetchall()
+    return [dict(row) for row in rows]
+
+
 def get_pending_scored_jobs(conn: sqlite3.Connection, threshold: int = 60) -> list[dict]:
     """Get jobs that passed scoring and are pending confirmation."""
     rows = conn.execute(

--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
 
 from bosshunter.browser import new_tab, close_tab, evaluate, click, wait_for_load
-from bosshunter.db import get_db, get_jobs_by_status, update_job_status, add_history, add_risk_event
+from bosshunter.db import get_db, get_jobs_ready_to_send, update_job_status, add_history, add_risk_event
 from bosshunter.throttle import RequestThrottle, SendWindowChecker, ProgressiveBackoff, should_take_day_off
 
 console = Console()
@@ -50,7 +50,7 @@ JS_SEND_GREETING = """
 
 
 def send_greetings(config: dict, force: bool = False) -> int:
-    """Send greetings to approved jobs. Returns count of successfully sent."""
+    """Send generated greetings. Returns count of successfully sent."""
     db = get_db()
     throttle_config = config.get("throttle", {})
 
@@ -73,10 +73,10 @@ def send_greetings(config: dict, force: bool = False) -> int:
         db.close()
         return 0
 
-    jobs = get_jobs_by_status(db, "ready")
+    jobs = get_jobs_ready_to_send(db)
 
     if not jobs:
-        console.print("[yellow]没有待发送的岗位[/yellow]")
+        console.print("[yellow]没有已生成招呼语的待发送岗位，请先运行 bosshunter greet[/yellow]")
         db.close()
         return 0
 

--- a/src/bosshunter/ui/confirm.py
+++ b/src/bosshunter/ui/confirm.py
@@ -5,7 +5,7 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.prompt import Prompt
 
-from bosshunter.db import get_db, get_jobs_by_status, update_job_status, add_history
+from bosshunter.db import get_db, get_jobs_pending_confirmation, update_job_status, add_history
 
 console = Console()
 
@@ -13,7 +13,7 @@ console = Console()
 def show_confirmation(config: dict) -> bool:
     """Display jobs for confirmation. Returns True if any jobs were approved."""
     db = get_db()
-    jobs = get_jobs_by_status(db, "ready")
+    jobs = get_jobs_pending_confirmation(db)
 
     if not jobs:
         console.print("[yellow]没有待确认的岗位[/yellow]")

--- a/tests/test_job_selection.py
+++ b/tests/test_job_selection.py
@@ -1,0 +1,81 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from bosshunter.db import (
+    get_db,
+    get_jobs_pending_confirmation,
+    get_jobs_ready_to_send,
+    insert_job,
+    update_job_greeting,
+    update_job_score,
+    update_job_status,
+)
+
+
+def _job(job_id: str, title: str = "Engineer") -> dict:
+    return {
+        "id": job_id,
+        "title": title,
+        "company": "Example",
+        "salary": "10-20K",
+        "city": "Beijing",
+        "experience": "1-3 years",
+        "jd": "Build product features",
+        "hr_name": "HR",
+        "hr_title": "Recruiter",
+        "hr_active": "",
+        "company_size": "",
+        "company_industry": "",
+        "url": "https://example.com/job",
+    }
+
+
+class JobSelectionTests(unittest.TestCase):
+    def test_pending_confirmation_excludes_jobs_with_greetings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = get_db(Path(tmp) / "bosshunter.db")
+            try:
+                insert_job(db, _job("scored"))
+                update_job_score(db, "scored", 88, "good match")
+                update_job_status(db, "scored", "ready")
+
+                insert_job(db, _job("sendable"))
+                update_job_score(db, "sendable", 92, "great match")
+                update_job_status(db, "sendable", "ready")
+                update_job_greeting(db, "sendable", "Hi, this role looks like a strong fit.")
+
+                jobs = get_jobs_pending_confirmation(db)
+            finally:
+                db.close()
+
+        self.assertEqual([job["id"] for job in jobs], ["scored"])
+
+    def test_ready_to_send_requires_a_non_empty_greeting(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = get_db(Path(tmp) / "bosshunter.db")
+            try:
+                insert_job(db, _job("no-greeting"))
+                update_job_status(db, "no-greeting", "ready")
+
+                insert_job(db, _job("blank-greeting"))
+                update_job_status(db, "blank-greeting", "ready")
+                update_job_greeting(db, "blank-greeting", "   ")
+
+                insert_job(db, _job("sendable"))
+                update_job_status(db, "sendable", "ready")
+                update_job_greeting(db, "sendable", "Hi, this role looks like a strong fit.")
+
+                insert_job(db, _job("approved"))
+                update_job_status(db, "approved", "approved")
+                update_job_greeting(db, "approved", "Not ready for send status yet.")
+
+                jobs = get_jobs_ready_to_send(db)
+            finally:
+                db.close()
+
+        self.assertEqual([job["id"] for job in jobs], ["sendable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add separate database helpers for jobs pending confirmation and jobs ready to send
- make `confirm` ignore ready jobs that already have a greeting
- make `send` only select ready jobs with a non-empty greeting
- add focused tests for the two ready-job selection paths

## Tests
- PYTHONPATH=src python -m unittest discover -s tests
- python -m compileall -q src tests
- ruff check src/bosshunter/db.py tests/test_job_selection.py
- bosshunter --help
- bosshunter --version
- python -c "import bosshunter; print(bosshunter.__version__)"
- git diff --check

Fixes #11
