### PR TITLE
feat: add deterministic greeting style guards

### DIFF
--- a/src/bosshunter/ai/greeter.py
+++ b/src/bosshunter/ai/greeter.py
@@ -25,20 +25,24 @@ GREETING_PROMPT = """你是一位求职者，需要在BOSS直聘上给HR发送�
 - 岗位要求摘要：{jd_summary}
 - 匹配分析：{match_reason}
 
-## 额外亮点（适时融入，不要生硬罗列）
+## 可用亮点（只选最相关的一项，不要罗列）
 {extra_highlights}
 
+## 最近已经使用过的开头（必须避开相同句式）
+{recent_openings}
+
 ## 要求
-1. 字数控制在50-150字
-2. 风格自然，像真人发的IM消息，不要太正式
-3. 突出1-2个最匹配的优势
-4. 表达对岗位的兴趣，但不要谄媚
-5. 不要用"您好，我是xxx"这种模板开头，要有差异化
-6. 适配手机端阅读
-7. 在合适的位置自然带出作品集链接（不要每次都放，根据岗位匹配度决定）
+1. 字数控制在60-110字，最多3个短句；像真人临时发出的IM，不写求职信
+2. 只围绕岗位描述里最独特、最具体的一点展开，不要复述职位名称或整段JD
+3. 开头可以谈判断、场景或问题，不要固定以“看到/关注到/了解到贵司在招”开头
+4. 只给一个最相关的能力证据；技术名词最多2个，不要堆叠术语
+5. 避免“挺有共鸣、挺兴奋、一直在做、从0到1、完整闭环、快速上手”等求职套话
+6. 结尾自然留一个沟通入口，不要固定写“方便的话可以看看/希望有机会聊聊”
+7. 作品集不是固定落款；只有岗位明确关注案例、作品、设计或原型时才可出现一次
 8. 【严禁】不得捏造我没有的经历、头衔或身份，只能使用"我的背景"中明确提到的信息
 9. 【严禁】不得把岗位JD中的描述（如公司头衔、项目名）当作我的经历来写
-10. 严格使用"我的背景"中的原文描述，不得改写或美化
+10. 项目经历只作轻量证据，可不提；如需提及，整条消息最多出现一次“项目”，不得写具体项目名称
+11. 可以压缩和概括“我的背景”，但不得新增事实、夸大结果或改写成更高职级经历
 {critique_section}
 请直接输出招呼语文本，不要加任何标记或解释。
 """
@@ -55,9 +59,10 @@ REVIEW_PROMPT = """请评估以下BOSS直聘招呼语的质量。
 1. 自然度：是否像真人发的IM消息，而非模板
 2. 相关性：是否针对该岗位突出匹配点
 3. 差异化：是否能从众多招呼中脱颖而出
+4. 克制度：是否只讲一个匹配点，避免项目名、术语堆叠、固定作品集落款和求职套话
 
 请严格按JSON格式输出，不要输出其他内容：
-{{"naturalness": 8, "relevance": 7, "differentiation": 6, "avg": 7.0, "critique": "改进建议（20字内）"}}
+{{"naturalness": 8, "relevance": 7, "differentiation": 6, "restraint": 8, "avg": 7.25, "critique": "改进建议（20字内）"}}
 """
 
 
@@ -206,6 +211,61 @@ def _normalize_greeting_response(response: str | None) -> str | None:
     return greeting.strip() or None
 
 
