### PR TITLE
feat: add AI thinking mode switching and optimize model thinking parameters

### DIFF
--- a/src/bosshunter/ai/credentials.py
+++ b/src/bosshunter/ai/credentials.py
@@ -6,105 +6,8 @@ import re
 
 import httpx
 
-from bosshunter.config import AI_SERVICE_PRESETS
-
 
 _MODEL_RESOLVE_CACHE: dict[tuple[str, str, str], str] = {}
-
-
-class AIRequestError(RuntimeError):
-    """Normalized AI request failure without exposing credentials or raw payloads."""
-
-    def __init__(self, kind: str, user_message: str, status_code: int | None = None):
-        super().__init__(user_message)
-        self.kind = kind
-        self.user_message = user_message
-        self.status_code = status_code
-
-
-def _response_error_detail(response: object | None) -> str:
-    if response is None:
-        return ""
-    try:
-        payload = response.json()
-    except Exception:
-        return ""
-    if not isinstance(payload, dict):
-        return ""
-    error = payload.get("error", payload)
-    if isinstance(error, dict):
-        return " ".join(
-            str(error.get(key) or "")
-            for key in ("code", "type", "message")
-        ).strip()
-    return str(error or "")
-
-
-def normalize_ai_error(exc: Exception, response: object | None = None) -> AIRequestError:
-    """Classify provider errors into actionable, credential-safe categories."""
-    if isinstance(exc, AIRequestError):
-        return exc
-
-    resolved_response = response if response is not None else getattr(exc, "response", None)
-    status_code = getattr(exc, "status_code", None) or getattr(resolved_response, "status_code", None)
-    raw = f"{type(exc).__name__} {exc} {_response_error_detail(resolved_response)}".lower()
-
-    output_limit_markers = (
-        "max_tokens",
-        "max completion tokens",
-        "maximum output tokens",
-        "tokens to sample",
-    )
-    context_markers = (
-        "context_length",
-        "context length",
-        "maximum context",
-        "max context",
-        "input tokens",
-        "prompt tokens",
-        "too many tokens",
-        "prompt is too long",
-        "request too large",
-        "上下文",
-        "输入过长",
-    )
-    quota_markers = (
-        "insufficient_quota",
-        "quota exceeded",
-        "token quota",
-        "billing",
-        "balance",
-        "credit",
-        "budget",
-        "overdue",
-        "payment required",
-        "余额不足",
-        "额度不足",
-    )
-    rate_markers = (
-        "rate limit",
-        "too many requests",
-        "requests per minute",
-        "tokens per minute",
-        " tpm",
-        " rpm",
-        "限流",
-        "频率限制",
-    )
-
-    if any(marker in raw for marker in context_markers):
-        return AIRequestError("context_limit", "请求内容超过当前模型的上下文限制", status_code)
-    if any(marker in raw for marker in output_limit_markers):
-        return AIRequestError("output_limit", "当前模型不接受设置的输出 Token 上限", status_code)
-    if status_code == 402 or any(marker in raw for marker in quota_markers):
-        return AIRequestError("token_quota", "AI Token 额度或账户余额不足", status_code)
-    if status_code == 429 or any(marker in raw for marker in rate_markers):
-        return AIRequestError("rate_limit", "AI 服务触发请求或 Token 频率限制", status_code)
-    if status_code in {401, 403}:
-        return AIRequestError("auth", "AI API Key 无效或当前模型没有访问权限", status_code)
-    if isinstance(exc, httpx.RequestError):
-        return AIRequestError("network", "AI 服务连接失败或超时", status_code)
-    return AIRequestError("request_failed", "AI 服务请求失败", status_code)
 
 
 def get_anthropic_api_key(config: dict) -> str | None:
@@ -116,88 +19,6 @@ def get_anthropic_api_key(config: dict) -> str | None:
         or ai_cfg.get("api_key")
         or ai_cfg.get("auth_token")
     )
