### PR TITLE
Fix monitor rate-limit safety guards

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,7 +68,11 @@ ai:
 
 monitor:
   interval: 30
+  # 仅“运行全流程”发送结束后生效；单独监测会立即执行首轮
+  initial_cooldown_minutes: 10
   chat_url: "https://www.zhipin.com/web/geek/chat"
+  max_conversations_per_cycle: 5
+  max_consecutive_page_failures: 3
   max_resume_sends_per_cycle: 5
   auto_reply_hr_questions: false
 

--- a/src/bosshunter/config.py
+++ b/src/bosshunter/config.py
@@ -112,7 +112,10 @@ DEFAULTS: dict[str, Any] = {
     },
     "monitor": {
         "interval": 30,  # 分钟
+        "initial_cooldown_minutes": 10,
         "chat_url": "https://www.zhipin.com/web/geek/chat",
+        "max_conversations_per_cycle": 5,
+        "max_consecutive_page_failures": 3,
         "max_resume_sends_per_cycle": 5,
         "auto_reply_hr_questions": False,
     },

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -15,7 +15,7 @@ from bosshunter.cancellation import (
 )
 from bosshunter.db import (
     get_db, get_jobs_by_status,
-    update_job_status, add_history,
+    update_job_status, add_history, add_risk_event,
 )
 from bosshunter.throttle import RequestThrottle, SendWindowChecker
 
@@ -33,6 +33,7 @@ JS_EXTRACT_CHAT_LIST = """
         const nameBox = item.querySelector('.name-box');
         const lastMsgEl = item.querySelector('.last-msg-text');
         const msgStatus = item.querySelector('.message-status');
+        const unreadEl = item.querySelector('.unread-count, .badge-count, .notice-badge, [class*="unread"]');
 
         if (!nameText) return;
 
@@ -51,6 +52,7 @@ JS_EXTRACT_CHAT_LIST = """
             hr_title: hrTitle,
             last_message: lastMsgEl ? lastMsgEl.textContent.trim().substring(0, 200) : '',
             has_reply: hasReply,
+            has_unread: !!unreadEl,
             is_our_message: isOurMessage,
             element_index: results.length
         });
@@ -58,6 +60,57 @@ JS_EXTRACT_CHAT_LIST = """
     return JSON.stringify(results);
 })()
 """
