### PR TITLE
Filter anonymous company jobs before scoring

### DIFF
--- a/src/bosshunter/ai/prefilter.py
+++ b/src/bosshunter/ai/prefilter.py
@@ -6,6 +6,9 @@ from bosshunter.job_filters import matching_deal_breaker
 
 
 _INTERNSHIP_KEYWORDS = ("实习", "intern", "internship", "管培")
+_ANONYMOUS_COMPANY_PATTERN = re.compile(
+    r"^(?:[\u4e00-\u9fff]{2,4})?某.+(?:公司|企业|集团)$"
+)
 
 
 def quick_score(job: dict, config: dict) -> tuple[int, str]:
@@ -13,6 +16,10 @@ def quick_score(job: dict, config: dict) -> tuple[int, str]:
     profile = config.get("profile", {})
     deal_breakers = profile.get("deal_breakers", [])
     title = job.get("title") or ""
+    company = str(job.get("company") or "").strip()
+
+    if _ANONYMOUS_COMPANY_PATTERN.search(company):
+        return 0, "匿名公司岗位"
 
     breaker = matching_deal_breaker(title, deal_breakers)
     if breaker:

--- a/tests/test_regression_small_fixes.py
+++ b/tests/test_regression_small_fixes.py
@@ -209,6 +209,50 @@ class AiPromptRegressionTests(unittest.TestCase):
 
 
 class PrefilterHardGateTests(unittest.TestCase):
+    def test_anonymous_company_jobs_are_filtered_before_ai_scoring(self):
+        from bosshunter.ai.prefilter import quick_score
+
+        config = {"profile": {"deal_breakers": [], "salary_min": 0}}
+        anonymous_companies = [
+            "某互联网公司",
+            "某500强上市公司",
+            "北京某大型计算机软件上市公司",
+            "上海某大型电子商务公司",
+            "北京某中型企业数字化与AI服务公司",
+        ]
+
+        for company in anonymous_companies:
+            with self.subTest(company=company):
+                score, reason = quick_score(
+                    {
+                        "company": company,
+                        "title": "AI产品经理",
+                        "jd": "",
+                        "salary": "20-30K",
+                    },
+                    config,
+                )
+
+                self.assertEqual(score, 0)
+                self.assertEqual(reason, "匿名公司岗位")
+
+    def test_named_company_jobs_still_pass_anonymous_company_filter(self):
+        from bosshunter.ai.prefilter import quick_score
+
+        config = {"profile": {"deal_breakers": [], "salary_min": 0}}
+        score, reason = quick_score(
+            {
+                "company": "荣耀终端技术有限公司",
+                "title": "AI产品经理",
+                "jd": "",
+                "salary": "20-30K",
+            },
+            config,
+        )
+
+        self.assertEqual(score, 100)
+        self.assertEqual(reason, "预筛通过")
+
     def test_deal_breakers_still_match_title_only(self):
         from bosshunter.ai.prefilter import quick_score
 


### PR DESCRIPTION
## What changed

- Filter anonymous company labels such as `某互联网公司` and `北京某大型企业` before AI scoring.
- Keep named companies unchanged.
- Add regression coverage for anonymous and named company examples.

## Why

Anonymous/headhunter postings can use incompatible communication flows and repeatedly fail during greeting delivery. Filtering them earlier avoids futile retries.

## Impact

Matching jobs are marked as filtered with reason `匿名公司岗位`; they do not enter greeting generation, confirmation, or delivery.

## Checks

- Full test suite: 225 passed, 11 subtests passed.