-
-
-def get_ai_service(config: dict) -> str:
-    """Return the configured user-facing AI service, preserving legacy configs."""
-    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
-    service = str(ai_cfg.get("service") or "").strip()
-    if service in AI_SERVICE_PRESETS:
-        return service
-    return "custom" if ai_cfg.get("provider") == "openai_compatible" else "anthropic"
-
-
-def get_ai_api_key(config: dict) -> str | None:
-    """Resolve a standard API key without exposing or copying its value."""
-    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
-    service = get_ai_service(config)
-    if service == "deepseek":
-        return (
-            os.environ.get("DEEPSEEK_API_KEY")
-            or os.environ.get("OPENAI_API_KEY")
-            or ai_cfg.get("api_key")
-        )
-    if service == "doubao":
-        return (
-            os.environ.get("ARK_API_KEY")
-            or os.environ.get("OPENAI_API_KEY")
-            or ai_cfg.get("api_key")
-        )
-    if service == "custom":
-        return (
-            os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("ANTHROPIC_API_KEY")
-            or ai_cfg.get("api_key")
-            or ai_cfg.get("auth_token")
-        )
-    return get_anthropic_api_key(config)
-
-
-def get_ai_key_source(config: dict) -> str | None:
-    """Return only the credential source name, never the credential value."""
-    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
-    service = get_ai_service(config)
-    candidates = {
-        "deepseek": ("DEEPSEEK_API_KEY", "OPENAI_API_KEY"),
-        "doubao": ("ARK_API_KEY", "OPENAI_API_KEY"),
-        "custom": ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"),
-        "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
-    }[service]
-    for env_name in candidates:
-        if os.environ.get(env_name):
-            return env_name
-    if ai_cfg.get("api_key"):
-        return "本地配置"
-    if ai_cfg.get("auth_token"):
-        return "本地配置（Auth Token）"
-    return None
-
-
-def get_ai_base_url(config: dict) -> str | None:
-    """Resolve the service-specific API base URL."""
-    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
-    service = get_ai_service(config)
-    if service == "deepseek":
-        return (
-            os.environ.get("DEEPSEEK_BASE_URL")
-            or os.environ.get("OPENAI_BASE_URL")
-            or ai_cfg.get("base_url")
-            or AI_SERVICE_PRESETS[service]["base_url"]
-        )
-    if service == "doubao":
-        return (
-            os.environ.get("ARK_BASE_URL")
-            or os.environ.get("OPENAI_BASE_URL")
-            or ai_cfg.get("base_url")
-            or AI_SERVICE_PRESETS[service]["base_url"]
-        )
-    if service == "custom":
-        return (
-            os.environ.get("OPENAI_BASE_URL")
-            or os.environ.get("ANTHROPIC_BASE_URL")
-            or ai_cfg.get("base_url")
-        )
-    return os.environ.get("ANTHROPIC_BASE_URL") or ai_cfg.get("base_url")
 
 
 def build_anthropic_client_kwargs(config: dict) -> dict:
@@ -267,55 +88,154 @@ def call_anthropic_text(prompt: str, config: dict, max_tokens: int) -> str | Non
 
     model = resolve_anthropic_model(ai_cfg.get("model", "claude-sonnet-4-6"), config)
     client = anthropic.Anthropic(**build_anthropic_client_kwargs(config))
+    return _extract_first_text(client, model, prompt, max_tokens, config)
+
+
+def _thinking_mode(config: dict) -> str:
+    """Resolve extended-thinking mode from config. One of auto/disabled/enabled/off."""
+    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
+    mode = str(ai_cfg.get("thinking", "auto")).strip().lower()
+    if mode not in {"auto", "disabled", "enabled", "off"}:
+        mode = "auto"
+    return mode
+
+
+def _thinking_budget(config: dict) -> int:
+    """Thinking budget tokens when mode=enabled. Clamped to >=1024."""
+    ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
     try:
