### PR TITLE
Fix runtime port fallback on reserved Windows ports

### DIFF
--- a/src/bosshunter/browser/runtime/__init__.py
+++ b/src/bosshunter/browser/runtime/__init__.py
@@ -193,8 +193,9 @@ def runtime_targets(config: dict[str, Any] | None = None) -> list[dict[str, Any]
 
 
 def _is_port_available(host: str, port: int) -> bool:
+    # No SO_REUSEADDR here: on Windows it allows binding ports already in use,
+    # which would make this probe report occupied ports as available.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
         except OSError:
@@ -264,7 +265,15 @@ def ensure_runtime(config: dict[str, Any] | None = None, wait_seconds: float = 1
         return False
 
     health = runtime_health(browser)
-    if health and health.get("runtime") != "bosshunter":
+    host = browser.get("proxy_host", "127.0.0.1")
+    port = int(browser.get("proxy_port", 3456))
+    # Swap ports when the configured one serves a foreign runtime, or when
+    # nothing responds and the port cannot be bound at all (e.g. Windows
+    # reserved port ranges that shift after every reboot).
+    needs_fallback = (health is not None and health.get("runtime") != "bosshunter") or (
+        health is None and not _is_port_available(host, port)
+    )
+    if needs_fallback:
         fallback_port = _find_available_runtime_port(browser)
         if fallback_port is None:
             return False

--- a/tests/test_browser_runtime.py
+++ b/tests/test_browser_runtime.py
@@ -186,6 +186,38 @@ class BrowserRuntimeManagerTests(unittest.TestCase):
         self.assertEqual(start_runtime.call_args.args[1], "node")
         self.assertEqual(get_runtime_url(), "http://127.0.0.1:3457")
 
+    @patch("bosshunter.browser.runtime.time.sleep")
+    @patch("bosshunter.browser.runtime._is_port_available")
+    @patch("bosshunter.browser.runtime.runtime_health")
+    @patch("bosshunter.browser.runtime.runtime_targets")
+    @patch("bosshunter.browser.runtime.start_runtime")
+    @patch("bosshunter.browser.runtime.check_node_available")
+    def test_ensure_runtime_uses_next_free_port_when_default_is_system_reserved(
+        self,
+        check_node,
+        start_runtime,
+        runtime_targets,
+        runtime_health,
+        is_port_available,
+        sleep,
+    ):
+        from bosshunter.browser.runtime import ensure_runtime
+
+        config = {"browser": {"runtime": "builtin", "auto_start_proxy": True, "proxy_host": "127.0.0.1", "proxy_port": 3456}}
+        check_node.return_value = {"available": True, "version": "v22.1.0"}
+        # Nothing responds on the configured port (no HTTP health) and the
+        # port itself cannot be bound, mirroring Windows reserved port ranges.
+        runtime_health.return_value = None
+        is_port_available.side_effect = lambda host, port: port == 3457
+        runtime_targets.side_effect = lambda browser: [{"targetId": "abc"}] if browser["proxy_port"] == 3457 else None
+
+        result = ensure_runtime(config, wait_seconds=0.01)
+
+        self.assertTrue(result)
+        self.assertEqual(config["browser"]["proxy_port"], 3457)
+        self.assertEqual(start_runtime.call_args.args[0]["proxy_port"], 3457)
+        self.assertEqual(start_runtime.call_args.args[1], "node")
+
     @patch("bosshunter.browser.runtime.subprocess.Popen")
     def test_start_runtime_sets_bosshunter_environment(self, popen):
         from bosshunter.browser.runtime import start_runtime


### PR DESCRIPTION
## Summary

Fixes #47

Windows 重启后 winnat（Hyper-V/WSL/Docker 依赖）会随机保留若干段 TCP 端口，当默认 `proxy_port: 3456` 落入保留段时，cdp-proxy bind 失败退出，Browser Runtime 永远无法启动（详见 Issue）。本 PR 扩展 `ensure_runtime()` 的端口回退条件，使「端口无响应且无法 bind」的场景也能自动换到可用端口，复用现有回退机制，改动最小化。

## 问题回顾

`ensure_runtime()` 原有的端口回退只在「端口被其他 HTTP 服务占用」（health 返回非 bosshunter 标识）时触发：

```python
health = runtime_health(browser)
if health and health.get("runtime") != "bosshunter":   # 保留段场景 health 为 None → 回退被跳过
    ...
start_runtime(...)   # 继续在绑不上的端口启动 → 代理退出 → 轮询超时 → False
```

端口被系统保留时：无进程监听 → `health` 为 `None`；bind 报 `EACCES`。两个信号原代码都没有利用。

## 改动内容

### 1. `src/bosshunter/browser/runtime/__init__.py` — `ensure_runtime()`

回退条件从单一场景扩展为两种：

```python
needs_fallback = (health is not None and health.get("runtime") != "bosshunter") or (
    health is None and not _is_port_available(host, port)   # 新增：端口无响应且 bind 不上
)
```

复用现有的 `_find_available_runtime_port()`（bind 探测扫描 `proxy_port+1` 起 100 个端口，被保留的端口会自动跳过）和 `_switch_runtime_port()`（已同时更新进程级配置，Web 控制台与 CLI 的所有浏览器操作都经由此处，无需其他改动）。

### 2. 同文件 — `_is_port_available()`

移除 `SO_REUSEADDR`：Windows 上该选项允许绑定已被其他进程监听的端口，会使探测误报「端口可用」。移除后顺带让「端口被静默非 HTTP 服务占用」的场景也能正确触发回退。

### 3. `tests/test_browser_runtime.py`

新增 `test_ensure_runtime_uses_next_free_port_when_default_is_system_reserved`：mock「配置端口无响应 + bind 失败」，断言自动切换到 3457、config 被更新、代理以新端口启动（写法对齐既有的 `non_bosshunter_service` 用例）。

## 设计决策

- **不把回退选中的端口持久化到 config.yaml**：保留段每次重启都变，持久化反而会固化到一个未来可能失效的端口；逐次探测自愈更稳。
- **不改 `cdp-proxy.mjs`**：端口由 Python 侧统一编排，通过 `BOSSHUNTER_BROWSER_PROXY_PORT` 环境变量传入，Node 侧无需感知回退逻辑。

## 测试与验证

- [x] 单元测试：`tests/test_browser_runtime.py` + `tests/test_browser_diagnostics.py` 共 24 个全部通过（含新增用例）
- [x] 真实场景复现验证：将 `config.yaml` 的 `proxy_port` 临时设为 3456（当前系统保留段 3414-3513 内）→ `bosshunter connect` 自动回退到 **3514**，四项检测全绿：

```
✓ Node.js 可用: v22.22.2
✓ BossHunter CDP Runtime 已启动: http://127.0.0.1:3514
✓ 已连接 Chrome
✓ 发现 BOSS直聘 页面: 「深圳招聘网」海量深圳人才招聘信息 - BOSS直聘
```

- [x] 正常路径回归：`proxy_port: 8456`（可绑定）→ 直接启动，无行为变化
- [x] `bosshunter --help` 正常运行
- [x] ruff：改动行无新增告警（该文件存在 4 处历史告警，未触碰）