### PR TITLE
Fix greeting delivery confirmation matching

### DIFF
--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -518,6 +518,41 @@ def _message_delivery_state(target_id: str, greeting: str) -> str:
     return str(result.get("state") or "missing")
 
 
+def _submitted_message_looks_accepted(target_id: str, greeting: str) -> bool:
+    """Return true when Boss appears to have accepted a send despite missing echo."""
+    greeting_escaped = json.dumps(greeting, ensure_ascii=False)
+    result = _parse_js_result(evaluate(target_id, f"""
+    (() => {{
+        const normalize = (value) => String(value || '')
+            .replace(/[\\u200b-\\u200f\\ufeff]/g, '')
+            .replace(/\\s+/g, ' ')
+            .trim();
+        const expected = normalize({greeting_escaped});
+        const input = document.querySelector('#chat-input');
+        const inputText = normalize(input ? input.innerText || input.textContent || input.value : '');
+        const inputCleared = !!input && inputText.length === 0;
+        const ownMessages = Array.from(document.querySelectorAll(
+            '.chat-record .message-item.item-myself, .chat-record .item-myself, '
+            + '.chat-record .message-item.item-self, .chat-record [class*="item-my"]'
+        ));
+        const hasFailedOwnMessage = ownMessages.some((node) => {{
+            const statusNode = node.querySelector('.message-status');
+            const statusClass = statusNode ? String(statusNode.className || '') : '';
+            const text = normalize(node.innerText || node.textContent);
+            return statusClass.includes('status-error')
+                || (text.includes('发送失败') && (text.includes(expected) || expected.includes(text)));
+        }});
+        return JSON.stringify({{
+            success: true,
+            accepted: inputCleared && !hasFailedOwnMessage,
+            inputCleared,
+            hasFailedOwnMessage
+        }});
+    }})()
+    """))
+    return bool(result.get("success") and result.get("accepted"))
+
+
 def _submit_chat_message_background(target_id: str, greeting: str) -> dict:
     """Use BossHunter's original Vue submit path without foregrounding Chrome."""
     greeting_escaped = json.dumps(greeting, ensure_ascii=False)
@@ -788,6 +823,13 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
                     "history_detail": "首次招呼语曾出现但未稳定保留在会话中",
                     "skip_backoff": True,
                 }, target_id
+        if _submitted_message_looks_accepted(target_id, greeting):
+            close_tab(target_id)
+            return {
+                "success": True,
+                "accepted_without_echo": True,
+                "first_contact": True,
+            }, None
         return {
             "success": False,
             "error": "first_contact_delivery_unverified",
@@ -852,6 +894,10 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
                 "history_detail": "消息曾出现但未稳定保留在会话中，未记录为已发送",
                 "skip_backoff": True,
             }, target_id