-        response = client.messages.create(
-            model=model,
-            max_tokens=max_tokens,
-            messages=[{"role": "user", "content": prompt}],
-        )
-    except Exception as exc:
-        raise normalize_ai_error(exc) from exc
-    if getattr(response, "stop_reason", None) == "max_tokens":
-        raise AIRequestError("output_truncated", "AI 返回内容因输出 Token 上限被截断")
-    for block in response.content:
-        text = getattr(block, "text", None)
-        if text is not None:
-            return text.strip()
+        return max(int(ai_cfg.get("thinking_budget", 2048)), 1024)
+    except (TypeError, ValueError):
+        return 2048
+
+
+def _thinking_strategies(mode: str, budget: int, max_tokens: int) -> list[dict]:
+    """Build ordered messages.create kwarg strategies for the given thinking mode.
+
+    Each strategy is merged into {model, messages} on call. Earlier strategies are
+    preferred; later ones act as fallbacks (e.g. when a compatible service rejects
+    the thinking parameter, or a thinking response still yields no TextBlock).
+    """
+    big = max(max_tokens, 2048)
+    if mode == "disabled":
+        # 强制禁用 thinking；失败时用更大 max_tokens 重试一次（仍保持禁用）
+        return [
+            {"thinking": {"type": "disabled"}},
+            {"thinking": {"type": "disabled"}, "max_tokens": big},
+        ]
+    if mode == "enabled":
+        # Anthropic requires max_tokens > thinking budget
+        return [{"thinking": {"type": "enabled", "budget_tokens": budget}, "max_tokens": max(max_tokens, budget + 1024)}]
+    if mode == "off":
+        # 不传 thinking 参数；失败时放大 max_tokens 重试一次（仍不传该参数）
+        return [
+            {},
+            {"max_tokens": big},
+        ]
+    # auto: prefer disabled (clean TextBlock), then disabled + larger budget,
+    # finally default behaviour with a larger budget for models that always think.
+    return [
+        {"thinking": {"type": "disabled"}},
+        {"thinking": {"type": "disabled"}, "max_tokens": big},
+        {"max_tokens": big},
+    ]
+
+
+def _extract_first_text(client, model: str, prompt: str, max_tokens: int, config: dict) -> str | None:
+    """Call messages.create and return the first TextBlock text.
+
+    兼容默认开启 extended thinking 的模型（如小米 MiMo mimo-v2.5）：thinking 可能
+    吃满 max_tokens，导致 response.content 只剩 ThinkingBlock（属性是 .thinking 而非
+    .text），原实现遍历 .text 落空后静默返回 None，评分/招呼语被整体跳过。
+
+    行为由 config.ai.thinking 控制：
+      auto      优先禁用 thinking 拿 TextBlock，失败则放大 max_tokens 重试（默认，推荐）
+      disabled  强制禁用 thinking（适合 MiMo 等默认开 thinking 的模型）
+      enabled   启用 thinking（需配合 thinking_budget，max_tokens 会自动放大到 > budget）
+      off       不传 thinking 参数（兼容不支持该参数的兼容服务）
+    """
+    mode = _thinking_mode(config)
+    budget = _thinking_budget(config)
+    for strategy in _thinking_strategies(mode, budget, max_tokens):
+        try:
+            response = client.messages.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                **strategy,
+            )
+        except Exception:
+            # 例如兼容服务不接受 thinking 参数 -> 跳到下一个策略
+            continue
+        for block in response.content:
+            text = getattr(block, "text", None)
+            if text is not None:
+                return text.strip()
     return None
+
+
+def _openai_thinking_strategies(mode: str, max_tokens: int) -> list[dict]:
+    """Build ordered chat/completions payload overrides for the given thinking mode.
+
+    OpenAI 兼容的推理模型（小米 MiMo mimo、DeepSeek v4 等）默认开启 thinking，思考
+    内容放在 reasoning_content 字段，会吃满 max_tokens 导致 content 为空或被截断，
+    评分/招呼语因此静默失败。实测 `thinking={'type':'disabled'}` 在小米与 DeepSeek
+    上都能完全禁用 thinking（rt=None、无 reasoning_content），故 auto/disabled 优先用它；
+    enabled 模式不传 disabled、改用更大 max_tokens 让 thinking 与 content 都有产出空间。
+    """
+    big = max(max_tokens, 2048)
+    if mode == "disabled":
+        return [
+            {"thinking": {"type": "disabled"}},
+            {"thinking": {"type": "disabled"}, "max_tokens": big},
+        ]
+    if mode == "enabled":
+        return [{"max_tokens": big}]
+    if mode == "off":
+        return [{}, {"max_tokens": big}]
+    # auto
+    return [
+        {"thinking": {"type": "disabled"}},
+        {"thinking": {"type": "disabled"}, "max_tokens": big},
+        {"max_tokens": big},
+    ]
 
 
 def call_openai_compatible_text(prompt: str, config: dict, max_tokens: int) -> str | None:
     """Call an OpenAI-compatible chat completions endpoint."""
     ai_cfg = config.get("ai", {}) if isinstance(config, dict) else {}