+
+JS_DETECT_MONITOR_RISK = """
+(() => {
+    const text = document.body ? document.body.innerText : '';
+    const title = document.title || '';
+    const url = window.location.href || '';
+    const hasCaptchaElement = !!document.querySelector(
+        '.geetest_panel, .captcha, [class*="captcha"], [id*="captcha"], iframe[src*="captcha"], iframe[src*="verify"]'
+    );
+    if (
+        hasCaptchaElement || /captcha|verify|security-check/i.test(url) ||
+        ['请完成验证', '安全验证', '拖动滑块', '点击完成验证'].some(value => text.includes(value))
+    ) return JSON.stringify({risk: 'captcha'});
+    if (
+        ['操作过于频繁', '访问过于频繁', '请求过于频繁', '操作频繁，请稍后再试'].some(value => text.includes(value))
+    ) return JSON.stringify({risk: 'rate_limit'});
+    if (
+        ['账号存在异常', '账号已被限制', '当前账号异常', '访问被拒绝', '账号或请求被拦截'].some(value => text.includes(value)) ||
+        ['账号异常', '访问受限'].some(value => title.includes(value))
+    ) return JSON.stringify({risk: 'blocked'});
+    return JSON.stringify({risk: null});
+})()
+"""
+
+
+class MonitorRiskDetected(RuntimeError):
+    """Raised when monitoring must stop immediately for account safety."""
+
+    def __init__(self, kind: str) -> None:
+        super().__init__(kind)
+        self.kind = kind
+
+
+class MonitorSafetyGuard:
+    """Track consecutive monitor page failures and stop at a conservative threshold."""
+
+    def __init__(self, config: dict) -> None:
+        raw_limit = config.get("monitor", {}).get("max_consecutive_page_failures", 3)
+        try:
+            self.limit = max(int(raw_limit), 1)
+        except (TypeError, ValueError):
+            self.limit = 3
+        self.consecutive_page_failures = 0
+
+    def record_page_failure(self) -> None:
+        self.consecutive_page_failures += 1
+        if self.consecutive_page_failures >= self.limit:
+            _raise_monitor_risk("consecutive_page_failures")
+
+    def record_page_success(self) -> None:
+        self.consecutive_page_failures = 0
 
 # JS: Extract full conversation messages from an open chat, including rich/system cards
 JS_EXTRACT_CONVERSATION = r"""
@@ -214,6 +267,75 @@ def _wait_for_page_or_stop(target_id: str, config: dict, timeout: float = 10) ->
     return not stop_requested(config)
 
 
+def _monitor_safety_guard(config: dict) -> MonitorSafetyGuard:
+    guard = config.get("_monitor_safety_guard")
+    if isinstance(guard, MonitorSafetyGuard):
+        return guard
+    guard = MonitorSafetyGuard(config)
+    config["_monitor_safety_guard"] = guard
+    return guard
+
+
+def _record_page_failure_unless_stopped(config: dict) -> None:
+    if not stop_requested(config):
+        _monitor_safety_guard(config).record_page_failure()
+
+
+def _record_monitor_risk(kind: str) -> None:
+    """Persist a safe risk event without page text, URLs, or account data."""
+    labels = {
+        "captcha": "监测检测到验证码，已停止",
+        "rate_limit": "监测检测到频率限制，已停止",
+        "blocked": "监测检测到账号或请求拦截，已停止",
+        "consecutive_page_failures": "监测连续页面失败达到阈值，已停止",
+    }
+    db = None
+    try:
+        db = get_db()
+        add_risk_event(db, f"monitor_{kind}", labels.get(kind, "监测检测到风险信号，已停止"))
+    except Exception:
+        # Failure to persist telemetry must never allow risky browsing to continue.
+        pass
+    finally:
+        if db is not None:
+            db.close()
+
+
+def _raise_monitor_risk(kind: str) -> None:
+    _record_monitor_risk(kind)
+    raise MonitorRiskDetected(kind)
+
+
+def _inspect_monitor_page(target_id: str) -> None:
+    """Stop immediately when the current platform page exposes a risk signal."""
+    raw = evaluate(target_id, JS_DETECT_MONITOR_RISK)
+    try:
+        result = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(result, dict):
+        return
+    kind = result.get("risk")
+    if kind in {"captcha", "rate_limit", "blocked"}:
+        _raise_monitor_risk(kind)
+
+
+def _open_monitor_tab(url: str, config: dict) -> str | None:
+    """Open one monitor page with an effective interval after every prior open attempt."""
+    if stop_requested(config):
+        return None
+    throttle = config.get("_monitor_request_throttle")
+    stop_event = get_stop_event(config)
+    if throttle is not None and bool(getattr(throttle, "has_marked_request", False)):
+        if throttle.wait(stop_event):
+            return None
+    target_id = new_tab(url, background=True)
+    if throttle is not None and hasattr(throttle, "mark"):
+        # Record attempts as well as successful opens so retries cannot become a burst.
+        throttle.mark()
+    return target_id
+
+
 def _detect_rejection(messages: list[dict]) -> bool:
     """Check if HR is rejecting in messages AFTER user's last reply."""
     rejection_keywords = ["不合适", "不匹配", "不太合适", "暂时没有", "不符合", "不太符合",
@@ -324,7 +446,12 @@ def _truncate_text(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[:limit]
 
 
-def _build_reply_detail(messages: list[dict], ai_reply: str, schema: str = "reply_pending.v1") -> str:
+def _build_reply_detail(
+    messages: list[dict],
+    ai_reply: str,
+    schema: str = "reply_pending.v1",
+    conversation: dict | None = None,
+) -> str:
     """Build structured history detail containing the HR question and AI reply."""
     hr_messages = _get_hr_messages_after_last_reply(messages)
     hr_question = "\n".join(str(msg.get("text", "")) for msg in hr_messages[-3:]).strip()
@@ -333,6 +460,9 @@ def _build_reply_detail(messages: list[dict], ai_reply: str, schema: str = "repl
         "schema": schema,
         "hr_question": _truncate_text(hr_question, 1000),
         "reply_fingerprint": reply_fingerprint,
+        "chat_list_last_message": _reply_fingerprint_from_hr_question(
+            str((conversation or {}).get("last_message", ""))
+        ),
         "ai_reply": _truncate_text(ai_reply or "", 1000),
         "conversation_tail": [
             {
@@ -384,6 +514,12 @@ def _reply_fingerprint_from_detail(detail: str) -> str:
         return _reply_fingerprint_from_hr_question(fingerprint)
     hr_question = payload.get("hr_question") or payload.get("pending_hr_question")
     return _reply_fingerprint_from_hr_question(hr_question) if isinstance(hr_question, str) else ""
+
+
+def _chat_list_fingerprint_from_detail(detail: str) -> str:
+    payload = _parse_reply_detail(detail)
+    value = payload.get("chat_list_last_message")
+    return _reply_fingerprint_from_hr_question(value) if isinstance(value, str) else ""
 
 
 def _build_reply_resolution_detail(
@@ -510,8 +646,9 @@ def _open_conversation(job: dict, config: dict) -> str | None:
     # Strategy A: Via job URL (try up to 2 times)
     if job_url:
         for attempt in range(2):
-            target_id = new_tab(job_url, background=True)
+            target_id = _open_monitor_tab(job_url, config)
             if not target_id:
+                _record_page_failure_unless_stopped(config)
                 if attempt == 0:
                     if _wait_or_stop(config, 3):
                         return None
@@ -520,7 +657,13 @@ def _open_conversation(job: dict, config: dict) -> str | None:
 
             if _wait_or_stop(config, 3) or not _wait_for_page_or_stop(target_id, config, timeout=10):
                 close_tab(target_id)
+                _record_page_failure_unless_stopped(config)
                 return None
+            try:
+                _inspect_monitor_page(target_id)
+            except MonitorRiskDetected:
+                close_tab(target_id)
+                raise
             if _wait_or_stop(config, 1):
                 close_tab(target_id)
                 return None
@@ -529,7 +672,13 @@ def _open_conversation(job: dict, config: dict) -> str | None:
             if click(target_id, ".btn-startchat") or click(target_id, "[ka*='chat']"):
                 if _wait_or_stop(config, 3) or not _wait_for_page_or_stop(target_id, config, timeout=10):
                     close_tab(target_id)
+                    _record_page_failure_unless_stopped(config)
                     return None
+                try:
+                    _inspect_monitor_page(target_id)
+                except MonitorRiskDetected:
+                    close_tab(target_id)
+                    raise
                 if _wait_or_stop(config, 2):
                     close_tab(target_id)
                     return None
@@ -542,6 +691,7 @@ def _open_conversation(job: dict, config: dict) -> str | None:
                     return target_id
 
             close_tab(target_id)
+            _record_page_failure_unless_stopped(config)
             if attempt == 0:
                 if _wait_or_stop(config, 2):
                     return None
@@ -557,13 +707,20 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
         return None
     monitor_cfg = config.get("monitor", {})
     chat_url = monitor_cfg.get("chat_url", "https://www.zhipin.com/web/geek/chat")
-    target_id = new_tab(chat_url, background=True)
+    target_id = _open_monitor_tab(chat_url, config)
     if not target_id:
+        _record_page_failure_unless_stopped(config)
         return None
 
     if _wait_or_stop(config, 4) or not _wait_for_page_or_stop(target_id, config, timeout=10):
         close_tab(target_id)
+        _record_page_failure_unless_stopped(config)
         return None
+    try:
+        _inspect_monitor_page(target_id)
+    except MonitorRiskDetected:
+        close_tab(target_id)
+        raise
     if _wait_or_stop(config, 3):
         close_tab(target_id)
         return None
@@ -640,6 +797,11 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
             if _wait_or_stop(config, 1):
                 close_tab(target_id)
                 return None
+            try:
+                _inspect_monitor_page(target_id)
+            except MonitorRiskDetected:
+                close_tab(target_id)
+                raise
             return target_id
     except (json.JSONDecodeError, TypeError):
         pass
@@ -664,11 +826,17 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
                 if _wait_or_stop(config, 1):
                     close_tab(target_id)
                     return None
+                try:
+                    _inspect_monitor_page(target_id)
+                except MonitorRiskDetected:
+                    close_tab(target_id)
+                    raise
                 return target_id
         except (json.JSONDecodeError, TypeError):
             pass
 
     close_tab(target_id)
+    _record_page_failure_unless_stopped(config)
     return None
 
 
@@ -752,16 +920,25 @@ def check_replies(config: dict) -> list[dict]:
     console.print(f"[bold]监测 {len(all_tracked_jobs)} 个对话的回复情况...[/bold]")
 
     # Open chat page
-    target_id = new_tab(chat_url, background=True)
+    target_id = _open_monitor_tab(chat_url, config)
     if not target_id:
         console.print("[red]无法打开聊天页面[/red]")
         db.close()
+        _monitor_safety_guard(config).record_page_failure()
         return []
 
     if _wait_or_stop(config, 3) or not _wait_for_page_or_stop(target_id, config, timeout=10):
         close_tab(target_id)
         db.close()
+        if not stop_requested(config):
+            _monitor_safety_guard(config).record_page_failure()
         return []
+    try:
+        _inspect_monitor_page(target_id)
+    except MonitorRiskDetected:
+        close_tab(target_id)
+        db.close()
+        raise
     if _wait_or_stop(config, 2):
         close_tab(target_id)
         db.close()
@@ -777,6 +954,7 @@ def check_replies(config: dict) -> list[dict]:
     if not raw:
         console.print("[yellow]未能获取聊天列表[/yellow]")
         db.close()
+        _monitor_safety_guard(config).record_page_failure()
         return []
 
     try:
@@ -784,7 +962,16 @@ def check_replies(config: dict) -> list[dict]:
     except (json.JSONDecodeError, TypeError):
         console.print("[yellow]聊天列表解析失败[/yellow]")
         db.close()
+        _monitor_safety_guard(config).record_page_failure()
         return []
+
+    if not isinstance(conversations, list):
+        console.print("[yellow]聊天列表格式异常[/yellow]")
+        db.close()
+        _monitor_safety_guard(config).record_page_failure()
+        return []
+
+    _monitor_safety_guard(config).record_page_success()
 
     if not conversations:
         console.print("[dim]聊天列表为空[/dim]")
@@ -794,6 +981,11 @@ def check_replies(config: dict) -> list[dict]:
     console.print(f"[dim]获取到 {len(conversations)} 条对话[/dim]")
 
     # Match conversations to tracked jobs and find ones with HR replies
+    raw_limit = monitor_cfg.get("max_conversations_per_cycle", 5)
+    try:
+        max_conversations = max(int(raw_limit), 1)
+    except (TypeError, ValueError):
+        max_conversations = 5
     results = []
     for conv in conversations:
         if stop_requested(config):
@@ -803,6 +995,19 @@ def check_replies(config: dict) -> list[dict]:
 
         matched_job = _match_conversation_to_job(conv, all_tracked_jobs)
         if matched_job:
+            pending = _get_unresolved_pending_reply(db, matched_job["id"])
+            if pending and _pending_matches_chat_list(_row_text(pending, "detail"), conv):
+                console.print(
+                    f"[dim]  跳过已有待确认回复: {matched_job['company']} - {matched_job['title']}[/dim]"
+                )
+                continue
+            handled = _get_latest_handled_reply(db, matched_job["id"])
+            if handled and _handled_reply_matches_chat_list(_row_text(handled, "detail"), conv):
+                console.print(
+                    f"[dim]  跳过已处理的相同HR消息: {matched_job['company']} - {matched_job['title']}[/dim]"
+                )
+                continue
+
             # Update status to replied if it was 'sent'
             if matched_job.get("status") == "sent":
                 update_job_status(db, matched_job["id"], "replied")
@@ -815,6 +1020,9 @@ def check_replies(config: dict) -> list[dict]:
             console.print(
                 f"[green]  ✓ {matched_job['company']} - {matched_job['title']} 有新回复[/green]"
             )
+            if len(results) >= max_conversations:
+                console.print(f"[dim]本轮已达到对话处理上限 {max_conversations}[/dim]")
+                break
 
     if not results:
         console.print("[dim]暂无新回复[/dim]")
@@ -861,7 +1069,7 @@ def _match_conversation_to_job(conv: dict, jobs: list[dict]) -> dict | None:
     return None
 
 
-def _handle_conversation(job: dict, config: dict) -> str:
+def _handle_conversation(job: dict, config: dict, conversation: dict | None = None) -> str:
     """Handle a single conversation that has an HR reply.
 
     Returns action taken: 'stopped', 'skipped_user_replied',
@@ -892,19 +1100,36 @@ def _handle_conversation(job: dict, config: dict) -> str:
     if not raw:
         close_tab(target_id)
         console.print("[yellow]    无法获取对话内容[/yellow]")
+        _monitor_safety_guard(config).record_page_failure()
         return "failed"
 
     try:
         messages = json.loads(raw) if isinstance(raw, str) else raw
     except (json.JSONDecodeError, TypeError):
         close_tab(target_id)
+        _monitor_safety_guard(config).record_page_failure()
         return "failed"
+
+    if not isinstance(messages, list):
+        close_tab(target_id)
+        _monitor_safety_guard(config).record_page_failure()
+        return "failed"
+
+    _monitor_safety_guard(config).record_page_success()
 
     # Check if I already replied after the last HR message
     if _check_if_i_already_replied(messages):
         console.print("[dim]    我已回复，跳过本轮[/dim]")
         close_tab(target_id)
         return "skipped_user_replied"
+
+    db = get_db()
+    existing_pending_reply = _has_existing_pending_reply(db, job["id"], messages)
+    db.close()
+    if existing_pending_reply:
+        console.print("[dim]    相同HR消息已有待确认回复，跳过重复处理[/dim]")
+        close_tab(target_id)
+        return "skipped_existing_pending"
 
     # Check if HR is rejecting
     if _detect_rejection(messages):
@@ -1045,7 +1270,12 @@ def _handle_conversation(job: dict, config: dict) -> str:
             return "stopped"
         console.print("[yellow]    已生成回复建议，等待监测执行中确认[/yellow]")
         db = get_db()
-        add_history(db, job["id"], "reply_pending", _build_reply_detail(messages, reply))
+        add_history(
+            db,
+            job["id"],
+            "reply_pending",
+            _build_reply_detail(messages, reply, conversation=conversation),
+        )
         db.close()
         close_tab(target_id)
         return "reply_pending"
@@ -1076,6 +1306,94 @@ def _row_text(row, key: str) -> str:
     except (KeyError, IndexError, TypeError):
         return ""
     return value if isinstance(value, str) else ""
+
+
+def _get_unresolved_pending_reply(db, job_id: str):
+    """Return the latest reply suggestion only when no later decision resolved it."""
+    return db.execute(
+        """
+        SELECT h.id, h.detail
+        FROM history h
+        WHERE h.job_id = ?
+          AND h.action = 'reply_pending'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM history r
+              WHERE r.job_id = h.job_id
+                AND r.id > h.id
+                AND r.action IN ('reply_dismissed', 'replied', 'auto_replied')
+          )
+        ORDER BY h.id DESC
+        LIMIT 1
+        """,
+        (job_id,),
+    ).fetchone()
+
+
+def _get_latest_handled_reply(db, job_id: str):
+    """Return the latest resolved/handled monitor action carrying an HR fingerprint."""
+    return db.execute(
+        """
+        SELECT action, detail
+        FROM history
+        WHERE job_id = ?
+          AND action IN ('reply_dismissed', 'replied', 'auto_replied', 'needs_resume', 'resume_failed')
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (job_id,),
+    ).fetchone()
+
+
+def _pending_matches_chat_list(pending_detail: str, conversation: dict) -> bool:
+    """Avoid reopening an unresolved suggestion unless the chat list proves it changed."""
+    if conversation.get("has_unread"):
+        return False
+    current_last_message = _reply_fingerprint_from_hr_question(conversation.get("last_message", ""))
+    stored_last_message = _chat_list_fingerprint_from_detail(pending_detail)
+    if stored_last_message:
+        return stored_last_message == current_last_message
+
+    payload = _parse_reply_detail(pending_detail)
+    pending_fingerprint = _reply_fingerprint_from_detail(pending_detail)
+    if not pending_fingerprint:
+        # Legacy suggestions have no safe message identity. Keep them idempotent until
+        # the user confirms or dismisses them rather than repeatedly opening the chat.
+        return True
+    hr_question = payload.get("hr_question")
+    if isinstance(hr_question, str) and hr_question.strip():
+        pending_last_message = _reply_fingerprint_from_hr_question(hr_question.splitlines()[-1])
+    else:
+        pending_last_message = pending_fingerprint
+    return bool(current_last_message) and pending_last_message == current_last_message
+
+
+def _handled_reply_matches_chat_list(detail: str, conversation: dict) -> bool:
+    """Match a previously handled HR message without treating legacy plain text as proof."""
+    if conversation.get("has_unread"):
+        return False
+    fingerprint = _reply_fingerprint_from_detail(detail)
+    if not fingerprint:
+        return False
+    current_last_message = _reply_fingerprint_from_hr_question(conversation.get("last_message", ""))
+    payload = _parse_reply_detail(detail)
+    stored_last_message = _chat_list_fingerprint_from_detail(detail)
+    if not stored_last_message:
+        hr_question = payload.get("hr_question") or payload.get("pending_hr_question")
+        if isinstance(hr_question, str) and hr_question.strip():
+            stored_last_message = _reply_fingerprint_from_hr_question(hr_question.splitlines()[-1])
+    return bool(current_last_message) and stored_last_message == current_last_message
+
+
+def _has_existing_pending_reply(db, job_id: str, messages: list[dict]) -> bool:
+    """Return true only for the same still-unresolved HR message sequence."""
+    pending = _get_unresolved_pending_reply(db, job_id)
+    if pending is None:
+        return False
+    pending_fingerprint = _reply_fingerprint_from_detail(_row_text(pending, "detail"))
+    if not pending_fingerprint:
+        return True
+    return pending_fingerprint == _reply_fingerprint_from_messages(messages)
 
 
 def _has_generated_resume_for_job(db, job_id: str) -> bool:
@@ -1212,8 +1530,6 @@ def _check_follow_ups(config: dict, throttle, replied_job_ids: set | None = None
             console.print(f"[yellow]  ! 跟进失败: {job['company']}[/yellow]")
 
         close_tab(target_id)
-        if throttle.wait(stop_event):
-            break
 
     db.close()
     return count
@@ -1264,12 +1580,20 @@ def monitor_and_send_resumes(config: dict) -> dict:
         throttle_config.get("interval_min", 60),
         throttle_config.get("interval_max", 180),
     )
+    monitor_config = dict(config)
+    monitor_config["_monitor_request_throttle"] = throttle
+    monitor_config["_monitor_safety_guard"] = MonitorSafetyGuard(config)
+
+    summary = {"skipped": 0, "replied": 0, "needs_resume": 0, "rejected": 0, "failed": 0}
 
     # Step 1: Check for HR replies — MUST run first
     console.print("\n[bold cyan]═══ 第一步：处理HR回复 ═══[/bold cyan]")
-    replied_conversations = check_replies(config)
-
-    summary = {"skipped": 0, "replied": 0, "needs_resume": 0, "rejected": 0, "failed": 0}
+    try:
+        replied_conversations = check_replies(monitor_config)
+    except MonitorRiskDetected as exc:
+        console.print(f"[red]⚠ 监测检测到风险信号 {exc.kind}，已立即停止[/red]")
+        summary["stop_reason"] = exc.kind
+        return summary
     if stop_event and stop_event.is_set():
         return summary
 
@@ -1285,11 +1609,21 @@ def monitor_and_send_resumes(config: dict) -> dict:
                 break
             job = item["job"]
             replied_job_ids.add(job["id"])
-            action = _handle_conversation(job, config)
+            try:
+                action = _handle_conversation(job, monitor_config, item.get("conversation"))
+            except MonitorRiskDetected as exc:
+                console.print(f"[red]⚠ 监测检测到风险信号 {exc.kind}，已立即停止[/red]")
+                summary["stop_reason"] = exc.kind
+                break
 
             if action == "stopped":
                 break
-            if action in ("skipped_user_replied", "skipped_existing_resume", "skipped_dismissed_reply"):
+            if action in (
+                "skipped_user_replied",
+                "skipped_existing_resume",
+                "skipped_existing_pending",
+                "skipped_dismissed_reply",
+            ):
                 summary["skipped"] += 1
             elif action == "auto_replied":
                 summary["replied"] += 1
@@ -1299,9 +1633,6 @@ def monitor_and_send_resumes(config: dict) -> dict:
                 summary["rejected"] += 1
             else:
                 summary["failed"] += 1
-
-            if throttle.wait(stop_event):
-                break
 
         console.print("\n[bold green]═══ 回复处理完成 ═══[/bold green]")
         console.print(f"  跳过(已手动回复): {summary['skipped']}")
@@ -1317,10 +1648,15 @@ def monitor_and_send_resumes(config: dict) -> dict:
 
     # Step 3: Follow up ONLY on jobs with absolutely no HR reply
     # Pass replied_job_ids so follow-up skips any job touched this cycle
-    if stop_event and stop_event.is_set():
+    if (stop_event and stop_event.is_set()) or summary.get("stop_reason"):
         return summary
     console.print("\n[bold cyan]═══ 第二步：跟进无回复岗位 ═══[/bold cyan]")
-    follow_up_count = _check_follow_ups(config, throttle, replied_job_ids=replied_job_ids)
+    try:
+        follow_up_count = _check_follow_ups(monitor_config, throttle, replied_job_ids=replied_job_ids)
+    except MonitorRiskDetected as exc:
+        console.print(f"[red]⚠ 监测检测到风险信号 {exc.kind}，已立即停止[/red]")
+        summary["stop_reason"] = exc.kind
+        return summary
     if follow_up_count:
         console.print(f"  二次跟进: {follow_up_count}")
         summary["follow_up"] = follow_up_count

--- a/src/bosshunter/main.py
+++ b/src/bosshunter/main.py
@@ -275,6 +275,8 @@ def monitor(ctx: click.Context, once: bool, interval: int | None) -> None:
         if summary.get("rejected"):
             parts.append(f"拒绝{summary['rejected']}条")
         console.print(f"\n[bold]本次: {', '.join(parts)}[/bold]")
+        if summary.get("stop_reason"):
+            console.print("[red]检测到平台风险信号，本次监测已安全停止[/red]")
     else:
         console.print(f"[bold cyan]═══ 持续监听模式 (间隔 {interval_min} 分钟) ═══[/bold cyan]\n")
         console.print("[dim]按 Ctrl+C 停止[/dim]\n")
@@ -282,6 +284,9 @@ def monitor(ctx: click.Context, once: bool, interval: int | None) -> None:
             while True:
                 try:
                     summary = monitor_and_send_resumes(config)
+                    if summary.get("stop_reason"):
+                        console.print("[red]检测到平台风险信号，持续监测已安全停止[/red]")
+                        break
                 except Exception as e:
                     console.print(f"[red]本轮监听出错: {e}[/red]")
                     console.print("[dim]将在下一轮重试...[/dim]")

--- a/src/bosshunter/pipeline.py
+++ b/src/bosshunter/pipeline.py
@@ -72,6 +72,16 @@ def run_pipeline(config: dict) -> None:
     from bosshunter.executor.monitor import monitor_and_send_resumes
 
     try:
+        raw_cooldown = config.get("monitor", {}).get("initial_cooldown_minutes", 10)
+        try:
+            initial_cooldown_sec = max(float(raw_cooldown), 0) * 60
+        except (TypeError, ValueError):
+            initial_cooldown_sec = 10 * 60
+        if initial_cooldown_sec > 0:
+            console.print(
+                f"[dim]发送结束后先冷却 {initial_cooldown_sec / 60:g} 分钟；按 Ctrl+C 可取消[/dim]\n"
+            )
+            time.sleep(initial_cooldown_sec)
         while True:
             try:
                 summary = monitor_and_send_resumes(config)
@@ -84,6 +94,9 @@ def run_pipeline(config: dict) -> None:
                     parts.append(f"[bold yellow]待手动发简历{summary['needs_resume']}份[/bold yellow]")
                 if parts:
                     console.print(f"  本轮: {', '.join(parts)}")
+                if summary.get("stop_reason"):
+                    console.print("[red]监测检测到风险信号，已安全停止[/red]")
+                    break
             except Exception as e:
                 console.print(f"[red]  监测出错: {e}[/red]")
             console.print(f"[dim]  下次检查: {interval_min} 分钟后...[/dim]\n")

--- a/src/bosshunter/throttle.py
+++ b/src/bosshunter/throttle.py
@@ -42,6 +42,11 @@ class RequestThrottle:
         self._last_request_time = now
         self._recent_times.append(now)
 
+    @property
+    def has_marked_request(self) -> bool:
+        """Return whether at least one request has been recorded."""
+        return self._last_request_time > 0
+
     def _burst_penalty(self) -> float:
         """Extra delay when requests arrive in bursts."""
         if not self._recent_times:

--- a/src/bosshunter/web/config_schema.json
+++ b/src/bosshunter/web/config_schema.json
@@ -73,7 +73,10 @@
       "icon": "Eye",
       "fields": [
         {"key": "interval", "label": "检查间隔 (分钟)", "type": "number", "min": 1, "max": 120, "default": 30},
+        {"key": "initial_cooldown_minutes", "label": "全流程首次监测冷却 (分钟)", "type": "number", "min": 0, "max": 120, "default": 10, "description": "仅运行全流程发送结束后生效；单独监测立即执行首轮，停止任务可取消冷却"},
         {"key": "chat_url", "label": "聊天页 URL", "type": "text", "default": "https://www.zhipin.com/web/geek/chat"},
+        {"key": "max_conversations_per_cycle", "label": "每轮最多处理对话数", "type": "number", "min": 1, "max": 20, "default": 5},
+        {"key": "max_consecutive_page_failures", "label": "连续页面失败停止阈值", "type": "number", "min": 1, "max": 10, "default": 3},
         {"key": "max_resume_sends_per_cycle", "label": "每轮最多发简历数", "type": "number", "min": 1, "max": 20, "default": 5},
         {"key": "auto_reply_hr_questions", "label": "检测到 HR 问题时自动回复", "type": "switch", "default": false, "description": "关闭时只生成回复建议，需要在监测执行中确认后发送"}
       ]

--- a/src/bosshunter/web/frontend/src/pages/ConfigPage.tsx
+++ b/src/bosshunter/web/frontend/src/pages/ConfigPage.tsx
@@ -439,8 +439,18 @@ export default function ConfigPage() {
             <Field label="检查间隔 (分钟)">
               <Input type="number" value={config.monitor?.interval || 30} onChange={e => updateConfig('monitor.interval', Number(e.target.value))} min={1} max={120} />
             </Field>
+            <Field label="全流程首次监测冷却 (分钟)">
+              <Input type="number" value={config.monitor?.initial_cooldown_minutes ?? 10} onChange={e => updateConfig('monitor.initial_cooldown_minutes', Number(e.target.value))} min={0} max={120} />
+              <p className="mt-1 text-xs text-muted">仅运行全流程发送结束后生效；单独监测立即检查，停止任务可取消等待。</p>
+            </Field>
             <Field label="聊天页 URL">
               <Input value={config.monitor?.chat_url || ''} onChange={e => updateConfig('monitor.chat_url', e.target.value)} />
+            </Field>
+            <Field label="每轮最多处理对话数">
+              <Input type="number" value={config.monitor?.max_conversations_per_cycle ?? 5} onChange={e => updateConfig('monitor.max_conversations_per_cycle', Number(e.target.value))} min={1} max={20} />
+            </Field>
+            <Field label="连续页面失败停止阈值">
+              <Input type="number" value={config.monitor?.max_consecutive_page_failures ?? 3} onChange={e => updateConfig('monitor.max_consecutive_page_failures', Number(e.target.value))} min={1} max={10} />
             </Field>
             <Field label="每轮最多发简历数">
               <Input type="number" value={config.monitor?.max_resume_sends_per_cycle || 5} onChange={e => updateConfig('monitor.max_resume_sends_per_cycle', Number(e.target.value))} min={1} />

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -59,7 +59,12 @@ from bosshunter.scoring_selection import preview_scoring, select_scoring_jobs, v
 from bosshunter.web.preflight import check_ai_connection, collect_preflight_checks, error_messages
 from bosshunter.web.resume_upload import ResumeUploadError, prepare_resume_content
 from bosshunter.web.city_lookup import CityLookupError, lookup_city
-from bosshunter.web.tasks import TaskAlreadyRunningError, WorkbenchTask, WorkbenchTaskRunner
+from bosshunter.web.tasks import (
+	TaskAlreadyRunningError,
+	WorkbenchTask,
+	WorkbenchTaskRunner,
+	wait_for_initial_monitor_cooldown,
+)
 
 mimetypes.add_type("application/javascript", ".js", strict=True)
 mimetypes.add_type("application/javascript", ".mjs", strict=True)
@@ -415,7 +420,7 @@ def _take_monitor_deliveries(task: WorkbenchTask) -> list[dict]:
 	return pending
 
 
-def _execute_monitor(task: WorkbenchTask, config: dict) -> None:
+def _execute_monitor(task: WorkbenchTask, config: dict, *, initial_cooldown: bool = False) -> None:
 	from bosshunter.executor.monitor import monitor_and_send_resumes
 
 	monitor_config = dict(config)
@@ -426,6 +431,8 @@ def _execute_monitor(task: WorkbenchTask, config: dict) -> None:
 	wakeup_event = task.context.setdefault("monitor_wakeup_event", Event())
 	task.context["monitoring"] = True
 	try:
+		if initial_cooldown and wait_for_initial_monitor_cooldown(task, config, _log):
+			return
 		while not task.stop_requested.is_set():
 			for batch in _take_monitor_deliveries(task):
 				deliver_config = dict(config)
@@ -437,8 +444,21 @@ def _execute_monitor(task: WorkbenchTask, config: dict) -> None:
 				if task.stop_requested.is_set():
 					return
 			_log(task, "执行一轮监测")
-			monitor_and_send_resumes(monitor_config)
+			summary = monitor_and_send_resumes(monitor_config)
 			if task.stop_requested.is_set():
+				return
+			stop_reason = summary.get("stop_reason")
+			if stop_reason:
+				reason_labels = {
+					"captcha": "验证码",
+					"rate_limit": "频率限制",
+					"blocked": "账号或请求被拦截",
+					"consecutive_page_failures": "连续页面失败",
+				}
+				reason = f"监测已安全停止：检测到{reason_labels.get(stop_reason, '风险信号')}"
+				task.stop_reason = reason
+				task.stop_requested.set()
+				_log(task, reason)
 				return
 			_log(task, f"本轮监测完成，{interval_min} 分钟后再次检查")
 			wakeup_event.wait(interval_sec)
@@ -510,7 +530,7 @@ def _execute_full(task: WorkbenchTask, config: dict) -> None:
 	_execute_deliver(task, deliver_config)
 	if task.stop_requested.is_set():
 		return
-	_execute_monitor(task, load_config(CONFIG_PATH))
+	_execute_monitor(task, load_config(CONFIG_PATH), initial_cooldown=True)
 
 
 def _queue_active_delivery(

--- a/src/bosshunter/web/tasks.py
+++ b/src/bosshunter/web/tasks.py
@@ -65,6 +65,26 @@ class WorkbenchTask:
 Executor = Callable[[WorkbenchTask, dict], None]
 
 
+def wait_for_initial_monitor_cooldown(
+    task: WorkbenchTask,
+    config: dict,
+    log: Callable[[WorkbenchTask, str], None],
+) -> bool:
+    """Wait for the full-flow monitor cooldown; return true when cancellation wins."""
+    raw_cooldown = config.get("monitor", {}).get("initial_cooldown_minutes", 10)
+    try:
+        cooldown_sec = max(float(raw_cooldown), 0) * 60
+    except (TypeError, ValueError):
+        cooldown_sec = 10 * 60
+    if cooldown_sec <= 0:
+        return False
+    log(task, f"发送结束，首次监测将在 {cooldown_sec / 60:g} 分钟冷却后开始")
+    if task.stop_requested.wait(cooldown_sec):
+        log(task, "首次监测冷却已取消")
+        return True
+    return False
+
+
 class WorkbenchTaskRunner:
     def __init__(self, executors: dict[str, Executor] | None = None):
         self._executors = executors or {}

--- a/tests/test_monitor_safety.py
+++ b/tests/test_monitor_safety.py
@@ -1,0 +1,280 @@
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+
+from bosshunter.db import add_history, get_db, insert_job, update_job_status
+from bosshunter.throttle import RequestThrottle
+
+
+def _job(job_id: str, hr_name: str | None = None) -> dict:
+    return {
+        "id": job_id,
+        "title": f"岗位-{job_id}",
+        "company": f"公司-{job_id}",
+        "salary": "20-30K",
+        "city": "北京",
+        "experience": "1-3年",
+        "jd": "负责产品运营",
+        "hr_name": hr_name or f"HR-{job_id}",
+        "hr_title": "招聘者",
+        "hr_active": "",
+        "company_size": "",
+        "company_industry": "",
+        "url": f"https://example.com/{job_id}",
+    }
+
+
+class MonitorThrottleTests(unittest.TestCase):
+    def test_mark_makes_configured_request_interval_effective(self):
+        throttle = RequestThrottle(delay_min=60, delay_max=60)
+
+        with patch("bosshunter.throttle.time.time", return_value=100), \
+             patch("bosshunter.throttle.random.gauss", return_value=60), \
+             patch("bosshunter.throttle.random.random", return_value=1), \
+             patch("bosshunter.throttle.time.sleep") as sleep:
+            throttle.mark()
+            stopped = throttle.wait()
+
+        self.assertFalse(stopped)
+        sleep.assert_called_once_with(60)
+
+    def test_every_monitor_tab_open_marks_and_waits_after_the_first(self):
+        from bosshunter.executor import monitor
+
+        events = []
+
+        class FakeThrottle:
+            has_marked_request = False
+
+            def wait(self, _stop_event=None):
+                events.append("wait")
+                return False
+
+            def mark(self):
+                events.append("mark")
+                self.has_marked_request = True
+
+        throttle = FakeThrottle()
+
+        def open_tab(_url, background=False):
+            self.assertTrue(background)
+            events.append("open")
+            return f"target-{events.count('open')}"
+
+        config = {"_monitor_request_throttle": throttle}
+        with patch.object(monitor, "new_tab", side_effect=open_tab):
+            monitor._open_monitor_tab("https://example.com/one", config)
+            monitor._open_monitor_tab("https://example.com/two", config)
+
+        self.assertEqual(events, ["open", "mark", "wait", "open", "mark"])
+
+
+class MonitorIdempotencyAndLimitTests(unittest.TestCase):
+    def test_same_unresolved_reply_is_skipped_but_new_hr_message_is_processed(self):
+        from bosshunter.executor import monitor
+
+        original_messages = [
+            {"sender": "me", "text": "你好，我对岗位感兴趣。"},
+            {"sender": "hr", "text": "请介绍一下相关经验。"},
+        ]
+        new_messages = [
+            *original_messages,
+            {"sender": "hr", "text": "也请补充一个最近的项目案例。"},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "data" / "bosshunter.db"
+            db = get_db(db_path)
+            try:
+                insert_job(db, _job("dedup"))
+                update_job_status(db, "dedup", "replied")
+                add_history(
+                    db,
+                    "dedup",
+                    "reply_pending",
+                    monitor._build_reply_detail(original_messages, "建议回复"),
+                )
+            finally:
+                db.close()
+
+            def open_db():
+                return get_db(db_path)
+
+            common = [
+                patch.object(monitor, "get_db", side_effect=open_db),
+                patch.object(monitor, "_open_conversation", return_value="target-1"),
+                patch.object(monitor, "close_tab"),
+                patch.object(monitor.time, "sleep"),
+            ]
+            with common[0], common[1] as open_conversation, common[2], common[3], \
+                 patch.object(monitor, "evaluate", return_value=json.dumps(original_messages)), \
+                 patch.object(monitor, "_generate_auto_reply") as generate_reply:
+                same_action = monitor._handle_conversation(_job("dedup") | {"status": "replied"}, {"monitor": {}})
+
+            self.assertEqual(same_action, "skipped_existing_pending")
+            open_conversation.assert_called_once()
+            generate_reply.assert_not_called()
+
+            with patch.object(monitor, "get_db", side_effect=open_db), \
+                 patch.object(monitor, "_open_conversation", return_value="target-2"), \
+                 patch.object(monitor, "close_tab"), \
+                 patch.object(monitor.time, "sleep"), \
+                 patch.object(monitor, "evaluate", return_value=json.dumps(new_messages)), \
+                 patch.object(monitor, "_generate_auto_reply", return_value="新的建议回复") as generate_reply:
+                new_action = monitor._handle_conversation(_job("dedup") | {"status": "replied"}, {"monitor": {}})
+
+            verify_db = get_db(db_path)
+            try:
+                pending_count = verify_db.execute(
+                    "SELECT COUNT(*) FROM history WHERE job_id = ? AND action = 'reply_pending'",
+                    ("dedup",),
+                ).fetchone()[0]
+            finally:
+                verify_db.close()
+
+        self.assertEqual(new_action, "reply_pending")
+        self.assertEqual(pending_count, 2)
+        generate_reply.assert_called_once()
+
+    def test_chat_list_skips_same_pending_before_opening_and_caps_new_items(self):
+        from bosshunter.executor import monitor
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "data" / "bosshunter.db"
+            db = get_db(db_path)
+            try:
+                for job_id in ("one", "two", "three"):
+                    insert_job(db, _job(job_id))
+                    update_job_status(db, job_id, "sent")
+                messages = [{"sender": "hr", "text": "旧问题"}]
+                add_history(
+                    db,
+                    "one",
+                    "reply_pending",
+                    monitor._build_reply_detail(
+                        messages,
+                        "旧建议",
+                        conversation={"last_message": "旧问题"},
+                    ),
+                )
+                update_job_status(db, "one", "replied")
+            finally:
+                db.close()
+
+            conversations = [
+                {
+                    "hr_name": f"HR-{job_id}",
+                    "company": f"公司-{job_id}",
+                    "last_message": "旧问题" if job_id == "one" else f"新问题-{job_id}",
+                    "has_reply": True,
+                    "has_unread": False,
+                }
+                for job_id in ("one", "two", "three")
+            ]
+
+            def open_db():
+                return get_db(db_path)
+
+            with patch.object(monitor, "get_db", side_effect=open_db), \
+                 patch.object(monitor, "_open_monitor_tab", return_value="chat-target"), \
+                 patch.object(monitor, "_wait_or_stop", return_value=False), \
+                 patch.object(monitor, "_wait_for_page_or_stop", return_value=True), \
+                 patch.object(monitor, "evaluate", return_value=json.dumps(conversations)), \
+                 patch.object(monitor, "close_tab"):
+                results = monitor.check_replies({"monitor": {"max_conversations_per_cycle": 1}})
+
+        self.assertEqual([item["job"]["id"] for item in results], ["two"])
+
+
+class MonitorRiskTests(unittest.TestCase):
+    def test_captcha_stops_cycle_and_records_only_safe_risk_detail(self):
+        from bosshunter.executor import monitor
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "data" / "bosshunter.db"
+            db = get_db(db_path)
+            try:
+                insert_job(db, _job("risk"))
+                update_job_status(db, "risk", "sent")
+            finally:
+                db.close()
+
+            def open_db():
+                return get_db(db_path)
+
+            with patch.object(monitor, "get_db", side_effect=open_db), \
+                 patch.object(monitor, "_open_monitor_tab", return_value="chat-target"), \
+                 patch.object(monitor, "_wait_or_stop", return_value=False), \
+                 patch.object(monitor, "_wait_for_page_or_stop", return_value=True), \
+                 patch.object(monitor, "evaluate", return_value=json.dumps({"risk": "captcha"})), \
+                 patch.object(monitor, "close_tab"):
+                summary = monitor.monitor_and_send_resumes({"throttle": {"send_windows": []}, "monitor": {}})
+
+            verify_db = get_db(db_path)
+            try:
+                events = [dict(row) for row in verify_db.execute("SELECT event_type, detail FROM risk_events").fetchall()]
+            finally:
+                verify_db.close()
+
+        self.assertEqual(summary["stop_reason"], "captcha")
+        self.assertEqual(events, [{"event_type": "monitor_captcha", "detail": "监测检测到验证码，已停止"}])
+
+    def test_consecutive_page_failures_stop_at_configured_threshold(self):
+        from bosshunter.executor import monitor
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "data" / "bosshunter.db"
+
+            def open_db():
+                return get_db(db_path)
+
+            guard = monitor.MonitorSafetyGuard({"monitor": {"max_consecutive_page_failures": 2}})
+            with patch.object(monitor, "get_db", side_effect=open_db):
+                guard.record_page_failure()
+                with self.assertRaises(monitor.MonitorRiskDetected) as raised:
+                    guard.record_page_failure()
+
+            verify_db = get_db(db_path)
+            try:
+                event = dict(verify_db.execute("SELECT event_type, detail FROM risk_events").fetchone())
+            finally:
+                verify_db.close()
+
+        self.assertEqual(raised.exception.kind, "consecutive_page_failures")
+        self.assertEqual(event["event_type"], "monitor_consecutive_page_failures")
+
+
+class FullFlowMonitorCooldownTests(unittest.TestCase):
+    def test_full_flow_initial_cooldown_is_cancellable_before_first_scan(self):
+        from bosshunter.web.tasks import WorkbenchTask, wait_for_initial_monitor_cooldown
+
+        task = WorkbenchTask(id="cooldown", mode="full", label="运行全流程")
+        result = []
+
+        worker = Thread(
+            target=lambda: result.append(
+                wait_for_initial_monitor_cooldown(
+                    task,
+                    {"monitor": {"initial_cooldown_minutes": 1}},
+                    lambda current_task, message: current_task.logs.append(message),
+                )
+            )
+        )
+        worker.start()
+        deadline = time.monotonic() + 1
+        while not task.logs and time.monotonic() < deadline:
+            time.sleep(0.01)
+        task.stop_requested.set()
+        worker.join(timeout=0.5)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(result, [True])
+        self.assertIn("首次监测冷却已取消", task.logs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_api_routes.py
+++ b/tests/test_web_api_routes.py
@@ -1152,7 +1152,7 @@ class WebApiRouteTests(unittest.TestCase):
                 config.get("throttle", {}).get("daily_limit"),
             ))
 
-        def fake_monitor(task, config):
+        def fake_monitor(task, config, **kwargs):
             calls.append("monitor")
 
         runner = WorkbenchTaskRunner()
@@ -1216,7 +1216,7 @@ class WebApiRouteTests(unittest.TestCase):
                      "_execute_deliver",
                      side_effect=lambda _task, config: calls.append(("deliver", config["_workbench_job_ids"])),
                  ), \
-                 patch.object(server, "_execute_monitor", side_effect=lambda *_: calls.append("monitor")), \
+                 patch.object(server, "_execute_monitor", side_effect=lambda *_, **__: calls.append("monitor")), \
                  patch.object(server, "load_config", return_value={}):
                 server._execute_full(task, {})
 


### PR DESCRIPTION
## Summary
- enforce effective throttling for every monitoring page open and retry
- deduplicate unresolved and already handled HR messages before reopening chats or calling AI
- cap conversations per cycle and add a cancellable full-flow initial cooldown
- stop immediately on captcha, rate-limit, account-block, or consecutive page-failure signals with safe risk telemetry
- keep automatic replies and follow-ups disabled by default

## Validation
- `312 passed, 11 subtests passed`
- frontend TypeScript check passed
- frontend production build passed using a temporary output directory

## Safety
- offline tests only; no real scrape, greet, send, or monitor command was run
- no API keys or platform page contents are included in risk logs
