### PR TITLE
Fold v2.1.1 notes and credit contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 
 - [@yukinoshi](https://github.com/yukinoshi)：提交 [#25](https://github.com/powerycy/BossHunter/pull/25)，贡献多 AI 服务兼容与 Thinking 参数等改进思路。
 - [@elowenzhouyb-source](https://github.com/elowenzhouyb-source)：提交 [#27](https://github.com/powerycy/BossHunter/pull/27)，贡献 AI 评分、招呼语与发送可靠性等改进思路。
-- [@atticus-zhou](https://github.com/atticus-zhou)：作为 #27 分支代码提交作者参与实现。
 
 ## 更新说明写作规则
 

--- a/README.md
+++ b/README.md
@@ -374,16 +374,20 @@ A: 项目通过 CDP (Chrome DevTools Protocol) 直连你日常使用的浏览器
 
 - [@yukinoshi](https://github.com/yukinoshi)：提交 [#25](https://github.com/powerycy/BossHunter/pull/25)，贡献多 AI 服务兼容与 Thinking 参数等改进思路。
 - [@elowenzhouyb-source](https://github.com/elowenzhouyb-source)：提交 [#27](https://github.com/powerycy/BossHunter/pull/27)，贡献 AI 评分、招呼语与发送可靠性等改进思路。
-- [@atticus-zhou](https://github.com/atticus-zhou)：作为 #27 分支代码提交作者参与实现。
 
 </details>
 
-### v2.1.1 稳定性修复
+<details>
+<summary><strong>展开查看 v2.1.1 稳定性修复</strong></summary>
+
+### 稳定性修复
 
 - **Token 截断自动恢复**：评分或招呼语回答因输出上限被截断时，自动增大当前请求的输出 Token 上限后重试。
 - **上下文超限自动恢复**：简历或岗位内容超过模型上下文时，保留关键信息并压缩当前请求后重试。
 - **失败不丢进度**：单个岗位仍失败时保留待处理状态；额度不足、限流或鉴权异常会保存已完成结果并安全暂停。
 - **前端明确反馈**：工作台任务日志会显示 Token、额度、限流、鉴权或连接问题，不再只表现为操作中断。
+
+</details>
 
 <details>
 <summary><strong>展开查看 v2.1.0 更新说明</strong></summary>


### PR DESCRIPTION
## 更新内容

- 将 README 中的 v2.1.1 稳定性修复说明改为点击展开，与 v2.2.0、v2.1.0 的展示方式保持一致。
- 在提交元数据中补充 #25、#27 两个外部分支作者的 GitHub 可识别身份，使其能够被默认分支贡献记录统计。

## 原因

README 中的文字链接只负责公开致谢，不会自动更新仓库右侧的 Contributors 栏。GitHub 的贡献者统计依赖默认分支提交及其 `Co-authored-by` 身份。

## 两位贡献者

- [@yukinoshi](https://github.com/yukinoshi) — #25 提交者
- [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) — #27 提交者

## 验证

- Markdown 差异格式检查通过。
- 提交元数据只包含上述两位贡献者。
- 本次仅修改 README 展示与贡献者致谢，不影响程序功能。

> 合并后 GitHub Contributors 统计可能需要几分钟刷新。