+def _opening_signature(greeting: str, limit: int = 24) -> str:
+    """Return a compact first-clause signature for batch-level diversity."""
+    text = " ".join(str(greeting or "").split())
+    for separator in ("，", "。", "！", "？", "——", "—", "-"):
+        text = text.split(separator, 1)[0]
+    return text[:limit]
+
+
+def _greeting_style_issues(
+    greeting: str,
+    recent_openings: list[str] | None = None,
+) -> list[str]:
+    """Return deterministic style issues that should trigger a rewrite."""
+    issues = []
+    if greeting.count("项目") > 1:
+        issues.append("不要反复强调项目，整条消息最多出现一次“项目”")
+    if len(greeting) > 110:
+        issues.append("压缩到110字以内，只保留一个匹配点")
+
+    templated_openings = (
+        "看到这个岗位",
+        "看到贵司在招",
+        "关注到贵司在招",
+        "了解到贵司在招",
+    )
+    if greeting.startswith(templated_openings):
+        issues.append("换掉模板化开头，直接从岗位中的具体问题或判断切入")
+
+    clichés = (
+        "挺有共鸣", "挺兴奋", "一直在做", "正好是我", "从0到1",
+        "完整闭环", "完整落地", "快速上手", "期待进一步沟通",
+        "方便的话可以看看",
+    )
+    used_clichés = [phrase for phrase in clichés if phrase in greeting]
+    if used_clichés:
+        issues.append(f"去掉求职套话：{'、'.join(used_clichés[:3])}")
+
+    lower_greeting = greeting.lower()
+    technical_concepts = [
+        any(term in lower_greeting for term in ("agent", "tool calling", "memory")),
+        any(term in lower_greeting for term in ("rag", "知识库")),
+        "prompt" in lower_greeting,
+        "工作流" in greeting and "agent" not in lower_greeting,
+        any(term in lower_greeting for term in ("大模型", "llm")),
+        "mcp" in lower_greeting,
+    ]
+    if sum(technical_concepts) > 2:
+        issues.append("技术名词最多保留2个，只留下与岗位最相关的能力证据")
+
+    opening = _opening_signature(greeting)
+    if opening and opening in set(recent_openings or []):
+        issues.append("本批次已使用相同开头，请换一种自然切入方式")
+    return issues
+
+
 def _parse_review_response(response: str | None) -> dict | None:
     if not isinstance(response, str) or not response.strip():
         return None
@@ -255,19 +315,25 @@ def _generate_greeting_once(
     *,
     compact: bool = False,
     max_tokens: int | None = None,
+    recent_openings: list[str] | None = None,
 ) -> str | None:
     """Generate a single greeting attempt."""
     jd_limit = 250 if compact else 500
     resume_limit = 800 if compact else 1500
     jd_summary = _truncate_prompt_text(job.get("jd", ""), jd_limit) or "无详细描述"
-    critique_section = f"\n7. 上次生成的问题: {critique}，请避免此问题\n" if critique else ""
+    critique_section = f"\n## 补充改进要求\n- {critique}\n" if critique else ""
 
     # Build extra highlights from config (portfolio URL, personal strengths, etc.)
     profile_cfg = config.get("profile", {})
     highlights = profile_cfg.get("extra_highlights", [])
     portfolio_url = profile_cfg.get("portfolio_url", "")
     highlight_lines = [f"- {h}" for h in highlights]
-    if portfolio_url:
+    portfolio_context = f"{job.get('title', '')} {job.get('jd', '')}".lower()
+    portfolio_requested = any(
+        keyword in portfolio_context
+        for keyword in ("作品集", "案例", "case", "原型", "交互设计", "视觉设计")
+    )
+    if portfolio_url and portfolio_requested:
         highlight_lines.append(f"- 个人作品集网址：{portfolio_url}")
     extra_highlights = "\n".join(highlight_lines) if highlight_lines else "（无额外亮点配置）"
 
@@ -280,6 +346,10 @@ def _generate_greeting_once(
         match_reason=_truncate_prompt_text(job.get("score_reason", ""), 240),
         critique_section=critique_section,
         extra_highlights=_truncate_prompt_text(extra_highlights, 500),
+        recent_openings=(
+            "\n".join(f"- {opening}" for opening in (recent_openings or [])[-8:])
+            or "（暂无）"
+        ),
     )
 
     ai_cfg = config.get("ai", {}) if isinstance(config.get("ai"), dict) else {}
@@ -293,10 +363,17 @@ def _generate_with_token_retry(
     resume_summary: str,
     config: dict,
     critique: str = "",
+    recent_openings: list[str] | None = None,
 ) -> str | None:
     """Retry only request-size/output-limit failures without changing batch size."""
     try:
-        result = _generate_greeting_once(job, resume_summary, config, critique)
+        result = _generate_greeting_once(
+            job,
+            resume_summary,
+            config,
+            critique,
+            recent_openings=recent_openings,
+        )
         if result:
             return result
         ai_cfg = config.get("ai", {}) if isinstance(config.get("ai"), dict) else {}
@@ -309,7 +386,13 @@ def _generate_with_token_retry(
                 config,
                 f"{job['company']}｜{job['title']} 未返回完整招呼语，正在重试（{attempt}/{max_attempts}）。",
             )
-            result = _generate_greeting_once(job, resume_summary, config, critique)
+            result = _generate_greeting_once(
+                job,
+                resume_summary,
+                config,
+                critique,
+                recent_openings=recent_openings,
+            )
             if result:
                 return result
         return None
@@ -345,6 +428,7 @@ def _generate_with_token_retry(
             critique,
             compact=compact,
             max_tokens=retry_max_tokens,
+            recent_openings=recent_openings,
         )
     except AIRequestError as retry_exc:
         if retry_exc.kind in {"output_truncated", "output_limit", "context_limit"}:
@@ -414,6 +498,21 @@ def generate_greetings(config: dict) -> int:
     except (TypeError, ValueError):
         max_iterations = 2
 
+    recent_rows = db.execute(
+        """
+        SELECT greeting
+        FROM jobs
+        WHERE greeting IS NOT NULL AND trim(greeting) != ''
+        ORDER BY updated_at DESC
+        LIMIT 20
+        """
+    ).fetchall()
+    recent_openings = [
+        opening
+        for row in recent_rows
+        if (opening := _opening_signature(str(row["greeting"] or "")))
+    ]
+
     count = 0
     failed = 0
     pause_reason = ""
@@ -446,18 +545,28 @@ def generate_greetings(config: dict) -> int:
                     except AIRequestError as exc:
                         pause_after_current = exc.user_message
                         break
-                    if review is None:
+                    style_issues = _greeting_style_issues(best_greeting, recent_openings)
+                    if review is None and not style_issues:
                         _notify(
                             config,
                             f"{job['company']}｜{job['title']} 的质量检查返回格式无法识别，已保留可用招呼语并继续。",
                         )
                         break
-                    if review and review.get("avg", 10) >= review_threshold:
+                    if review and review.get("avg", 10) >= review_threshold and not style_issues:
                         break
-                    critique = review.get("critique", "") if review else ""
+                    critique_parts = style_issues[:]
+                    if review and review.get("critique"):
+                        critique_parts.append(str(review["critique"]))
+                    critique = "；".join(critique_parts)
 
                 try:
-                    greeting = _generate_with_token_retry(job, resume_summary, config, critique)
+                    greeting = _generate_with_token_retry(
+                        job,
+                        resume_summary,
+                        config,
+                        critique,
+                        recent_openings,
+                    )
                 except OperationCancelled:
                     cancelled = True
                     break
@@ -489,6 +598,9 @@ def generate_greetings(config: dict) -> int:
 
             update_job_greeting(db, job["id"], best_greeting)
             update_job_status(db, job["id"], "ready")
+            opening = _opening_signature(best_greeting)
+            if opening:
+                recent_openings.append(opening)
             count += 1
             progress.update(task, advance=1, description=f"生成招呼语 ({index}/{len(jobs)})")
 

--- a/tests/test_ai_token_resilience.py
+++ b/tests/test_ai_token_resilience.py
@@ -468,6 +468,47 @@ class ScorerTokenResilienceTests(unittest.TestCase):
 
 
 class GreeterTokenResilienceTests(unittest.TestCase):
