### PR TITLE
fix: verify ambiguous greeting delivery from chat list

### DIFF
--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -16,6 +16,7 @@ from bosshunter.browser import (
     navigate,
     press_key,
     type_text,
+    wait_for_load,
 )
 from bosshunter.db import get_db, get_jobs_ready_to_send, update_job_status, add_history, add_risk_event
 from bosshunter.throttle import RequestThrottle, SendWindowChecker, ProgressiveBackoff, should_take_day_off
@@ -518,39 +519,65 @@ def _message_delivery_state(target_id: str, greeting: str) -> str:
     return str(result.get("state") or "missing")
 
 
-def _submitted_message_looks_accepted(target_id: str, greeting: str) -> bool:
-    """Return true when Boss appears to have accepted a send despite missing echo."""
-    greeting_escaped = json.dumps(greeting, ensure_ascii=False)
-    result = _parse_js_result(evaluate(target_id, f"""
-    (() => {{
-        const normalize = (value) => String(value || '')
-            .replace(/[\\u200b-\\u200f\\ufeff]/g, '')
-            .replace(/\\s+/g, ' ')
-            .trim();
-        const expected = normalize({greeting_escaped});
-        const input = document.querySelector('#chat-input');
-        const inputText = normalize(input ? input.innerText || input.textContent || input.value : '');
-        const inputCleared = !!input && inputText.length === 0;
-        const ownMessages = Array.from(document.querySelectorAll(
-            '.chat-record .message-item.item-myself, .chat-record .item-myself, '
-            + '.chat-record .message-item.item-self, .chat-record [class*="item-my"]'
-        ));
-        const hasFailedOwnMessage = ownMessages.some((node) => {{
-            const statusNode = node.querySelector('.message-status');
-            const statusClass = statusNode ? String(statusNode.className || '') : '';
-            const text = normalize(node.innerText || node.textContent);
-            return statusClass.includes('status-error')
-                || (text.includes('发送失败') && (text.includes(expected) || expected.includes(text)));
-        }});
-        return JSON.stringify({{
-            success: true,
-            accepted: inputCleared && !hasFailedOwnMessage,
-            inputCleared,
-            hasFailedOwnMessage
-        }});
-    }})()
-    """))
-    return bool(result.get("success") and result.get("accepted"))
+def _verify_greeting_in_chat_list(
+    job: dict,
+    greeting: str,
+    stop_event,
+    attempts: int = 6,
+) -> bool:
+    """Confirm an ambiguous send from the matching BOSS chat-list row.
+
+    A cleared input only proves that the page handled the submit action. Require
+    the target company and complete greeting in the same row before recording a
+    success, so this fallback cannot cause an automatic duplicate or false sent
+    state.
+    """
+    company = " ".join(str(job.get("company") or "").split())
+    expected = " ".join(str(greeting or "").split())
+    if not company or not expected:
+        return False
+
+    target_id = new_tab("https://www.zhipin.com/web/geek/chat", background=True)
+    if not target_id:
+        return False
+
+    try:
+        wait_for_load(target_id, timeout=10)
+        company_json = json.dumps(company, ensure_ascii=False)
+        expected_json = json.dumps(expected, ensure_ascii=False)
+        expression = f"""
+        (() => {{
+			const normalize = (value) => String(value || '').replace(/\\s+/g, ' ').trim();
+            const expectedCompany = normalize({company_json});
+            const expectedGreeting = normalize({expected_json});
+            const rows = Array.from(document.querySelectorAll('li[role=listitem]'));
+            const matched = rows.some((row) => {{
+                const nameBox = row.querySelector('.name-box');
+                const spans = nameBox ? Array.from(nameBox.querySelectorAll('span')) : [];
+                const actualCompany = normalize(spans.length >= 2 ? spans[1].textContent : '');
+                const lastMessage = row.querySelector('.last-msg-text, .last-msg, .message-text');
+                const actualMessage = normalize(lastMessage ? lastMessage.textContent : row.innerText);
+                const companyMatches = actualCompany && (
+                    actualCompany === expectedCompany
+                    || actualCompany.includes(expectedCompany)
+                    || expectedCompany.includes(actualCompany)
+                );
+                return companyMatches && actualMessage.includes(expectedGreeting);
+            }});
+            return JSON.stringify({{success: true, matched}});
+        }})()
+        """
+        for attempt in range(max(1, attempts)):
+            if _stop_requested(stop_event):
+                return False
+            result = _parse_js_result(evaluate(target_id, expression, timeout=5))
+            if result.get("success") and result.get("matched"):
+                return True
+            if attempt + 1 < attempts and _sleep_or_stop(1, stop_event):
+                return False
+        return False
+    finally:
+        close_tab(target_id)
 
 
 def _submit_chat_message_background(target_id: str, greeting: str) -> dict:
@@ -779,6 +806,14 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
 
     if not chat_ready.get("success"):
         if contact_action == "first_contact_submitted":
+            if _verify_greeting_in_chat_list(job, greeting, stop_event):
+                close_tab(target_id)
+                return {
+                    "success": True,
+                    "verified": True,
+                    "first_contact": True,
+                    "verified_from_chat_list": True,
+                }, None
             return {
                 "success": False,
                 "error": "first_contact_navigation_unverified",
@@ -817,18 +852,27 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
                         "verified": True,
                         "first_contact": True,
                     }, None
+                if _verify_greeting_in_chat_list(job, greeting, stop_event):
+                    close_tab(target_id)
+                    return {
+                        "success": True,
+                        "verified": True,
+                        "first_contact": True,
+                        "verified_from_chat_list": True,
+                    }, None
                 return {
                     "success": False,
                     "error": "first_contact_send_not_stable",
                     "history_detail": "首次招呼语曾出现但未稳定保留在会话中",
                     "skip_backoff": True,
                 }, target_id
-        if _submitted_message_looks_accepted(target_id, greeting):
+        if _verify_greeting_in_chat_list(job, greeting, stop_event):
             close_tab(target_id)
             return {
                 "success": True,
-                "accepted_without_echo": True,
+                "verified": True,
                 "first_contact": True,
+                "verified_from_chat_list": True,
             }, None
         return {
             "success": False,
@@ -888,6 +932,13 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
             if _message_delivery_state(target_id, greeting) == "delivered":
                 close_tab(target_id)
                 return {"success": True, "verified": True}, None
+            if _verify_greeting_in_chat_list(job, greeting, stop_event):
+                close_tab(target_id)
+                return {
+                    "success": True,
+                    "verified": True,
+                    "verified_from_chat_list": True,
+                }, None
             return {
                 "success": False,
                 "error": "send_not_stable",
@@ -895,9 +946,13 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
                 "skip_backoff": True,
             }, target_id
 
-    if _submitted_message_looks_accepted(target_id, greeting):
+    if _verify_greeting_in_chat_list(job, greeting, stop_event):
         close_tab(target_id)
-        return {"success": True, "accepted_without_echo": True}, None
+        return {
+            "success": True,
+            "verified": True,
+            "verified_from_chat_list": True,
+        }, None
 
     return {
         "success": False,

--- a/tests/test_job_selection.py
+++ b/tests/test_job_selection.py
@@ -21,7 +21,7 @@ from bosshunter.executor.sender import _chat_target_matches_job
 from bosshunter.executor.sender import _confirm_preset_greeting
 from bosshunter.executor.sender import _handle_greet_popup
 from bosshunter.executor.sender import _message_delivery_state
-from bosshunter.executor.sender import _submitted_message_looks_accepted
+from bosshunter.executor.sender import _verify_greeting_in_chat_list
 from bosshunter.executor.sender import send_greetings
 from bosshunter.executor.sender import _send_greeting_once
 from bosshunter.executor.sender import _submit_chat_message_background
@@ -131,18 +131,22 @@ class JobSelectionTests(unittest.TestCase):
         self.assertIn("text.includes(expectedText)", script)
         self.assertIn("发送中|已读|未读|送达|发送成功|重试|重新发送", script)
 
-    def test_send_acceptance_fallback_requires_cleared_input_without_failure(self):
-        greeting = "您好，我的经历和岗位需求比较匹配。"
-        with patch(
-            "bosshunter.executor.sender.evaluate",
-            return_value='{"success": true, "accepted": true, "inputCleared": true, "hasFailedOwnMessage": false}',
-        ) as evaluate_mock:
-            accepted = _submitted_message_looks_accepted("target-1", greeting)
+    def test_chat_list_verification_requires_company_and_complete_greeting(self):
+        result = '{"success": true, "matched": true}'
+        with patch("bosshunter.executor.sender.new_tab", return_value="chat-target"), \
+             patch("bosshunter.executor.sender.wait_for_load"), \
+             patch("bosshunter.executor.sender.evaluate", return_value=result) as evaluate, \
+             patch("bosshunter.executor.sender.close_tab") as close_tab:
+            verified = _verify_greeting_in_chat_list(
+                {"company": "Example"},
+                "完整招呼语内容",
+                None,
+            )
 
-        self.assertTrue(accepted)
-        script = evaluate_mock.call_args.args[1]
-        self.assertIn("inputCleared && !hasFailedOwnMessage", script)
-        self.assertIn("status-error", script)
+        self.assertTrue(verified)
+        expression = evaluate.call_args.args[1]
+        self.assertIn("companyMatches && actualMessage.includes(expectedGreeting)", expression)
+        close_tab.assert_called_once_with("chat-target")
 
     def test_startchat_popup_reuses_chat_redirect_without_foreground_input(self):
         click_result = {"redirectUrl": "/web/geek/chat?jobId=first-contact"}
@@ -261,7 +265,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual(evaluate_mock.call_count, len(evaluate_results))
         close_tab.assert_called_once_with("target-1")
 
-    def test_send_greeting_accepts_cleared_input_when_echo_is_missing(self):
+    def test_send_greeting_accepts_chat_list_receipt_when_echo_is_missing(self):
         job = {
             "id": "accepted-without-echo",
             "company": "Example",
@@ -276,7 +280,7 @@ class JobSelectionTests(unittest.TestCase):
              patch("bosshunter.executor.sender._wait_for_chat_page", return_value={"success": True, "target_id": "target-1"}), \
              patch("bosshunter.executor.sender._message_delivery_state", return_value="missing"), \
              patch("bosshunter.executor.sender._submit_chat_message_background", return_value={"success": True}), \
-             patch("bosshunter.executor.sender._submitted_message_looks_accepted", return_value=True), \
+             patch("bosshunter.executor.sender._verify_greeting_in_chat_list", return_value=True), \
              patch("bosshunter.executor.sender.close_tab") as close_tab, \
              patch("bosshunter.executor.sender.time.sleep"):
             result, target_id = _send_greeting_once(
@@ -287,7 +291,8 @@ class JobSelectionTests(unittest.TestCase):
 
         self.assertIsNone(target_id)
         self.assertTrue(result["success"])
-        self.assertTrue(result["accepted_without_echo"])
+        self.assertTrue(result["verified"])
+        self.assertTrue(result["verified_from_chat_list"])
         close_tab.assert_called_once_with("target-1")
 
     def test_send_greeting_uses_original_flow_when_platform_preset_is_enabled(self):


### PR DESCRIPTION
## Summary

- replace the cleared-input delivery fallback with traceable chat-list verification
- require the target company and complete greeting in the same chat row before marking a send successful
- retain manual-check behavior when delivery evidence remains ambiguous

## Why

A cleared chat input only proves that the page handled the submit action. It does not prove that the target conversation received the greeting. This change reduces false failure reports without introducing false sent states or automatic duplicate sends.

## Tests

- 305 pytest tests passed
- 11 subtests passed
- focused delivery verification tests passed after the final escape cleanup
- Python compile check passed with SyntaxWarning treated as an error

## Validation boundary

- no live BOSS message was sent while preparing this PR
- DOM behavior is covered by deterministic tests and should still be checked against the current BOSS page before release
- no resume, database, API credential, log, screenshot, generated output, local path, or personal contact information is included