+
+    if _submitted_message_looks_accepted(target_id, greeting):
+        close_tab(target_id)
+        return {"success": True, "accepted_without_echo": True}, None
 
     return {
         "success": False,

--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -459,20 +459,37 @@ def _message_delivery_state(target_id: str, greeting: str) -> str:
     greeting_escaped = json.dumps(greeting, ensure_ascii=False)
     result = _parse_js_result(evaluate(target_id, f"""
     (() => {{
-        const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+        const normalize = (value) => String(value || '')
+            .replace(/[\\u200b-\\u200f\\ufeff]/g, '')
+            .replace(/\\s+/g, ' ')
+            .trim();
+        const removeDeliveryLabels = (value) => normalize(value)
+            .replace(/(发送中|已读|未读|送达|发送成功|重试|重新发送)$/g, '')
+            .trim();
+        const textMatchesExpected = (value, expectedText) => {{
+            const text = removeDeliveryLabels(value);
+            return text === expectedText || text.includes(expectedText);
+        }};
+        const messageText = (node) => {{
+            const contentNode = node.querySelector(
+                '.message-content, .text, .content, .message-text, '
+                + '[class*="message-content"], [class*="msg-content"], [class*="text"]'
+            );
+            return normalize(contentNode ? contentNode.innerText || contentNode.textContent : node.innerText || node.textContent);
+        }};
         const expected = normalize({greeting_escaped});
         const ownMessages = Array.from(document.querySelectorAll(
             '.chat-record .message-item.item-myself, .chat-record .item-myself, '
             + '.chat-record .message-item.item-self, .chat-record [class*="item-my"]'
         ));
-        const matching = ownMessages.filter((node) => normalize(node.innerText || node.textContent) === expected);
+        const matching = ownMessages.filter((node) => textMatchesExpected(messageText(node), expected));
         const messageList = document.querySelector('.chat-record');
         const vue = messageList && messageList.__vue__;
         const records = vue && Array.isArray(vue.list$) ? vue.list$ : [];
         const matchingRecords = records.filter((message) => {{
             if (!message || !message.isSelf) return false;
-            const text = message.text || message.lastText || message.content || '';
-            return normalize(text) === expected;
+            const text = message.text || message.lastText || message.content || message.message || message.body || '';
+            return textMatchesExpected(text, expected);
         }});
         if (!matching.length && !matchingRecords.length) {{
             return JSON.stringify({{success: true, state: 'missing'}});

--- a/tests/test_job_selection.py
+++ b/tests/test_job_selection.py
@@ -21,6 +21,7 @@ from bosshunter.executor.sender import _chat_target_matches_job
 from bosshunter.executor.sender import _confirm_preset_greeting
 from bosshunter.executor.sender import _handle_greet_popup
 from bosshunter.executor.sender import _message_delivery_state
+from bosshunter.executor.sender import _submitted_message_looks_accepted
 from bosshunter.executor.sender import send_greetings
 from bosshunter.executor.sender import _send_greeting_once
 from bosshunter.executor.sender import _submit_chat_message_background
@@ -129,6 +130,19 @@ class JobSelectionTests(unittest.TestCase):
         self.assertIn(".message-content", script)
         self.assertIn("text.includes(expectedText)", script)
         self.assertIn("发送中|已读|未读|送达|发送成功|重试|重新发送", script)
+
+    def test_send_acceptance_fallback_requires_cleared_input_without_failure(self):
+        greeting = "您好，我的经历和岗位需求比较匹配。"
+        with patch(
+            "bosshunter.executor.sender.evaluate",
+            return_value='{"success": true, "accepted": true, "inputCleared": true, "hasFailedOwnMessage": false}',
+        ) as evaluate_mock:
+            accepted = _submitted_message_looks_accepted("target-1", greeting)
+
+        self.assertTrue(accepted)
+        script = evaluate_mock.call_args.args[1]
+        self.assertIn("inputCleared && !hasFailedOwnMessage", script)
+        self.assertIn("status-error", script)
 
     def test_startchat_popup_reuses_chat_redirect_without_foreground_input(self):
         click_result = {"redirectUrl": "/web/geek/chat?jobId=first-contact"}
@@ -245,6 +259,35 @@ class JobSelectionTests(unittest.TestCase):
         self.assertIsNone(target_id)
         self.assertTrue(result["success"])
         self.assertEqual(evaluate_mock.call_count, len(evaluate_results))
+        close_tab.assert_called_once_with("target-1")
+
+    def test_send_greeting_accepts_cleared_input_when_echo_is_missing(self):
+        job = {
+            "id": "accepted-without-echo",
+            "company": "Example",
+            "title": "Engineer",
+            "url": "https://www.zhipin.com/job_detail/accepted-without-echo.html",
+        }
+
+        with patch("bosshunter.executor.sender.new_tab", return_value="target-1"), \
+             patch("bosshunter.executor.sender.evaluate", return_value='{"success": true}'), \
+             patch("bosshunter.executor.sender._click_chat_button", return_value={"success": True}), \
+             patch("bosshunter.executor.sender._detect_greet_popup", return_value={"success": True, "popup": False}), \
+             patch("bosshunter.executor.sender._wait_for_chat_page", return_value={"success": True, "target_id": "target-1"}), \
+             patch("bosshunter.executor.sender._message_delivery_state", return_value="missing"), \
+             patch("bosshunter.executor.sender._submit_chat_message_background", return_value={"success": True}), \
+             patch("bosshunter.executor.sender._submitted_message_looks_accepted", return_value=True), \
+             patch("bosshunter.executor.sender.close_tab") as close_tab, \
+             patch("bosshunter.executor.sender.time.sleep"):
+            result, target_id = _send_greeting_once(
+                job,
+                "您好，我对这个岗位很感兴趣。",
+                {"browse_before_greet": False, "_send_verification_attempts": 1},
+            )
+
+        self.assertIsNone(target_id)
+        self.assertTrue(result["success"])
+        self.assertTrue(result["accepted_without_echo"])
         close_tab.assert_called_once_with("target-1")
 
     def test_send_greeting_uses_original_flow_when_platform_preset_is_enabled(self):

--- a/tests/test_job_selection.py
+++ b/tests/test_job_selection.py
@@ -20,6 +20,7 @@ from bosshunter.executor.sender import CHAT_BUTTON_SCRIPT_FOR_TESTS
 from bosshunter.executor.sender import _chat_target_matches_job
 from bosshunter.executor.sender import _confirm_preset_greeting
 from bosshunter.executor.sender import _handle_greet_popup
+from bosshunter.executor.sender import _message_delivery_state
 from bosshunter.executor.sender import send_greetings
 from bosshunter.executor.sender import _send_greeting_once
 from bosshunter.executor.sender import _submit_chat_message_background
@@ -114,6 +115,20 @@ class JobSelectionTests(unittest.TestCase):
         script = evaluate_mock.call_args.args[1]
         self.assertIn("vue.handleSubmit()", script)
         self.assertIn("enableSubmit", script)
+
+    def test_delivery_check_matches_bubble_text_with_status_labels(self):
+        greeting = "您好，我的经历和岗位需求比较匹配。"
+        with patch(
+            "bosshunter.executor.sender.evaluate",
+            return_value='{"success": true, "state": "delivered"}',
+        ) as evaluate_mock:
+            state = _message_delivery_state("target-1", greeting)
+
+        self.assertEqual(state, "delivered")
+        script = evaluate_mock.call_args.args[1]
+        self.assertIn(".message-content", script)
+        self.assertIn("text.includes(expectedText)", script)
+        self.assertIn("发送中|已读|未读|送达|发送成功|重试|重新发送", script)
 
     def test_startchat_popup_reuses_chat_redirect_without_foreground_input(self):
         click_result = {"redirectUrl": "/web/geek/chat?jobId=first-contact"}


### PR DESCRIPTION
## Summary
- make greeting delivery verification read chat bubble content more flexibly
- tolerate trailing delivery labels such as 已读/送达/发送中 when matching the sent greeting
- treat a cleared chat input with no visible failure marker as an accepted send when the echo cannot be read
- keep explicit failed/loading status handling so real failures are still surfaced
- add focused regression tests for status-label matching and the accepted-without-echo fallback

## Root cause
Boss chat DOM can include delivery labels or status text in the same message node as the greeting. In some successful sends, the message echo is also not exposed through the selectors/Vue fields we can read, while the chat input has already been cleared by the platform. The previous verifier required a readable exact echo, so a visibly successful send could still be recorded as `send_not_confirmed`.

## Validation
- `./.venv/bin/python -m pytest tests/test_job_selection.py`

Note: this PR only contains sender confirmation fixes. Local database corrections for user-confirmed sent jobs were done separately and are not part of this PR.