+    def test_style_guard_flags_template_language_and_technical_stacking(self):
+        greeting = (
+            "看到这个岗位挺有共鸣，我一直在做Agent、RAG、Prompt和MCP项目，"
+            "可以完成从0到1的完整闭环，期待进一步沟通。"
+        )
+
+        issues = greeter._greeting_style_issues(greeting)
+
+        self.assertTrue(any("模板化开头" in issue for issue in issues))
+        self.assertTrue(any("求职套话" in issue for issue in issues))
+        self.assertTrue(any("技术名词" in issue for issue in issues))
+
+    def test_style_guard_flags_an_opening_already_used_in_the_batch(self):
+        greeting = "复杂流程里最关键的是先把异常边界定义清楚，我有相关需求梳理经验，可以交流下具体场景。"
+
+        issues = greeter._greeting_style_issues(
+            greeting,
+            [greeter._opening_signature(greeting)],
+        )
+
+        self.assertIn("本批次已使用相同开头，请换一种自然切入方式", issues)
+
+    def test_portfolio_is_only_added_when_the_job_explicitly_requests_it(self):
+        config = {
+            "profile": {
+                "portfolio_url": "https://portfolio.example",
+                "extra_highlights": ["有用户研究经验"],
+            }
+        }
+        ordinary_job = _job("ordinary")
+        design_job = {**_job("design"), "jd": "请提供交互设计案例和原型作品集。"}
+
+        with patch("bosshunter.ai.greeter._call_claude", return_value="生成结果") as call_ai:
+            greeter._generate_greeting_once(ordinary_job, "匿名简历摘要", config)
+            ordinary_prompt = call_ai.call_args.args[0]
+            greeter._generate_greeting_once(design_job, "匿名简历摘要", config)
+            design_prompt = call_ai.call_args.args[0]
+
+        self.assertNotIn("https://portfolio.example", ordinary_prompt)
+        self.assertIn("https://portfolio.example", design_prompt)
+
     def test_greeting_json_wrapper_is_normalized(self):
         response = '```json\n{"greeting":"您好，我的产品经验与岗位需求比较匹配。"}\n```'
 
@@ -520,6 +561,37 @@ class GreeterTokenResilienceTests(unittest.TestCase):
         )
         update_status.assert_called_once_with(db, "review-format", "ready")
         self.assertTrue(any("质量检查返回格式无法识别" in message for message in logs))
+
+    def test_style_guard_rewrites_even_when_model_review_is_malformed(self):
+        db = MagicMock()
+        jobs = [_job("style-rewrite")]
+
+        with (
+            patch("bosshunter.ai.greeter.get_db", return_value=db),
+            patch("bosshunter.ai.greeter.get_jobs_by_status", return_value=jobs),
+            patch("bosshunter.ai.greeter._get_resume_summary", return_value="匿名简历摘要"),
+            patch(
+                "bosshunter.ai.greeter._call_claude",
+                side_effect=[
+                    "看到这个岗位挺有共鸣，我一直在做相关项目，期待进一步沟通。",
+                    "评分很好，但没有按 JSON 返回。",
+                    "复杂流程先理清异常边界更重要，我有相关需求梳理经验，可以交流下具体场景。",
+                ],
+            ) as call_ai,
+            patch("bosshunter.ai.greeter.update_job_greeting") as update_greeting,
+            patch("bosshunter.ai.greeter.update_job_status"),
+        ):
+            count = greeter.generate_greetings(
+                {"ai": {"greeting_max_iterations": 1}}
+            )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(call_ai.call_count, 3)
+        update_greeting.assert_called_once_with(
+            db,
+            "style-rewrite",
+            "复杂流程先理清异常边界更重要，我有相关需求梳理经验，可以交流下具体场景。",
+        )
 
     def test_empty_greeting_retries_before_leaving_job_pending(self):
         db = MagicMock()


### PR DESCRIPTION
## Summary
- make greeting prompts shorter, more conversational, and focused on one JD-specific point
- add deterministic checks for template openings, cliches, technical-term stacking, repeated project emphasis, and duplicate batch openings
- include portfolio links only when the JD explicitly requests cases, prototypes, design work, or a portfolio
- preserve usable output when model review is malformed, while still rewriting deterministic style violations

## Tests
- `PYTHONPATH=src python -m pytest -q`
- 309 passed, 11 subtests passed
- compileall with SyntaxWarning treated as error
- diff and privacy scan clean

## Safety boundary
- no live job-platform messages were sent
- tests use synthetic job and resume data only