### PR TITLE
fix: remove hidden scrape job limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ bosshunter run
 ### 分步执行
 
 ```bash
-bosshunter scrape -k "Python开发" -l 30   # 采集
-bosshunter score                            # AI 评分
+bosshunter scrape -k "Python开发"         # 采集
+bosshunter score                          # AI 评分
 bosshunter confirm                          # 人工确认
 bosshunter greet                            # 生成招呼语
 bosshunter send                             # 发送已生成的招呼语

--- a/src/bosshunter/main.py
+++ b/src/bosshunter/main.py
@@ -118,9 +118,9 @@ def connect(ctx: click.Context) -> None:
 
 @cli.command()
 @click.option("--keyword", "-k", default=None, help="搜索关键词（覆盖配置文件）")
-@click.option("--limit", "-l", default=30, help="最多抓取岗位数")
+@click.option("--limit", "-l", default=None, type=int, help="最多抓取岗位数（默认不限制）")
 @click.pass_context
-def scrape(ctx: click.Context, keyword: str | None, limit: int) -> None:
+def scrape(ctx: click.Context, keyword: str | None, limit: int | None) -> None:
     """采集岗位信息"""
     from bosshunter.scraper.jobs import scrape_jobs
 

--- a/src/bosshunter/pipeline.py
+++ b/src/bosshunter/pipeline.py
@@ -28,7 +28,7 @@ def run_pipeline(config: dict) -> None:
     console.print("[bold]Step 2/6: 采集岗位[/bold]")
     from bosshunter.scraper.jobs import scrape_jobs
     keywords = config["search"]["keywords"]
-    count = scrape_jobs(config, keywords, limit=30)
+    count = scrape_jobs(config, keywords)
     if count == 0:
         console.print("[yellow]  ! 未采集到新岗位，尝试继续处理已有岗位...[/yellow]")
     else:

--- a/src/bosshunter/scraper/jobs.py
+++ b/src/bosshunter/scraper/jobs.py
@@ -129,10 +129,11 @@ def _generate_job_id(url: str) -> str:
     return hashlib.md5(url.encode()).hexdigest()[:16]
 
 
-def scrape_jobs(config: dict, keywords: list[str], limit: int = 200) -> int:
+def scrape_jobs(config: dict, keywords: list[str], limit: int | None = None) -> int:
     """Scrape jobs from BOSS直聘 and store in database.
 
     Supports multi-keyword × multi-city combinations with pagination.
+    When limit is None, collection is bounded only by city × keyword × max_pages.
     Returns the number of new jobs added.
     """
     db = get_db()
@@ -172,7 +173,7 @@ def scrape_jobs(config: dict, keywords: list[str], limit: int = 200) -> int:
         console=console
     ) as progress:
         for city, city_code, keyword in search_combos:
-            if new_count >= limit:
+            if limit is not None and new_count >= limit:
                 break
 
             label = f"{city}/{keyword}" if len(cities) > 1 else keyword
@@ -180,7 +181,7 @@ def scrape_jobs(config: dict, keywords: list[str], limit: int = 200) -> int:
             keyword_new = 0
 
             for page in range(1, max_pages + 1):
-                if new_count >= limit:
+                if limit is not None and new_count >= limit:
                     break
 
                 # Build paginated URL
@@ -229,7 +230,7 @@ def scrape_jobs(config: dict, keywords: list[str], limit: int = 200) -> int:
 
                 # Process each job
                 for job_data in jobs_list:
-                    if new_count >= limit:
+                    if limit is not None and new_count >= limit:
                         break
 
                     job_url = job_data.get("url", "")

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -170,7 +170,7 @@ def _execute_collect(task: WorkbenchTask, config: dict) -> None:
 
 	keywords = config.get("search", {}).get("keywords", [])
 	_log(task, "开始采集岗位")
-	scrape_jobs(config, keywords, limit=30)
+	scrape_jobs(config, keywords)
 	if task.stop_requested.is_set():
 		return
 	_log(task, "开始 AI 评分")


### PR DESCRIPTION
## Summary
- Remove the hidden 30-job scrape cap from web workbench and full pipeline collection.
- Keep optional CLI --limit support, defaulting to no job-count cap.
- Update README scrape example to avoid implying a default 30-job collection limit.

## Test Plan
- [x] PYTHONPATH=src python -m pytest
- [x] PYTHONPATH=src python -m compileall -q src/bosshunter
- [x] npm run build in src/bosshunter/web/frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)