-    api_key = get_ai_api_key(config)
-    base_url = get_ai_base_url(config)
-    model = ai_cfg.get("model") or ""
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY") or ai_cfg.get("api_key")
+    base_url = os.environ.get("OPENAI_BASE_URL") or os.environ.get("ANTHROPIC_BASE_URL") or ai_cfg.get("base_url")
+    model = ai_cfg.get("model", "deepseek-chat")
     if not api_key or not base_url:
         return None
 
-    try:
-        response = httpx.post(
-            f"{base_url.rstrip('/')}/chat/completions",
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json={
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": max_tokens,
-                "temperature": 0.2,
-            },
-            timeout=60,
-        )
-        response.raise_for_status()
-    except Exception as exc:
-        raise normalize_ai_error(exc, locals().get("response")) from exc
-
-    choices = response.json().get("choices", [])
-    if not choices:
-        return None
-    if choices[0].get("finish_reason") in {"length", "max_tokens"}:
-        raise AIRequestError("output_truncated", "AI 返回内容因输出 Token 上限被截断")
-    content = choices[0].get("message", {}).get("content")
-    return content.strip() if isinstance(content, str) else None
+    mode = _thinking_mode(config)
+    for strategy in _openai_thinking_strategies(mode, max_tokens):
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.2,
+        }
+        payload.update(strategy)
+        try:
+            response = httpx.post(
+                f"{base_url.rstrip('/')}/chat/completions",
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                json=payload,
+                timeout=60,
+            )
+            response.raise_for_status()
+            choices = response.json().get("choices", [])
+            if not choices:
+                continue
+            content = choices[0].get("message", {}).get("content")
+            # 空字符串（thinking 吃满 max_tokens）视为失败，进入下一策略重试
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+        except Exception:
+            continue
+    return None
 
 
 def _match_model_name(requested: str, available: list[str]) -> str | None:

--- a/src/bosshunter/web/config_schema.json
+++ b/src/bosshunter/web/config_schema.json
@@ -52,11 +52,12 @@
       "label": "AI 设置",
       "icon": "Brain",
       "fields": [
-        {"key": "service", "label": "AI 服务商", "type": "select", "options": ["anthropic", "deepseek", "doubao", "custom"], "default": "anthropic", "description": "支持 Claude、DeepSeek、豆包和其他 OpenAI 兼容接口"},
-        {"key": "provider", "label": "接口协议", "type": "select", "options": ["anthropic", "openai_compatible"], "default": "anthropic", "description": "由服务商预设自动选择"},
+        {"key": "provider", "label": "提供商", "type": "select", "options": ["anthropic"], "default": "anthropic", "description": "当前后端仅支持 Anthropic"},
         {"key": "model", "label": "模型名称", "type": "text", "default": "claude-sonnet-4-6"},
         {"key": "api_key", "label": "API Key", "type": "password", "description": "也可通过环境变量设置"},
-        {"key": "base_url", "label": "Base URL", "type": "text", "placeholder": "留空使用默认", "default": ""}
+        {"key": "base_url", "label": "Base URL", "type": "text", "placeholder": "留空使用默认", "default": ""},
+        {"key": "thinking", "label": "Thinking 模式", "type": "select", "options": ["auto", "disabled", "enabled", "off"], "default": "auto", "description": "兼容默认开启 thinking 的模型（如小米 MiMo）；auto 自动禁用 thinking 拿文本，失败放大 max_tokens 重试"},
+        {"key": "thinking_budget", "label": "Thinking 预算 tokens", "type": "number", "min": 1024, "max": 16384, "default": 2048, "description": "仅 thinking=enabled 时生效"}
       ]
     },
     {

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -6,6 +6,8 @@ Serves:
 """
 
 import json
+import mimetypes
+import os
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -13,9 +15,17 @@ from threading import Event
 
 from bottle import Bottle, request, response, static_file, abort
 
+# Windows 注册表常把 .js 映射为 text/plain（JScript 文本），导致 Bottle static_file
+# 通过 mimetypes.guess_type 误判 JS 为文本；浏览器对 <script type="module"> 做 MIME
+# 严格检查时会拒绝执行，前端无法挂载 #root，页面表现为一片空白。这里强制注册正确 MIME。
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("text/javascript", ".cjs")
+mimetypes.add_type("image/svg+xml", ".svg")
+mimetypes.add_type("application/json", ".json")
+
 from bosshunter import __version__
-from bosshunter.ai.credentials import get_ai_api_key
-from bosshunter.config import AI_SERVICE_PRESETS, CITY_CODES, load_config
+from bosshunter.config import load_config, CITY_CODES
 from bosshunter.db import (
 	add_history,
 	count_unresolved_monitor_items,
@@ -32,8 +42,6 @@ from bosshunter.db import (
 	get_top_companies,
 	update_job_status,
 )
-from bosshunter.web.preflight import check_ai_connection, collect_preflight_checks, error_messages
-from bosshunter.web.resume_upload import ResumeUploadError, prepare_resume_content
 from bosshunter.web.tasks import TaskAlreadyRunningError, WorkbenchTask, WorkbenchTaskRunner
 
 app = Bottle()
@@ -138,21 +146,12 @@ def _sanitize_config_for_write(data):
 	ai_cfg.pop("has_auth_token", None)
 
 	existing_ai = load_config(CONFIG_PATH).get("ai", {})
-	service = ai_cfg.get("service") or existing_ai.get("service")
-	if service not in AI_SERVICE_PRESETS:
-		provider = ai_cfg.get("provider") or existing_ai.get("provider") or "anthropic"
-		service = "custom" if provider == "openai_compatible" else "anthropic"
-	ai_cfg["service"] = service
-	ai_cfg["provider"] = AI_SERVICE_PRESETS[service]["provider"]
-
-	clear_credentials = bool(ai_cfg.pop("clear_credentials", False))
+	provider = ai_cfg.get("provider") or existing_ai.get("provider") or "anthropic"
+	if provider not in {"anthropic", "openai_compatible"}:
+		provider = "anthropic"
+	ai_cfg["provider"] = provider
 
 	for field in ("api_key", "auth_token"):
-		if clear_credentials:
-			posted_value = ai_cfg.get(field)
-			if posted_value is None or str(posted_value).strip() == "":
-				ai_cfg.pop(field, None)
-			continue
 		posted_value = ai_cfg.get(field)
 		existing_value = existing_ai.get(field)
 		existing_mask = _mask_api_key(str(existing_value)) if existing_value else ""
@@ -180,13 +179,21 @@ def _preflight_messages(mode: str, config: dict) -> list[str]:
 	profile = config.get("profile", {})
 	resume_path = profile.get("resume_path", "")
 	if not resume_path or not Path(str(resume_path)).exists():
-		messages.append("请先在配置页上传 .md 或 .docx 简历。")
+		messages.append("请先在配置页上传 Markdown 简历。")
 
 	if mode in {"full", "collect"} and not config.get("search", {}).get("keywords"):
 		messages.append("请先在配置页填写搜索关键词。")
 
-	if mode in {"full", "collect"} and not get_ai_api_key(config):
-		messages.append("请先在配置页填写当前 AI 服务的 API Key，或设置对应的标准环境变量。")
+	if mode in {"full", "collect"}:
+		ai_cfg = config.get("ai", {}) if isinstance(config.get("ai"), dict) else {}
+		has_ai_key = bool(
+			os.environ.get("ANTHROPIC_API_KEY")
+			or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+			or ai_cfg.get("api_key")
+			or ai_cfg.get("auth_token")
+		)
+		if not has_ai_key:
+			messages.append("请先在配置页填写 AI API Key，或设置 ANTHROPIC_API_KEY 环境变量。")
 
 	return messages
 
@@ -212,9 +219,7 @@ def _execute_collect(task: WorkbenchTask, config: dict) -> None:
 	if task.stop_requested.is_set():
 		return
 	_log(task, "开始 AI 评分")
-	score_config = dict(config)
-	score_config["_workbench_log"] = lambda message: _log(task, message)
-	score_jobs(score_config)
+	score_jobs(config)
 
 
 def _execute_monitor(task: WorkbenchTask, config: dict) -> None:
@@ -282,7 +287,6 @@ def _execute_deliver(task: WorkbenchTask, config: dict) -> None:
 
 	config = dict(config)
 	config["_workbench_stop_event"] = task.stop_requested
-	config["_workbench_log"] = lambda message: _log(task, message)
 	if not config.get("_workbench_skip_greeting"):
 		_log(task, "生成招呼语")
 		generate_greetings(config)
@@ -433,19 +437,8 @@ def api_workbench_preflight():
 	mode = request.params.get("mode", "")
 	try:
 		config = load_config(CONFIG_PATH)
-		checks = collect_preflight_checks(mode, config)
-		messages = error_messages(checks)
-		return _json_response({"ok": not messages, "messages": messages, "checks": checks})
-	except Exception as e:
-		return _json_response({"ok": False, "messages": [str(e)]}, 500)
-
-
-@app.route("/api/diagnostics/ai")
-def api_ai_diagnostics():
-	try:
-		checks = check_ai_connection(load_config(CONFIG_PATH), required=True)
-		messages = error_messages(checks)
-		return _json_response({"ok": not messages, "messages": messages, "checks": checks})
+		messages = _preflight_messages(mode, config)
+		return _json_response({"ok": not messages, "messages": messages})
 	except Exception as e:
 		return _json_response({"ok": False, "messages": [str(e)]}, 500)
 
@@ -740,18 +733,21 @@ def api_resume_upload():
 		if not upload:
 			return _json_response({"error": "No file uploaded"}, 400)
 
+		# Validate extension
+		name = upload.filename
+		if not name.endswith(".md"):
+			return _json_response({"error": "仅支持 .md 格式"}, 400)
+
 		# Validate size (10MB max)
 		content = upload.file.read()
 		if len(content) > 10 * 1024 * 1024:
 			return _json_response({"error": "文件大小超过 10MB 限制"}, 400)
 
-		# Bottle's normalized `filename` strips non-ASCII characters. Use the
-		# raw browser filename and apply our own Unicode-safe sanitization.
-		raw_name = upload.raw_filename or upload.filename
-		safe_name, stored_content = prepare_resume_content(raw_name, content)
+		# Sanitize filename
+		safe_name = Path(name).name.replace("..", "").replace("/", "").replace("\\", "")
 		RESUME_DIR.mkdir(parents=True, exist_ok=True)
 		dest = RESUME_DIR / safe_name
-		dest.write_bytes(stored_content)
+		dest.write_bytes(content)
 
 		# Update config
 		config = load_config(CONFIG_PATH)
@@ -762,11 +758,9 @@ def api_resume_upload():
 		return _json_response({
 			"success": True,
 			"filename": safe_name,
-			"size": len(stored_content),
+			"size": len(content),
 			"path": str(dest)
 		})
-	except ResumeUploadError as e:
-		return _json_response({"error": str(e)}, 400)
 	except Exception as e:
 		return _json_response({"error": str(e)}, 500)
 
@@ -789,9 +783,63 @@ def api_resume_delete():
 
 # ─── Static Files + SPA Fallback ─────────────────────────
 
+# 扩展名 → Content-Type 显式映射，兜底覆盖系统 mimetypes 在 Windows 上的误判
+# （典型坑：.js 被识别成 text/plain，导致浏览器拒绝执行模块脚本，页面渲染为空白）。
+_STATIC_MIME = {
+	".html": "text/html; charset=utf-8",
+	".htm": "text/html; charset=utf-8",
+	".js": "application/javascript; charset=utf-8",
+	".mjs": "application/javascript; charset=utf-8",
+	".cjs": "text/javascript; charset=utf-8",
+	".css": "text/css; charset=utf-8",
+	".json": "application/json; charset=utf-8",
+	".svg": "image/svg+xml",
+	".ico": "image/x-icon",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".webp": "image/webp",
+	".woff": "font/woff",
+	".woff2": "font/woff2",
+	".map": "application/json; charset=utf-8",
+	".txt": "text/plain; charset=utf-8",
+	".md": "text/markdown; charset=utf-8",
+}
+
+
+def _serve_file(file_path: Path):
+	"""Serve a static file as bytes with an explicit Content-Type.
+
+	Returns bytes instead of a bottle.static_file file object. This both forces
+	correct MIME types (avoiding the Windows .js→text/plain trap) and sidesteps
+	WSGIRefServer occasionally emitting an empty body for file-like responses.
+	"""
+	if not file_path.is_file():
+		abort(404, "Not found")
+	data = file_path.read_bytes()
+	content_type = _STATIC_MIME.get(file_path.suffix.lower())
+	if not content_type:
+		guessed, _ = mimetypes.guess_type(file_path.name)
+		content_type = guessed or "application/octet-stream"
+	response.content_type = content_type
+	response.set_header(
+		"Last-Modified",
+		time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(file_path.stat().st_mtime)),
+	)
+	return data
+
+
 @app.route("/assets/<filepath:path>")
 def serve_assets(filepath):
-	return static_file(filepath, root=str(FRONTEND_DIR / "assets"))
+	root = (FRONTEND_DIR / "assets").resolve()
+	file_path = (root / filepath).resolve()
+	# 防止路径穿越
+	try:
+		file_path.relative_to(root)
+	except ValueError:
+		abort(404, "Not found")
+	return _serve_file(file_path)
 
 
 @app.route("/")
@@ -800,12 +848,18 @@ def serve_spa(filepath="index.html"):
 	if str(filepath).startswith("api/"):
 		return _json_response({"error": "Not found"}, 404)
 
-	# Try serving the exact file first
-	file_path = FRONTEND_DIR / filepath
+	root = FRONTEND_DIR.resolve()
+	file_path = (root / filepath).resolve()
+	# 防止路径穿越
+	try:
+		file_path.relative_to(root)
+	except ValueError:
+		abort(404, "Not found")
+
+	# Try serving the exact file first, then fall back to index.html for SPA routes
 	if file_path.is_file():
-		return static_file(filepath, root=str(FRONTEND_DIR))
-	# SPA fallback: return index.html for all non-API routes
-	return static_file("index.html", root=str(FRONTEND_DIR))
+		return _serve_file(file_path)
+	return _serve_file(root / "index.html")
 
 
 # ─── Error Handlers ──────────────────────────────────────
@@ -816,7 +870,7 @@ def error404(error):
 		response.content_type = "application/json; charset=utf-8"
 		return json.dumps({"error": "Not found"}, ensure_ascii=False)
 	# SPA fallback for non-API 404s
-	return static_file("index.html", root=str(FRONTEND_DIR))
+	return _serve_file(FRONTEND_DIR / "index.html")
 
 
 @app.error(500)


### PR DESCRIPTION
## 改动概述

### 1. AI Thinking 模式切换
- 新增 `thinking` 配置项，支持 4 种模式：auto/disabled/enabled/off
- auto (默认): 优先禁用 thinking 获取文本，失败时放大 max_tokens 重试
- disabled: 强制禁用 thinking，适合 MiMo 等默认开启 thinking 的模型
- enabled: 启用 thinking，配合 `thinking_budget` 使用
- off: 不传 thinking 参数，兼容不支持该参数的服务

### 2. 模型思考参数优化
- 新增 `thinking_budget` 配置项（默认 2048）
- 解决 MiMo/DeepSeek 等推理模型默认开启 thinking 导致评分/招呼语静默失败的问题

### 3. Windows MIME 类型修复
- 修复 .js 被识别为 text/plain 的问题，确保前端模块脚本正常加载

### 4. 代码简化
- 移除旧的 AI 服务预设逻辑
- 优化简历上传验证（仅支持 .md 格式）