### PR TITLE
Add collection account-safety guardrails

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,13 @@ search:
   max_pages: 5
   sort: newest
 
+collection:
+  daily_new_jobs_limit: 100       # 单日新增唯一岗位上限；重复岗位不计入
+  daily_search_page_limit: 30
+  daily_detail_page_limit: 150
+  max_consecutive_page_failures: 3
+  delivery_cooldown_minutes: 30   # 全流程采集结束到投递的最短冷却
+
 scoring:
   threshold: 70
   max_candidates: 20
@@ -83,6 +90,10 @@ follow_up:
 
 dedup:
   history_file: "./data/history.jsonl"
+
+safety:
+  daily_platform_page_limit: 500  # 采集、投递和监测合计的页面打开硬上限
+  risk_lock_minutes: 1440         # 风险信号触发后跨重启保持冷却
 
 browser:
   runtime: "builtin"

--- a/src/bosshunter/config.py
+++ b/src/bosshunter/config.py
@@ -79,6 +79,13 @@ DEFAULTS: dict[str, Any] = {
         "city_codes": {},
         "max_pages": 3,
     },
+    "collection": {
+        "daily_new_jobs_limit": 100,
+        "daily_search_page_limit": 30,
+        "daily_detail_page_limit": 150,
+        "max_consecutive_page_failures": 3,
+        "delivery_cooldown_minutes": 30,
+    },
     "scoring": {
         "threshold": 71,
         "max_candidates": 20,
@@ -126,6 +133,10 @@ DEFAULTS: dict[str, Any] = {
     },
     "dedup": {
         "history_file": "./data/history.jsonl",
+    },
+    "safety": {
+        "daily_platform_page_limit": 500,
+        "risk_lock_minutes": 1440,
     },
     "browser": {
         "runtime": "builtin",

--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -79,10 +80,26 @@ def _init_tables(conn: sqlite3.Connection) -> None:
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
 
+        CREATE TABLE IF NOT EXISTS platform_access_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            stage TEXT NOT NULL,
+            action TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS platform_safety_state (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            reason TEXT NOT NULL,
+            locked_until TEXT NOT NULL,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
         CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
         CREATE INDEX IF NOT EXISTS idx_jobs_score ON jobs(score);
         CREATE INDEX IF NOT EXISTS idx_history_job_id ON history(job_id);
         CREATE INDEX IF NOT EXISTS idx_risk_events_type ON risk_events(event_type);
+        CREATE INDEX IF NOT EXISTS idx_platform_access_stage_action
+            ON platform_access_events(stage, action, created_at);
     """)
     conn.commit()
     _migrate_v1_1(conn)
@@ -484,6 +501,90 @@ def add_risk_event(conn: sqlite3.Connection, event_type: str, detail: str = "") 
         (event_type, detail)
     )
     conn.commit()
+
+
+def count_jobs_created_today(conn: sqlite3.Connection) -> int:
+    """Count unique jobs stored during the current local calendar day."""
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS cnt FROM jobs
+        WHERE datetime(created_at, 'localtime') >= datetime('now', 'localtime', 'start of day')
+        """
+    ).fetchone()
+    return int(row["cnt"] if row else 0)
+
+
+def count_platform_access_today(
+    conn: sqlite3.Connection,
+    *,
+    stage: str | None = None,
+    action: str | None = None,
+) -> int:
+    """Count recorded platform page opens during the current local day."""
+    clauses = ["datetime(created_at, 'localtime') >= datetime('now', 'localtime', 'start of day')"]
+    params: list[str] = []
+    if stage:
+        clauses.append("stage = ?")
+        params.append(stage)
+    if action:
+        clauses.append("action = ?")
+        params.append(action)
+    row = conn.execute(
+        f"SELECT COUNT(*) AS cnt FROM platform_access_events WHERE {' AND '.join(clauses)}",
+        params,
+    ).fetchone()
+    return int(row["cnt"] if row else 0)
+
+
+def add_platform_access(conn: sqlite3.Connection, stage: str, action: str) -> None:
+    """Record one platform page-open attempt without URLs or account data."""
+    conn.execute(
+        "INSERT INTO platform_access_events (stage, action) VALUES (?, ?)",
+        (stage, action),
+    )
+    conn.commit()
+
+
+def set_platform_safety_lock(
+    conn: sqlite3.Connection,
+    reason: str,
+    *,
+    minutes: int = 1440,
+) -> None:
+    """Persist a temporary account-safety lock across task and process restarts."""
+    locked_until = datetime.now(timezone.utc) + timedelta(minutes=max(int(minutes), 1))
+    conn.execute(
+        """
+        INSERT INTO platform_safety_state (id, reason, locked_until, updated_at)
+        VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(id) DO UPDATE SET
+            reason = excluded.reason,
+            locked_until = excluded.locked_until,
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        (reason, locked_until.isoformat()),
+    )
+    conn.commit()
+
+
+def get_active_platform_safety_lock(conn: sqlite3.Connection) -> dict[str, str] | None:
+    """Return the active safety lock, clearing it after its cooldown expires."""
+    row = conn.execute(
+        "SELECT reason, locked_until FROM platform_safety_state WHERE id = 1"
+    ).fetchone()
+    if not row:
+        return None
+    try:
+        locked_until = datetime.fromisoformat(str(row["locked_until"]))
+        if locked_until.tzinfo is None:
+            locked_until = locked_until.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        locked_until = datetime.now(timezone.utc)
+    if locked_until <= datetime.now(timezone.utc):
+        conn.execute("DELETE FROM platform_safety_state WHERE id = 1")
+        conn.commit()
+        return None
+    return {"reason": str(row["reason"]), "locked_until": locked_until.isoformat()}
 
 
 def get_funnel_stats(conn: sqlite3.Connection, *, today: bool = False) -> dict[str, int]:

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -15,9 +15,14 @@ from bosshunter.cancellation import (
 )
 from bosshunter.db import (
     get_db, get_jobs_by_status,
-    update_job_status, add_history, add_risk_event,
+    update_job_status, add_history, add_risk_event, set_platform_safety_lock,
 )
 from bosshunter.throttle import RequestThrottle, SendWindowChecker
+from bosshunter.platform_safety import (
+    PlatformAccessGuard,
+    PlatformSafetyStop,
+    TransientPlatformAccessGuard,
+)
 
 console = Console()
 
@@ -97,6 +102,7 @@ class MonitorSafetyGuard:
     """Track consecutive monitor page failures and stop at a conservative threshold."""
 
     def __init__(self, config: dict) -> None:
+        self.config = config
         raw_limit = config.get("monitor", {}).get("max_consecutive_page_failures", 3)
         try:
             self.limit = max(int(raw_limit), 1)
@@ -107,7 +113,7 @@ class MonitorSafetyGuard:
     def record_page_failure(self) -> None:
         self.consecutive_page_failures += 1
         if self.consecutive_page_failures >= self.limit:
-            _raise_monitor_risk("consecutive_page_failures")
+            _raise_monitor_risk("consecutive_page_failures", self.config)
 
     def record_page_success(self) -> None:
         self.consecutive_page_failures = 0
@@ -281,7 +287,7 @@ def _record_page_failure_unless_stopped(config: dict) -> None:
         _monitor_safety_guard(config).record_page_failure()
 
 
-def _record_monitor_risk(kind: str) -> None:
+def _record_monitor_risk(kind: str, config: dict | None = None) -> None:
     """Persist a safe risk event without page text, URLs, or account data."""
     labels = {
         "captcha": "监测检测到验证码，已停止",
@@ -293,6 +299,12 @@ def _record_monitor_risk(kind: str) -> None:
     try:
         db = get_db()
         add_risk_event(db, f"monitor_{kind}", labels.get(kind, "监测检测到风险信号，已停止"))
+        raw_minutes = (config or {}).get("safety", {}).get("risk_lock_minutes", 1440)
+        try:
+            lock_minutes = max(int(raw_minutes), 1)
+        except (TypeError, ValueError):
+            lock_minutes = 1440
+        set_platform_safety_lock(db, kind, minutes=lock_minutes)
     except Exception:
         # Failure to persist telemetry must never allow risky browsing to continue.
         pass
@@ -301,12 +313,12 @@ def _record_monitor_risk(kind: str) -> None:
             db.close()
 
 
-def _raise_monitor_risk(kind: str) -> None:
-    _record_monitor_risk(kind)
+def _raise_monitor_risk(kind: str, config: dict | None = None) -> None:
+    _record_monitor_risk(kind, config)
     raise MonitorRiskDetected(kind)
 
 
-def _inspect_monitor_page(target_id: str) -> None:
+def _inspect_monitor_page(target_id: str, config: dict) -> None:
     """Stop immediately when the current platform page exposes a risk signal."""
     raw = evaluate(target_id, JS_DETECT_MONITOR_RISK)
     try:
@@ -317,7 +329,7 @@ def _inspect_monitor_page(target_id: str) -> None:
         return
     kind = result.get("risk")
     if kind in {"captcha", "rate_limit", "blocked"}:
-        _raise_monitor_risk(kind)
+        _raise_monitor_risk(kind, config)
 
 
 def _open_monitor_tab(url: str, config: dict) -> str | None:
@@ -329,6 +341,12 @@ def _open_monitor_tab(url: str, config: dict) -> str | None:
     if throttle is not None and bool(getattr(throttle, "has_marked_request", False)):
         if throttle.wait(stop_event):
             return None
+    access_guard = config.get("_platform_access_guard")
+    if isinstance(access_guard, (PlatformAccessGuard, TransientPlatformAccessGuard)):
+        try:
+            access_guard.reserve("monitor_page")
+        except PlatformSafetyStop as exc:
+            raise MonitorRiskDetected(exc.reason) from exc
     target_id = new_tab(url, background=True)
     if throttle is not None and hasattr(throttle, "mark"):
         # Record attempts as well as successful opens so retries cannot become a burst.
@@ -660,7 +678,7 @@ def _open_conversation(job: dict, config: dict) -> str | None:
                 _record_page_failure_unless_stopped(config)
                 return None
             try:
-                _inspect_monitor_page(target_id)
+                _inspect_monitor_page(target_id, config)
             except MonitorRiskDetected:
                 close_tab(target_id)
                 raise
@@ -675,7 +693,7 @@ def _open_conversation(job: dict, config: dict) -> str | None:
                     _record_page_failure_unless_stopped(config)
                     return None
                 try:
-                    _inspect_monitor_page(target_id)
+                    _inspect_monitor_page(target_id, config)
                 except MonitorRiskDetected:
                     close_tab(target_id)
                     raise
@@ -717,7 +735,7 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
         _record_page_failure_unless_stopped(config)
         return None
     try:
-        _inspect_monitor_page(target_id)
+        _inspect_monitor_page(target_id, config)
     except MonitorRiskDetected:
         close_tab(target_id)
         raise
@@ -798,7 +816,7 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
                 close_tab(target_id)
                 return None
             try:
-                _inspect_monitor_page(target_id)
+                _inspect_monitor_page(target_id, config)
             except MonitorRiskDetected:
                 close_tab(target_id)
                 raise
@@ -827,7 +845,7 @@ def _open_conversation_from_chat_list(job: dict, config: dict) -> str | None:
                     close_tab(target_id)
                     return None
                 try:
-                    _inspect_monitor_page(target_id)
+                    _inspect_monitor_page(target_id, config)
                 except MonitorRiskDetected:
                     close_tab(target_id)
                     raise
@@ -934,7 +952,7 @@ def check_replies(config: dict) -> list[dict]:
             _monitor_safety_guard(config).record_page_failure()
         return []
     try:
-        _inspect_monitor_page(target_id)
+        _inspect_monitor_page(target_id, config)
     except MonitorRiskDetected:
         close_tab(target_id)
         db.close()
@@ -1583,6 +1601,11 @@ def monitor_and_send_resumes(config: dict) -> dict:
     monitor_config = dict(config)
     monitor_config["_monitor_request_throttle"] = throttle
     monitor_config["_monitor_safety_guard"] = MonitorSafetyGuard(config)
+    monitor_config["_platform_access_guard"] = TransientPlatformAccessGuard(
+        config,
+        "monitor",
+        get_db,
+    )
 
     summary = {"skipped": 0, "replied": 0, "needs_resume": 0, "rejected": 0, "failed": 0}
 

--- a/src/bosshunter/executor/sender.py
+++ b/src/bosshunter/executor/sender.py
@@ -17,8 +17,12 @@ from bosshunter.browser import (
     press_key,
     type_text,
 )
-from bosshunter.db import get_db, get_jobs_ready_to_send, update_job_status, add_history, add_risk_event
+from bosshunter.db import (
+    get_db, get_jobs_ready_to_send, update_job_status, add_history, add_risk_event,
+    set_platform_safety_lock,
+)
 from bosshunter.throttle import RequestThrottle, SendWindowChecker, ProgressiveBackoff, should_take_day_off
+from bosshunter.platform_safety import PlatformAccessGuard, PlatformSafetyStop
 
 console = Console()
 
@@ -684,6 +688,16 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
         for target in get_page_targets()
         if target.get("targetId")
     }
+    access_guard = throttle_config.get("_platform_access_guard")
+    if isinstance(access_guard, PlatformAccessGuard):
+        try:
+            access_guard.reserve("job_page")
+        except PlatformSafetyStop as exc:
+            return {
+                "success": False,
+                "error": exc.reason,
+                "history_detail": "为了账户安全，已达到平台页面访问上限或仍处于风险冷却",
+            }, None
     target_id = new_tab(job["url"], background=True)
     if not target_id:
         return {"success": False, "error": "open_page_failed", "history_detail": "无法打开页面", "skip_backoff": True}, None
@@ -910,7 +924,7 @@ def _send_greeting_once(job: dict, greeting: str, throttle_config: dict) -> tupl
 def send_greetings(config: dict, force: bool = False) -> int:
     """Send generated greetings. Returns count of successfully sent."""
     db = get_db()
-    throttle_config = config.get("throttle", {})
+    throttle_config = dict(config.get("throttle", {}))
     stop_event = config.get("_workbench_stop_event")
     workbench_job_ids = {str(job_id) for job_id in config.get("_workbench_job_ids", [])}
     send_report = {
@@ -928,8 +942,16 @@ def send_greetings(config: dict, force: bool = False) -> int:
     # the web workflow enough detail to distinguish failures from quota deferrals.
     config["_workbench_send_report"] = send_report
     if isinstance(stop_event, Event):
-        throttle_config = dict(throttle_config)
         throttle_config["_workbench_stop_event"] = stop_event
+    access_guard = PlatformAccessGuard(db, config, "send")
+    throttle_config["_platform_access_guard"] = access_guard
+    try:
+        access_guard.ensure_unlocked()
+    except PlatformSafetyStop as exc:
+        send_report["stop_reason"] = exc.reason
+        console.print("[yellow]为了账户安全，平台风险冷却尚未结束，已停止投递[/yellow]")
+        db.close()
+        return 0
 
     # Anti-ban: random day off (可通过 --force 跳过)
     day_off_prob = throttle_config.get("day_off_probability", 0.05)
@@ -1056,6 +1078,10 @@ def send_greetings(config: dict, force: bool = False) -> int:
                 backoff.record_success()
             else:
                 error = result_data.get("error", "unknown")
+                if error in {"daily_platform_page_limit", "persistent_risk_lock"}:
+                    send_report["stop_reason"] = error
+                    console.print("[yellow]为了账户安全，已达到平台页面访问上限或仍处于风险冷却，停止投递[/yellow]")
+                    break
                 send_report["failed_count"] += 1
                 update_job_status(db, job["id"], "error")
                 add_history(db, job["id"], "error", result_data.get("history_detail", f"发送失败: {error}"))
@@ -1073,6 +1099,12 @@ def send_greetings(config: dict, force: bool = False) -> int:
                 if error in ["captcha", "rate_limit", "blocked"]:
                     console.print(f"\n[red]⚠ 检测到风控信号: {error}，安全暂停[/red]")
                     add_risk_event(db, error, f"触发风控: {error}")
+                    lock_minutes = config.get("safety", {}).get("risk_lock_minutes", 1440)
+                    try:
+                        lock_minutes = max(int(lock_minutes), 1)
+                    except (TypeError, ValueError):
+                        lock_minutes = 1440
+                    set_platform_safety_lock(db, error, minutes=lock_minutes)
                     send_report["stop_reason"] = error
                     break
 
@@ -1080,6 +1112,12 @@ def send_greetings(config: dict, force: bool = False) -> int:
                 if backoff.should_pause_long:
                     console.print(f"\n[red]⚠ 连续错误过多，暂停 {int(pause_duration/60)} 分钟[/red]")
                     add_risk_event(db, "backoff_pause", f"暂停{int(pause_duration)}秒")
+                    lock_minutes = config.get("safety", {}).get("risk_lock_minutes", 1440)
+                    try:
+                        lock_minutes = max(int(lock_minutes), 1)
+                    except (TypeError, ValueError):
+                        lock_minutes = 1440
+                    set_platform_safety_lock(db, "consecutive_errors", minutes=lock_minutes)
                     send_report["stop_reason"] = "consecutive_errors"
                     break
                 elif pause_duration > 0:

--- a/src/bosshunter/platform_safety.py
+++ b/src/bosshunter/platform_safety.py
@@ -1,0 +1,89 @@
+"""Shared page-access budgets and persistent safety locks for platform workflows."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable
+
+from bosshunter.db import (
+    add_platform_access,
+    count_platform_access_today,
+    get_active_platform_safety_lock,
+    set_platform_safety_lock,
+)
+
+
+class PlatformSafetyStop(RuntimeError):
+    """Raised before another platform page is opened when a safety guard stops work."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass
+class PlatformAccessGuard:
+    conn: sqlite3.Connection
+    config: dict
+    stage: str
+
+    def ensure_unlocked(self) -> None:
+        lock = get_active_platform_safety_lock(self.conn)
+        if lock:
+            raise PlatformSafetyStop("persistent_risk_lock")
+
+    def reserve(self, action: str, *, daily_limit: int | None = None) -> None:
+        """Reserve one page-open attempt before navigation."""
+        self.ensure_unlocked()
+        safety_cfg = self.config.get("safety", {})
+        global_limit = _positive_int(safety_cfg.get("daily_platform_page_limit", 500), 500)
+        if count_platform_access_today(self.conn) >= global_limit:
+            raise PlatformSafetyStop("daily_platform_page_limit")
+        if daily_limit is not None:
+            stage_count = count_platform_access_today(
+                self.conn,
+                stage=self.stage,
+                action=action,
+            )
+            if stage_count >= max(int(daily_limit), 1):
+                raise PlatformSafetyStop(f"daily_{action}_limit")
+        add_platform_access(self.conn, self.stage, action)
+
+    def lock(self, reason: str) -> None:
+        safety_cfg = self.config.get("safety", {})
+        minutes = _positive_int(safety_cfg.get("risk_lock_minutes", 1440), 1440)
+        set_platform_safety_lock(self.conn, reason, minutes=minutes)
+
+
+@dataclass
+class TransientPlatformAccessGuard:
+    """Open a short-lived DB connection for workflows without a cycle-long connection."""
+
+    config: dict
+    stage: str
+    db_factory: Callable[[], sqlite3.Connection]
+
+    def ensure_unlocked(self) -> None:
+        conn = self.db_factory()
+        try:
+            PlatformAccessGuard(conn, self.config, self.stage).ensure_unlocked()
+        finally:
+            conn.close()
+
+    def reserve(self, action: str, *, daily_limit: int | None = None) -> None:
+        conn = self.db_factory()
+        try:
+            PlatformAccessGuard(conn, self.config, self.stage).reserve(
+                action,
+                daily_limit=daily_limit,
+            )
+        finally:
+            conn.close()
+
+
+def _positive_int(value: object, default: int) -> int:
+    try:
+        return max(int(value), 1)
+    except (TypeError, ValueError):
+        return default

--- a/src/bosshunter/scraper/jobs.py
+++ b/src/bosshunter/scraper/jobs.py
@@ -11,12 +11,14 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from bosshunter.browser import (
-    new_tab, close_tab, evaluate, scroll, wait_for_load
+    new_tab, close_tab, evaluate, navigate, scroll, wait_for_load
 )
 from bosshunter.config import CITY_CODES
 from bosshunter.cancellation import get_stop_event
-from bosshunter.db import get_db, job_exists, insert_job
-from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
+from bosshunter.ai.prefilter import quick_score
+from bosshunter.db import add_risk_event, count_jobs_created_today, get_db, job_exists, insert_job
+from bosshunter.job_filters import matching_deal_breaker
+from bosshunter.platform_safety import PlatformAccessGuard, PlatformSafetyStop
 from bosshunter.throttle import PageThrottle
 
 console = Console()
@@ -128,6 +130,30 @@ JS_EXTRACT_DETAIL = """
 })()
 """
 
+JS_DETECT_COLLECTION_RISK = """
+(() => {
+    const text = (document.body?.innerText || '').slice(0, 10000);
+    const url = String(location.href || '');
+    const title = String(document.title || '');
+    const captcha = document.querySelector(
+        '.geetest_panel, .captcha, [class*="captcha"], [id*="captcha"], iframe[src*="captcha"], iframe[src*="verify"]'
+    );
+    if (captcha || /captcha|security-check|\\/verify/i.test(url) || /验证码|安全验证|完成验证/.test(text)) {
+        return JSON.stringify({risk: 'captcha'});
+    }
+    if (/403|forbidden|access-denied/i.test(url) || /403|访问被拒绝|账号异常|账号受限/.test(title + text)) {
+        return JSON.stringify({risk: 'blocked'});
+    }
+    if (/操作频繁|访问频繁|请求频繁|稍后再试|频率限制/.test(text)) {
+        return JSON.stringify({risk: 'rate_limit'});
+    }
+    if (/\\/web\\/user\\/(?:login|\\?ka=header-login)/i.test(url)) {
+        return JSON.stringify({risk: 'login_required'});
+    }
+    return JSON.stringify({risk: null});
+})()
+"""
+
 
 def _generate_job_id(url: str) -> str:
     """Generate a unique job ID from URL path."""
@@ -145,7 +171,7 @@ def _wait_or_stop(stop_event, seconds: float) -> bool:
     return False
 
 
-def scrape_jobs(
+def _scrape_jobs_impl(
     config: dict,
     keywords: list[str],
     limit: int | None = None,
@@ -154,24 +180,83 @@ def scrape_jobs(
 ) -> int:
     """Scrape jobs from BOSS直聘 and store in database.
 
-    Supports multi-keyword × multi-city combinations with pagination.
-    When limit is None, collection is bounded only by city × keyword × max_pages.
+    Supports multi-keyword × multi-city combinations with pagination. All configured
+    limits are ceilings rather than targets; natural search exhaustion may stop earlier.
+    Duplicate list entries do not consume the new-job limit or open detail pages.
     Returns the number of new jobs added.
     """
     db = get_db()
     stop_event = get_stop_event(config)
+    if stop_event is not None and stop_event.is_set():
+        db.close()
+        return 0
     throttle = PageThrottle(delay_min=2.0, delay_max=5.0)
-    deal_breakers = config.get("profile", {}).get("deal_breakers", [])
     jd_deal_breakers = config.get("profile", {}).get("jd_deal_breakers", [])
     progress_callback = config.get("_workbench_collect_progress")
+    collection_cfg = config.get("collection", {})
+    guard = PlatformAccessGuard(db, config, "collection")
     seen_count = 0
-    blocked_companies = config.get("profile", {}).get("blocked_companies", [])
     new_count = 0
     duplicate_count = 0
+    filtered_count = 0
+    search_pages_this_cycle = 0
+    page_failures = 0
+    worker_target: str | None = None
+    collect_report = {"stop_reason": None}
+    config["_workbench_collect_report"] = collect_report
+
+    daily_new_limit = _positive_int(collection_cfg.get("daily_new_jobs_limit", 100), 100)
+    daily_search_limit = _positive_int(collection_cfg.get("daily_search_page_limit", 30), 30)
+    daily_detail_limit = _positive_int(collection_cfg.get("daily_detail_page_limit", 150), 150)
+    failure_limit = _positive_int(collection_cfg.get("max_consecutive_page_failures", 3), 3)
+    daily_remaining = max(daily_new_limit - count_jobs_created_today(db), 0)
+    requested_limit = daily_remaining if limit is None else max(int(limit), 0)
+    effective_new_limit = min(requested_limit, daily_remaining)
 
     def report_progress() -> None:
         if callable(progress_callback):
-            progress_callback({"seen": seen_count, "new": new_count, "duplicate": duplicate_count})
+            progress_callback({
+                "seen": seen_count,
+                "new": new_count,
+                "duplicate": duplicate_count,
+                "filtered": filtered_count,
+                "search_pages": search_pages_this_cycle,
+            })
+
+    def stop_for_risk(kind: str) -> None:
+        labels = {
+            "captcha": "采集检测到验证码，已停止",
+            "blocked": "采集检测到账号或请求拦截，已停止",
+            "rate_limit": "采集检测到频率限制，已停止",
+            "login_required": "采集检测到登录状态失效，已停止",
+            "consecutive_page_failures": "采集连续页面失败达到阈值，已停止",
+        }
+        add_risk_event(db, f"collection_{kind}", labels.get(kind, "采集检测到风险信号，已停止"))
+        guard.lock(kind)
+        collect_report["stop_reason"] = kind
+        collect_report["new_count"] = new_count
+        if worker_target:
+            close_tab(worker_target)
+        db.close()
+        raise PlatformSafetyStop(kind)
+
+    def record_failure() -> None:
+        nonlocal page_failures
+        page_failures += 1
+        if page_failures >= failure_limit:
+            stop_for_risk("consecutive_page_failures")
+
+    def inspect_page(target_id: str) -> None:
+        nonlocal page_failures
+        raw = evaluate(target_id, JS_DETECT_COLLECTION_RISK)
+        try:
+            result = json.loads(raw) if isinstance(raw, str) else (raw or {})
+        except (json.JSONDecodeError, TypeError):
+            result = {}
+        kind = result.get("risk") if isinstance(result, dict) else None
+        if kind:
+            stop_for_risk(str(kind))
+        page_failures = 0
 
     # Pagination config
     search_config = config.get("search", {})
@@ -197,7 +282,17 @@ def scrape_jobs(
         db.close()
         return 0
 
-    if stop_event is not None and stop_event.is_set():
+    if effective_new_limit <= 0:
+        collect_report["stop_reason"] = "daily_new_jobs_limit"
+        console.print(f"[yellow]今日已达到新增岗位上限 ({daily_new_limit})[/yellow]")
+        db.close()
+        return 0
+
+    try:
+        guard.ensure_unlocked()
+    except PlatformSafetyStop as exc:
+        collect_report["stop_reason"] = exc.reason
+        console.print("[yellow]平台安全锁仍在冷却中，已跳过采集[/yellow]")
         db.close()
         return 0
 
@@ -211,7 +306,7 @@ def scrape_jobs(
         for city, city_code, keyword in search_combos:
             if stop_event is not None and stop_event.is_set():
                 break
-            if limit is not None and new_count >= limit:
+            if collect_report.get("stop_reason") or new_count >= effective_new_limit:
                 break
 
             label = f"{city}/{keyword}" if len(cities) > 1 else keyword
@@ -221,7 +316,7 @@ def scrape_jobs(
             for page in range(1, max_pages + 1):
                 if stop_event is not None and stop_event.is_set():
                     break
-                if limit is not None and new_count >= limit:
+                if collect_report.get("stop_reason") or new_count >= effective_new_limit:
                     break
 
                 # Build paginated URL
@@ -232,44 +327,52 @@ def scrape_jobs(
                 if page > 1:
                     search_url += f"&page={page}"
 
-                # Open search page
-                target_id = new_tab(search_url, background=True)
-                if not target_id:
+                # Reuse one visible worker tab instead of creating a background tab per page.
+                try:
+                    guard.reserve("search_page", daily_limit=daily_search_limit)
+                except PlatformSafetyStop as exc:
+                    collect_report["stop_reason"] = exc.reason
+                    break
+                if worker_target is None:
+                    worker_target = new_tab(search_url, background=False)
+                    opened = bool(worker_target)
+                else:
+                    opened = navigate(worker_target, search_url)
+                if not opened:
+                    record_failure()
                     if page == 1:
                         progress.update(task, description=f"[red]✗ 无法打开搜索页: {label}[/red]")
                     break
+                target_id = worker_target
+                search_pages_this_cycle += 1
 
                 if _wait_or_stop(stop_event, 3):
-                    close_tab(target_id)
                     break
                 wait_for_load(target_id, timeout=10)
+                inspect_page(target_id)
                 if stop_event is not None and stop_event.is_set():
-                    close_tab(target_id)
                     break
 
                 # Scroll to load all results on this page
                 scroll(target_id, y=2000)
                 if _wait_or_stop(stop_event, 1.5):
-                    close_tab(target_id)
                     break
                 scroll(target_id, y=4000)
                 if _wait_or_stop(stop_event, 1.5):
-                    close_tab(target_id)
                     break
 
                 # Extract job list
                 result = evaluate(target_id, JS_EXTRACT_LIST)
                 if not result:
-                    close_tab(target_id)
+                    record_failure()
                     break
 
                 try:
                     jobs_list = json.loads(result)
                 except (json.JSONDecodeError, TypeError):
-                    close_tab(target_id)
+                    record_failure()
                     break
-
-                close_tab(target_id)
+                page_failures = 0
 
                 # No results on this page, stop pagination
                 if not jobs_list:
@@ -281,7 +384,7 @@ def scrape_jobs(
                 for job_data in jobs_list:
                     if stop_event is not None and stop_event.is_set():
                         break
-                    if limit is not None and new_count >= limit:
+                    if collect_report.get("stop_reason") or new_count >= effective_new_limit:
                         break
 
                     seen_count += 1
@@ -295,39 +398,47 @@ def scrape_jobs(
                         report_progress()
                         continue
 
-                    # Skip deal breakers
-                    if matching_deal_breaker(job_data.get("title", ""), deal_breakers):
-                        continue
-                    if matching_blocked_company(job_data.get("company", ""), blocked_companies):
+                    # Apply every filter available from the list card before opening details.
+                    prefilter_score, _ = quick_score(job_data, config)
+                    if prefilter_score <= 0:
+                        filtered_count += 1
+                        report_progress()
                         continue
 
                     # Open detail page for full JD
                     if throttle.wait(stop_event):
                         break
                     detail_url = f"https://www.zhipin.com{job_url}"
-                    detail_target = new_tab(detail_url, background=True)
-                    if not detail_target:
+                    try:
+                        guard.reserve("detail_page", daily_limit=daily_detail_limit)
+                    except PlatformSafetyStop as exc:
+                        collect_report["stop_reason"] = exc.reason
+                        break
+                    if not navigate(target_id, detail_url):
+                        record_failure()
                         continue
+                    detail_target = target_id
 
                     if _wait_or_stop(stop_event, 2):
-                        close_tab(detail_target)
                         break
                     wait_for_load(detail_target, timeout=10)
+                    inspect_page(detail_target)
                     if stop_event is not None and stop_event.is_set():
-                        close_tab(detail_target)
                         break
 
                     # Extract detail
                     detail_result = evaluate(detail_target, JS_EXTRACT_DETAIL)
-                    close_tab(detail_target)
 
                     if not detail_result:
+                        record_failure()
                         continue
 
                     try:
                         detail = json.loads(detail_result)
                     except (json.JSONDecodeError, TypeError):
+                        record_failure()
                         continue
+                    page_failures = 0
 
                     # Build job record
                     job_record = {
@@ -347,23 +458,67 @@ def scrape_jobs(
                     }
 
                     if matching_deal_breaker(job_record["jd"], jd_deal_breakers):
+                        filtered_count += 1
+                        report_progress()
                         continue
 
                     insert_job(db, job_record)
                     if collected_job_ids is not None:
                         collected_job_ids.append(job_id)
                     new_count += 1
+                    collect_report["new_count"] = new_count
                     keyword_new += 1
                     report_progress()
                     progress.update(task, description=f"搜索: {label} 第{page}页 (新增 {keyword_new})")
 
                 # Anti-scraping: pause between pages
-                if page < max_pages:
+                if page < max_pages and not collect_report.get("stop_reason"):
                     if _wait_or_stop(stop_event, random.uniform(3.0, 6.0)):
                         break
 
             progress.update(task, description=f"搜索: {label} (新增 {keyword_new})")
 
+    if not collect_report.get("stop_reason"):
+        if new_count >= effective_new_limit:
+            collect_report["stop_reason"] = "daily_new_jobs_limit" if effective_new_limit == daily_remaining else None
+    collect_report.update({
+        "new_count": new_count,
+        "seen_count": seen_count,
+        "duplicate_count": duplicate_count,
+        "filtered_count": filtered_count,
+        "search_pages": search_pages_this_cycle,
+    })
     report_progress()
+    if worker_target:
+        close_tab(worker_target)
     db.close()
     return new_count
+
+
+def scrape_jobs(
+    config: dict,
+    keywords: list[str],
+    limit: int | None = None,
+    *,
+    collected_job_ids: list[str] | None = None,
+) -> int:
+    """Run the guarded scraper and convert account-risk signals into a safe stop."""
+    try:
+        return _scrape_jobs_impl(
+            config,
+            keywords,
+            limit,
+            collected_job_ids=collected_job_ids,
+        )
+    except PlatformSafetyStop as exc:
+        report = config.setdefault("_workbench_collect_report", {})
+        report["stop_reason"] = exc.reason
+        console.print(f"[yellow]采集已安全停止：{exc.reason}[/yellow]")
+        return int(report.get("new_count") or 0)
+
+
+def _positive_int(value: object, default: int) -> int:
+    try:
+        return max(int(value), 1)
+    except (TypeError, ValueError):
+        return default

--- a/src/bosshunter/web/config_schema.json
+++ b/src/bosshunter/web/config_schema.json
@@ -36,6 +36,18 @@
       ]
     },
     {
+      "key": "collection",
+      "label": "采集安全设置",
+      "icon": "Shield",
+      "fields": [
+        {"key": "daily_new_jobs_limit", "label": "单日新增唯一岗位上限", "type": "number", "min": 1, "max": 500, "default": 100, "description": "重复岗位不计入"},
+        {"key": "daily_search_page_limit", "label": "单日搜索页上限", "type": "number", "min": 1, "max": 200, "default": 30},
+        {"key": "daily_detail_page_limit", "label": "单日详情页尝试上限", "type": "number", "min": 1, "max": 500, "default": 150},
+        {"key": "max_consecutive_page_failures", "label": "连续页面失败停止阈值", "type": "number", "min": 1, "max": 10, "default": 3},
+        {"key": "delivery_cooldown_minutes", "label": "采集后投递冷却（分钟）", "type": "number", "min": 0, "max": 240, "default": 30}
+      ]
+    },
+    {
       "key": "throttle",
       "label": "反检测设置",
       "icon": "Shield",

--- a/src/bosshunter/web/frontend/src/pages/ConfigPage.tsx
+++ b/src/bosshunter/web/frontend/src/pages/ConfigPage.tsx
@@ -279,6 +279,33 @@ export default function ConfigPage() {
           </div>
         </SectionCard>
 
+        {/* Collection Safety Section */}
+        <SectionCard title="采集安全设置" sectionKey="collection" expanded={expandedSections} toggle={toggleSection}>
+          <div className="space-y-4">
+            <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
+              以下均为单日最大值，不是采集目标；重复岗位不占新增岗位额度。
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <Field label="单日新增唯一岗位上限">
+                <Input type="number" value={config.collection?.daily_new_jobs_limit ?? 100} onChange={e => updateConfig('collection.daily_new_jobs_limit', Number(e.target.value))} min={1} max={500} />
+              </Field>
+              <Field label="单日搜索页上限">
+                <Input type="number" value={config.collection?.daily_search_page_limit ?? 30} onChange={e => updateConfig('collection.daily_search_page_limit', Number(e.target.value))} min={1} max={200} />
+              </Field>
+              <Field label="单日详情页尝试上限">
+                <Input type="number" value={config.collection?.daily_detail_page_limit ?? 150} onChange={e => updateConfig('collection.daily_detail_page_limit', Number(e.target.value))} min={1} max={500} />
+              </Field>
+              <Field label="连续页面失败停止阈值">
+                <Input type="number" value={config.collection?.max_consecutive_page_failures ?? 3} onChange={e => updateConfig('collection.max_consecutive_page_failures', Number(e.target.value))} min={1} max={10} />
+              </Field>
+            </div>
+            <Field label="全流程采集后投递冷却（分钟）">
+              <Input type="number" value={config.collection?.delivery_cooldown_minutes ?? 30} onChange={e => updateConfig('collection.delivery_cooldown_minutes', Number(e.target.value))} min={0} max={240} />
+              <p className="mt-1 text-xs text-muted">等待期间可停止任务；单独采集不受影响。</p>
+            </Field>
+          </div>
+        </SectionCard>
+
         {/* Scoring Section */}
         <SectionCard title="评分设置" sectionKey="scoring" expanded={expandedSections} toggle={toggleSection}>
           <div className="space-y-4">

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -29,6 +29,7 @@ from bosshunter.db import (
 	JobDeletionConflictError,
 	add_history,
 	count_unresolved_monitor_items,
+	get_active_platform_safety_lock,
 	get_daily_activity,
 	get_db,
 	get_funnel_stats,
@@ -288,6 +289,8 @@ def _record_collect_progress(task: WorkbenchTask, state: dict) -> None:
 		"collect_seen": int(state.get("seen") or 0),
 		"collect_new": int(state.get("new") or 0),
 		"collect_duplicate": int(state.get("duplicate") or 0),
+		"collect_filtered": int(state.get("filtered") or 0),
+		"collect_search_pages": int(state.get("search_pages") or 0),
 	})
 
 
@@ -316,12 +319,36 @@ def _execute_collect(task: WorkbenchTask, config: dict) -> None:
 	collect_config["_workbench_collect_progress"] = lambda state: _record_collect_progress(task, state)
 	collected_job_ids: list[str] = []
 	scrape_jobs(collect_config, keywords, collected_job_ids=collected_job_ids)
+	collect_report = collect_config.get("_workbench_collect_report", {})
+	stop_reason = str(collect_report.get("stop_reason") or "")
+	limit_labels = {
+		"daily_new_jobs_limit": "单日新增岗位上限",
+		"daily_search_page_limit": "单日搜索页上限",
+		"daily_detail_page_limit": "单日详情页上限",
+		"daily_platform_page_limit": "单日平台页面总上限",
+	}
+	risk_labels = {
+		"captcha": "验证码",
+		"blocked": "账号或请求被拦截",
+		"rate_limit": "频率限制",
+		"login_required": "登录状态失效",
+		"consecutive_page_failures": "连续页面失败",
+		"persistent_risk_lock": "平台安全锁仍在冷却",
+	}
+	if stop_reason in limit_labels:
+		_log(task, f"为了账户安全，采集已达到{limit_labels[stop_reason]}，已停止继续访问；已采集岗位将继续本地评分")
+	elif stop_reason in risk_labels:
+		reason = f"为了账户安全，检测到{risk_labels[stop_reason]}，采集已立即停止并进入安全冷却"
+		task.stop_reason = reason
+		task.stop_requested.set()
+		_log(task, reason)
 	if task.stop_requested.is_set():
 		return
 	_log(
 		task,
 		f"本轮采集完成：扫描 {task.metrics.get('collect_seen', 0)}，新增 {task.metrics.get('collect_new', 0)}，重复 {task.metrics.get('collect_duplicate', 0)}",
 	)
+	task.context["collection_completed_monotonic"] = time.monotonic()
 	_log(task, f"开始 AI 评分：处理全部未评分岗位（本轮新增 {len(collected_job_ids)} 个）")
 	score_config = dict(config)
 	score_config["_workbench_stop_event"] = task.stop_requested
@@ -422,6 +449,8 @@ def _take_monitor_deliveries(task: WorkbenchTask) -> list[dict]:
 
 def _execute_monitor(task: WorkbenchTask, config: dict, *, initial_cooldown: bool = False) -> None:
 	from bosshunter.executor.monitor import monitor_and_send_resumes
+	if _stop_for_active_platform_lock(task):
+		return
 
 	monitor_config = dict(config)
 	monitor_config["_workbench_stop_event"] = task.stop_requested
@@ -454,6 +483,8 @@ def _execute_monitor(task: WorkbenchTask, config: dict, *, initial_cooldown: boo
 					"rate_limit": "频率限制",
 					"blocked": "账号或请求被拦截",
 					"consecutive_page_failures": "连续页面失败",
+					"daily_platform_page_limit": "单日平台页面访问上限",
+					"persistent_risk_lock": "平台安全锁冷却",
 				}
 				reason = f"监测已安全停止：检测到{reason_labels.get(stop_reason, '风险信号')}"
 				task.stop_reason = reason
@@ -523,6 +554,8 @@ def _execute_full(task: WorkbenchTask, config: dict) -> None:
 		return
 
 	_log(task, f"前端已确认 {len(job_ids)} 个岗位，继续投递")
+	if _wait_for_collection_delivery_cooldown(task, config):
+		return
 	# The user may adjust the daily limit or other send settings while reviewing
 	# jobs. Reload immediately before delivery instead of using the task-start snapshot.
 	deliver_config = load_config(CONFIG_PATH)
@@ -576,6 +609,8 @@ def _take_active_delivery(task: WorkbenchTask) -> dict | None:
 
 def _execute_deliver(task: WorkbenchTask, config: dict) -> None:
 	"""Run one delivery worker and drain batches queued while it is active."""
+	if _stop_for_active_platform_lock(task):
+		return
 	queue_lock = task.context.setdefault("delivery_queue_lock", Lock())
 	with queue_lock:
 		task.context["delivering"] = True
@@ -605,6 +640,40 @@ def _execute_deliver(task: WorkbenchTask, config: dict) -> None:
 			task.context["delivering"] = False
 			task.context.pop("delivery_scheduled_ids", None)
 			task.context.pop("pending_deliveries", None)
+
+
+def _stop_for_active_platform_lock(task: WorkbenchTask) -> bool:
+	db = _get_web_db()
+	try:
+		lock = get_active_platform_safety_lock(db)
+	finally:
+		db.close()
+	if not lock:
+		return False
+	reason = "为了账户安全，平台风险冷却尚未结束，已停止本次平台访问"
+	task.stop_reason = reason
+	task.stop_requested.set()
+	_log(task, reason)
+	return True
+
+
+def _wait_for_collection_delivery_cooldown(task: WorkbenchTask, config: dict) -> bool:
+	completed_at = task.context.get("collection_completed_monotonic")
+	if not isinstance(completed_at, (int, float)):
+		return False
+	raw_minutes = config.get("collection", {}).get("delivery_cooldown_minutes", 30)
+	try:
+		cooldown_seconds = max(float(raw_minutes), 0) * 60
+	except (TypeError, ValueError):
+		cooldown_seconds = 30 * 60
+	remaining = max(cooldown_seconds - (time.monotonic() - completed_at), 0)
+	if remaining <= 0:
+		return False
+	_log(task, f"为了账户安全，采集结束后冷却 {remaining / 60:.1f} 分钟再开始投递")
+	if task.stop_requested.wait(remaining):
+		_log(task, "采集到投递的安全冷却已取消")
+		return True
+	return False
 
 
 def _execute_deliver_batch(task: WorkbenchTask, config: dict) -> None:

--- a/tests/test_collection_safety.py
+++ b/tests/test_collection_safety.py
@@ -1,0 +1,176 @@
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from bosshunter.config import DEFAULTS
+from bosshunter.db import (
+    add_platform_access,
+    count_jobs_created_today,
+    count_platform_access_today,
+    get_active_platform_safety_lock,
+    get_db,
+    insert_job,
+    set_platform_safety_lock,
+)
+from bosshunter.platform_safety import PlatformAccessGuard, PlatformSafetyStop
+from bosshunter.scraper.jobs import scrape_jobs
+from bosshunter.web.server import _execute_collect, _wait_for_collection_delivery_cooldown
+from bosshunter.web.tasks import WorkbenchTask
+
+
+def _job(job_id: str) -> dict:
+    return {
+        "id": job_id,
+        "title": "AI 产品经理",
+        "company": "示例公司",
+        "salary": "20-30K",
+        "city": "北京",
+        "experience": "3-5年",
+        "jd": "产品工作",
+        "hr_name": "",
+        "hr_title": "",
+        "hr_active": "",
+        "company_size": "",
+        "company_industry": "",
+        "url": f"https://www.zhipin.com/job_detail/{job_id}.html",
+    }
+
+
+class CollectionSafetyTests(unittest.TestCase):
+    def test_default_limits_are_daily_only(self):
+        collection = DEFAULTS["collection"]
+        self.assertEqual(collection["daily_new_jobs_limit"], 100)
+        self.assertEqual(collection["daily_search_page_limit"], 30)
+        self.assertEqual(collection["daily_detail_page_limit"], 150)
+        self.assertNotIn("max_new_jobs_per_cycle", collection)
+        self.assertNotIn("max_search_pages_per_cycle", collection)
+
+    def test_daily_access_limit_stops_before_the_next_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = get_db(Path(tmp) / "bosshunter.db")
+            guard = PlatformAccessGuard(db, {"safety": {"daily_platform_page_limit": 500}}, "collection")
+            for _ in range(30):
+                guard.reserve("search_page", daily_limit=30)
+
+            with self.assertRaises(PlatformSafetyStop) as raised:
+                guard.reserve("search_page", daily_limit=30)
+
+            self.assertEqual(raised.exception.reason, "daily_search_page_limit")
+            self.assertEqual(
+                count_platform_access_today(db, stage="collection", action="search_page"),
+                30,
+            )
+            db.close()
+
+    def test_global_page_budget_is_shared_across_workflows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = get_db(Path(tmp) / "bosshunter.db")
+            config = {"safety": {"daily_platform_page_limit": 2}}
+            PlatformAccessGuard(db, config, "collection").reserve("search_page")
+            PlatformAccessGuard(db, config, "send").reserve("job_page")
+
+            with self.assertRaises(PlatformSafetyStop) as raised:
+                PlatformAccessGuard(db, config, "monitor").reserve("monitor_page")
+
+            self.assertEqual(raised.exception.reason, "daily_platform_page_limit")
+            db.close()
+
+    def test_unique_daily_count_ignores_accesses_and_counts_jobs_once(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = get_db(Path(tmp) / "bosshunter.db")
+            insert_job(db, _job("one"))
+            add_platform_access(db, "collection", "search_page")
+            add_platform_access(db, "collection", "detail_page")
+            self.assertEqual(count_jobs_created_today(db), 1)
+            db.close()
+
+    def test_risk_lock_survives_a_new_database_connection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "bosshunter.db"
+            db = get_db(db_path)
+            set_platform_safety_lock(db, "captcha", minutes=30)
+            db.close()
+
+            reopened = get_db(db_path)
+            lock = get_active_platform_safety_lock(reopened)
+            self.assertEqual(lock["reason"], "captcha")
+            reopened.close()
+
+    def test_daily_new_job_limit_stops_without_opening_platform_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "bosshunter.db"
+            db = get_db(db_path)
+            for index in range(100):
+                insert_job(db, _job(f"job-{index}"))
+            config = {
+                "profile": {"target_cities": ["北京"]},
+                "search": {"max_pages": 1},
+                "collection": {"daily_new_jobs_limit": 100},
+            }
+
+            with patch("bosshunter.scraper.jobs.get_db", return_value=db), \
+                 patch("bosshunter.scraper.jobs.new_tab") as new_tab:
+                count = scrape_jobs(config, ["AI"])
+
+            self.assertEqual(count, 0)
+            self.assertEqual(config["_workbench_collect_report"]["stop_reason"], "daily_new_jobs_limit")
+            new_tab.assert_not_called()
+
+    def test_collection_risk_stops_and_records_safe_reason(self):
+        db = Mock()
+        progress = Mock()
+        progress.add_task.return_value = "task"
+        context = Mock()
+        context.__enter__ = Mock(return_value=progress)
+        context.__exit__ = Mock(return_value=False)
+        config = {
+            "profile": {"target_cities": ["北京"]},
+            "search": {"max_pages": 1},
+        }
+
+        with patch("bosshunter.scraper.jobs.get_db", return_value=db), \
+             patch("bosshunter.scraper.jobs.count_jobs_created_today", return_value=0), \
+             patch("bosshunter.scraper.jobs.PlatformAccessGuard") as guard_cls, \
+             patch("bosshunter.scraper.jobs.Progress", return_value=context), \
+             patch("bosshunter.scraper.jobs.new_tab", return_value="worker"), \
+             patch("bosshunter.scraper.jobs.wait_for_load"), \
+             patch("bosshunter.scraper.jobs.evaluate", return_value=json.dumps({"risk": "captcha"})), \
+             patch("bosshunter.scraper.jobs.close_tab"), \
+             patch("bosshunter.scraper.jobs.time.sleep"):
+            count = scrape_jobs(config, ["AI"])
+
+        self.assertEqual(count, 0)
+        self.assertEqual(config["_workbench_collect_report"]["stop_reason"], "captcha")
+        guard_cls.return_value.lock.assert_called_once_with("captcha")
+
+    def test_frontend_task_log_explains_daily_limit(self):
+        task = WorkbenchTask(id="collect", mode="collect", label="单独采集")
+        config = {"search": {"keywords": ["AI"]}}
+
+        def fake_scrape(collect_config, _keywords, *, collected_job_ids=None):
+            collect_config["_workbench_collect_report"] = {"stop_reason": "daily_search_page_limit"}
+            return 0
+
+        with patch("bosshunter.scraper.jobs.scrape_jobs", side_effect=fake_scrape), \
+             patch("bosshunter.ai.scorer.score_jobs", return_value=(0, 0)):
+            _execute_collect(task, config)
+
+        self.assertTrue(any("为了账户安全" in line and "单日搜索页上限" in line for line in task.logs))
+
+    def test_collection_delivery_cooldown_is_cancellable(self):
+        task = WorkbenchTask(id="full", mode="full", label="运行全流程")
+        task.context["collection_completed_monotonic"] = time.monotonic()
+        task.stop_requested.set()
+        self.assertTrue(
+            _wait_for_collection_delivery_cooldown(
+                task,
+                {"collection": {"delivery_cooldown_minutes": 30}},
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scraper_background.py
+++ b/tests/test_scraper_background.py
@@ -81,10 +81,16 @@ class ScraperBackgroundTests(unittest.TestCase):
         }
 
         with patch("bosshunter.scraper.jobs.get_db", return_value=db), \
+             patch("bosshunter.scraper.jobs.count_jobs_created_today", return_value=0), \
+             patch("bosshunter.scraper.jobs.PlatformAccessGuard") as guard_cls, \
              patch("bosshunter.scraper.jobs.Progress", return_value=progress_context), \
              patch("bosshunter.scraper.jobs.PageThrottle") as throttle_cls, \
-             patch("bosshunter.scraper.jobs.new_tab", side_effect=["search-target", "detail-target"]), \
-             patch("bosshunter.scraper.jobs.evaluate", side_effect=[json.dumps(jobs), json.dumps(detail)]), \
+             patch("bosshunter.scraper.jobs.new_tab", return_value="worker-target"), \
+             patch("bosshunter.scraper.jobs.navigate", return_value=True), \
+             patch("bosshunter.scraper.jobs.evaluate", side_effect=[
+                 json.dumps({"risk": None}), json.dumps(jobs),
+                 json.dumps({"risk": None}), json.dumps(detail),
+             ]), \
              patch("bosshunter.scraper.jobs.wait_for_load"), \
              patch("bosshunter.scraper.jobs.scroll"), \
              patch("bosshunter.scraper.jobs.close_tab"), \
@@ -93,13 +99,16 @@ class ScraperBackgroundTests(unittest.TestCase):
              patch("bosshunter.scraper.jobs.insert_job"), \
              patch("bosshunter.scraper.jobs.time.sleep"):
             throttle_cls.return_value.wait.return_value = None
+            guard_cls.return_value.ensure_unlocked.return_value = None
             count = scrape_jobs(config, ["AI"], collected_job_ids=collected_job_ids)
 
         self.assertEqual(count, 1)
         self.assertEqual(len(collected_job_ids), 1)
-        self.assertEqual(updates[-1], {"seen": 2, "new": 1, "duplicate": 1})
+        self.assertEqual(updates[-1], {
+            "seen": 2, "new": 1, "duplicate": 1, "filtered": 0, "search_pages": 1,
+        })
 
-    def test_search_and_detail_pages_open_in_background(self):
+    def test_search_and_detail_pages_reuse_one_visible_worker_tab(self):
         db = Mock()
         progress = Mock()
         progress.add_task.return_value = "task-1"
@@ -128,15 +137,21 @@ class ScraperBackgroundTests(unittest.TestCase):
         }
 
         with patch("bosshunter.scraper.jobs.get_db", return_value=db), \
+             patch("bosshunter.scraper.jobs.count_jobs_created_today", return_value=0), \
+             patch("bosshunter.scraper.jobs.PlatformAccessGuard") as guard_cls, \
              patch("bosshunter.scraper.jobs.Progress", return_value=progress_context), \
              patch("bosshunter.scraper.jobs.PageThrottle") as throttle_cls, \
              patch(
                  "bosshunter.scraper.jobs.new_tab",
-                 side_effect=["search-target", "detail-target"],
+                 return_value="worker-target",
              ) as new_tab, \
+             patch("bosshunter.scraper.jobs.navigate", return_value=True) as navigate, \
              patch(
                  "bosshunter.scraper.jobs.evaluate",
-                 side_effect=[json.dumps(jobs), json.dumps(detail)],
+                 side_effect=[
+                     json.dumps({"risk": None}), json.dumps(jobs),
+                     json.dumps({"risk": None}), json.dumps(detail),
+                 ],
              ), \
              patch("bosshunter.scraper.jobs.wait_for_load"), \
              patch("bosshunter.scraper.jobs.scroll"), \
@@ -146,21 +161,17 @@ class ScraperBackgroundTests(unittest.TestCase):
              patch("bosshunter.scraper.jobs.insert_job"), \
              patch("bosshunter.scraper.jobs.time.sleep"):
             throttle_cls.return_value.wait.return_value = None
+            guard_cls.return_value.ensure_unlocked.return_value = None
             count = scrape_jobs(config, ["AI"])
 
         self.assertEqual(count, 1)
-        self.assertEqual(
-            new_tab.call_args_list,
-            [
-                call(
-                    "https://www.zhipin.com/web/geek/job?query=AI&city=101010100",
-                    background=True,
-                ),
-                call(
-                    "https://www.zhipin.com/job_detail/background-job.html",
-                    background=True,
-                ),
-            ],
+        new_tab.assert_called_once_with(
+            "https://www.zhipin.com/web/geek/job?query=AI&city=101010100",
+            background=False,
+        )
+        navigate.assert_called_once_with(
+            "worker-target",
+            "https://www.zhipin.com/job_detail/background-job.html",
         )
 
 

--- a/tests/test_web_api_routes.py
+++ b/tests/test_web_api_routes.py
@@ -579,7 +579,9 @@ class WebApiRouteTests(unittest.TestCase):
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
-                now = datetime.now(UTC).replace(tzinfo=None)
+                # Funnel "today" uses the machine's local calendar day. Keep fixtures
+                # in the same clock so this remains stable around local midnight.
+                now = datetime.now()
                 fixtures = (
                     ("today-ready", "ready", now),
                     ("today-sent", "sent", now - timedelta(hours=1)),


### PR DESCRIPTION
## Summary
- add daily collection ceilings: 100 unique new jobs, 30 search pages, and 150 detail-page attempts; duplicates do not consume the unique-job limit
- reuse one visible collection tab, prefilter list cards before detail navigation, and add cancellable collection-to-delivery cooldown
- stop collection on CAPTCHA, rate limiting, account blocks, login loss, or consecutive page failures and persist a cross-restart safety lock
- share a daily platform-page budget across collection, delivery, and monitoring, with clear workbench safety messages
- expose collection safety settings in configuration UI without enabling any additional automatic sending

## Validation
- `pytest -q` — 321 passed, 11 subtests passed
- frontend `npm run build` — passed
- Python compile, JSON schema parse, and `git diff --check` — passed

All validation was offline; no platform workflow was executed.