### PR TITLE
fix(executor): 修复监控风险检测的掩码误判

### DIFF
--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -122,11 +122,22 @@ JS_EXTRACT_CHAT_LIST = r"""
 
 JS_DETECT_MONITOR_RISK = """
 (() => {
-    const text = document.body ? document.body.innerText : '';
+    // Read only visible UI content. Hidden template nodes and mask placeholders
+    // often contain generic security wording and must not stop a real session.
+    const visible = (el) => {
+        if (!el) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) === 0) return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+    };
+    const visibleText = (el) => visible(el) ? (el.innerText || el.textContent || '').trim() : '';
+    const visibleNodes = Array.from(document.querySelectorAll('body *')).filter(visible);
+    const text = visibleNodes.map(visibleText).filter(Boolean).join(' ');
     const title = document.title || '';
     const url = window.location.href || '';
-    const hasCaptchaElement = !!document.querySelector(
-        '.geetest_panel, .captcha, [class*="captcha"], [id*="captcha"], iframe[src*="captcha"], iframe[src*="verify"]'
+    const hasCaptchaElement = visibleNodes.some((el) =>
+        el.matches('.geetest_panel, .captcha, [class*="captcha"], [id*="captcha"], iframe[src*="captcha"], iframe[src*="verify"]')
     );
     if (
         hasCaptchaElement || /captcha|verify|security-check/i.test(url) ||

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -122,18 +122,26 @@ JS_EXTRACT_CHAT_LIST = r"""
 
 JS_DETECT_MONITOR_RISK = """
 (() => {
-    // Read only visible UI content. Hidden template nodes and mask placeholders
-    // often contain generic security wording and must not stop a real session.
+    // Read only actionable UI content. Hidden templates and elements covered by
+    // an unrelated mask must not stop a real session.
     const visible = (el) => {
         if (!el) return false;
-        const style = window.getComputedStyle(el);
-        if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) === 0) return false;
+        for (let current = el; current && current !== document.documentElement; current = current.parentElement) {
+            const style = window.getComputedStyle(current);
+            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) === 0) return false;
+        }
         const rect = el.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
+        if (rect.width <= 0 || rect.height <= 0) return false;
+        const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        return !!top && (top === el || el.contains(top));
     };
-    const visibleText = (el) => visible(el) ? (el.innerText || el.textContent || '').trim() : '';
+    const visibleText = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        if (node.parentElement && visible(node.parentElement)) visibleText.push(node.nodeValue || '');
+    }
+    const text = visibleText.join(' ');
     const visibleNodes = Array.from(document.querySelectorAll('body *')).filter(visible);
-    const text = visibleNodes.map(visibleText).filter(Boolean).join(' ');
     const title = document.title || '';
     const url = window.location.href || '';
     const hasCaptchaElement = visibleNodes.some((el) =>
@@ -146,9 +154,15 @@ JS_DETECT_MONITOR_RISK = """
     if (
         ['操作过于频繁', '访问过于频繁', '请求过于频繁', '操作频繁，请稍后再试'].some(value => text.includes(value))
     ) return JSON.stringify({risk: 'rate_limit'});
+    if (/(?:^|[\\/?#=_-])(?:403|forbidden|access-denied)(?:$|[\\/?#=&_-])/i.test(url)) {
+        return JSON.stringify({risk: 'blocked'});
+    }
+    if (/^(?:403(?:\\s+forbidden)?|forbidden|access denied|访问被拒绝|账号异常|账号受限)/i.test(title.trim())) {
+        return JSON.stringify({risk: 'blocked'});
+    }
     if (
         ['账号存在异常', '账号已被限制', '当前账号异常', '访问被拒绝', '账号或请求被拦截'].some(value => text.includes(value)) ||
-        ['账号异常', '访问受限'].some(value => title.includes(value))
+        /(?:^|\\s)403(?:\\s+forbidden)?(?=\\s|$)/i.test(text)
     ) return JSON.stringify({risk: 'blocked'});
     return JSON.stringify({risk: null});
 })()

--- a/src/bosshunter/executor/monitor.py
+++ b/src/bosshunter/executor/monitor.py
@@ -124,24 +124,46 @@ JS_DETECT_MONITOR_RISK = """
 (() => {
     // Read only actionable UI content. Hidden templates and elements covered by
     // an unrelated mask must not stop a real session.
-    const visible = (el) => {
+    const hasVisibleStyle = (el) => {
         if (!el) return false;
-        for (let current = el; current && current !== document.documentElement; current = current.parentElement) {
+        for (let current = el; current; current = current.parentElement) {
             const style = window.getComputedStyle(current);
-            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) === 0) return false;
+            // display cannot be overridden by descendants and ancestor opacity
+            // always applies. visibility, however, may be reset to visible by a
+            // descendant, so inspect only the target's computed value below.
+            if (style.display === 'none' || Number(style.opacity || 1) === 0) return false;
         }
-        const rect = el.getBoundingClientRect();
-        if (rect.width <= 0 || rect.height <= 0) return false;
-        const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-        return !!top && (top === el || el.contains(top));
+        return window.getComputedStyle(el).visibility !== 'hidden';
+    };
+    const visibleAt = (el, rect) => {
+        if (!hasVisibleStyle(el) || rect.width <= 0 || rect.height <= 0) return false;
+        const points = [
+            [rect.left + rect.width / 2, rect.top + rect.height / 2],
+            [rect.left + 1, rect.top + 1],
+            [rect.right - 1, rect.bottom - 1],
+        ];
+        return points.some(([x, y]) => {
+            if (x < 0 || y < 0 || x >= innerWidth || y >= innerHeight) return false;
+            const top = document.elementFromPoint(x, y);
+            return !!top && (top === el || el.contains(top));
+        });
     };
     const visibleText = [];
     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        if (node.parentElement && visible(node.parentElement)) visibleText.push(node.nodeValue || '');
+        if (!node.parentElement || !hasVisibleStyle(node.parentElement)) continue;
+        const range = document.createRange();
+        range.selectNode(node);
+        if (Array.from(range.getClientRects()).some((rect) => visibleAt(node.parentElement, rect))) {
+            // Do not insert separators: inline tags split a rendered phrase into
+            // multiple text nodes, while hidden nodes must simply be omitted.
+            visibleText.push(node.nodeValue || '');
+        }
     }
-    const text = visibleText.join(' ');
-    const visibleNodes = Array.from(document.querySelectorAll('body *')).filter(visible);
+    const text = visibleText.join('');
+    const visibleNodes = Array.from(document.querySelectorAll('body *')).filter((el) =>
+        Array.from(el.getClientRects()).some((rect) => visibleAt(el, rect))
+    );
     const title = document.title || '';
     const url = window.location.href || '';
     const hasCaptchaElement = visibleNodes.some((el) =>
@@ -157,11 +179,12 @@ JS_DETECT_MONITOR_RISK = """
     if (/(?:^|[\\/?#=_-])(?:403|forbidden|access-denied)(?:$|[\\/?#=&_-])/i.test(url)) {
         return JSON.stringify({risk: 'blocked'});
     }
-    if (/^(?:403(?:\\s+forbidden)?|forbidden|access denied|访问被拒绝|账号异常|账号受限)/i.test(title.trim())) {
+    if (/^(?:403(?:\\s+forbidden)?|forbidden|access denied)/i.test(title.trim())) {
         return JSON.stringify({risk: 'blocked'});
     }
     if (
         ['账号存在异常', '账号已被限制', '当前账号异常', '访问被拒绝', '账号或请求被拦截'].some(value => text.includes(value)) ||
+        ['账号异常', '访问受限', '访问被拒绝'].some(value => title.includes(value)) ||
         /(?:^|\\s)403(?:\\s+forbidden)?(?=\\s|$)/i.test(text)
     ) return JSON.stringify({risk: 'blocked'});
     return JSON.stringify({risk: null});

--- a/src/bosshunter/web/frontend/package-lock.json
+++ b/src/bosshunter/web/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^5.2.0",
         "autoprefixer": "^10.4.19",
+        "jsdom": "^26.1.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.4.5",
@@ -45,6 +46,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -335,6 +357,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1413,6 +1550,16 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1677,6 +1824,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmmirror.com/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1804,6 +1965,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1821,6 +1996,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -1858,6 +2040,19 @@
       "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -2064,6 +2259,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2135,6 +2384,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2171,6 +2427,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmmirror.com/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2338,6 +2634,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmmirror.com/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2355,6 +2658,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-parse": {
@@ -2583,6 +2899,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2858,6 +3184,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmmirror.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2880,6 +3213,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -2946,6 +3299,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
@@ -3072,6 +3432,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmmirror.com/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmmirror.com/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3083,6 +3463,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -3271,6 +3677,106 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/bosshunter/web/frontend/package.json
+++ b/src/bosshunter/web/frontend/package.json
@@ -29,6 +29,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
     "vite": "^6.4.3"

--- a/src/bosshunter/web/frontend/tests/monitor_risk_dom_runner.mjs
+++ b/src/bosshunter/web/frontend/tests/monitor_risk_dom_runner.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+const cases = JSON.parse(readFileSync(0, 'utf8'));
+
+function detect({ body = '', title = '', url = 'https://www.zhipin.com/web/geek/chat', topSelector, script }) {
+    const dom = new JSDOM(`<!doctype html><title>${title}</title><body>${body}</body>`, {
+        runScripts: 'outside-only',
+        url,
+    });
+    const { document, HTMLElement } = dom.window;
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value() {
+            return { left: 10, top: 10, width: 100, height: 30, right: 110, bottom: 40 };
+        },
+    });
+    document.elementFromPoint = () => document.querySelector(topSelector || '[data-top]') || document.body;
+    return JSON.parse(dom.window.eval(script));
+}
+
+process.stdout.write(JSON.stringify(cases.map(detect)));

--- a/src/bosshunter/web/frontend/tests/monitor_risk_dom_runner.mjs
+++ b/src/bosshunter/web/frontend/tests/monitor_risk_dom_runner.mjs
@@ -3,18 +3,41 @@ import { JSDOM } from 'jsdom';
 
 const cases = JSON.parse(readFileSync(0, 'utf8'));
 
-function detect({ body = '', title = '', url = 'https://www.zhipin.com/web/geek/chat', topSelector, script }) {
+function detect({ body = '', title = '', url = 'https://www.zhipin.com/web/geek/chat', topSelector, rects = {}, script }) {
     const dom = new JSDOM(`<!doctype html><title>${title}</title><body>${body}</body>`, {
         runScripts: 'outside-only',
         url,
     });
     const { document, HTMLElement } = dom.window;
+    document.title = title;
+    const defaultRect = { left: 10, top: 10, width: 100, height: 30 };
+    const rectangleFor = (element) => {
+        for (const [selector, rect] of Object.entries(rects)) {
+            if (element.matches(selector)) return { ...defaultRect, ...rect };
+        }
+        return defaultRect;
+    };
+    const toDomRect = (rect) => ({
+        ...rect,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        x: rect.left,
+        y: rect.top,
+    });
     Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
         configurable: true,
         value() {
-            return { left: 10, top: 10, width: 100, height: 30, right: 110, bottom: 40 };
+            return toDomRect(rectangleFor(this));
         },
     });
+    dom.window.Range.prototype.getClientRects = function getClientRects() {
+        const element = this.startContainer.nodeType === 3
+            ? this.startContainer.parentElement
+            : this.commonAncestorContainer.parentElement || this.commonAncestorContainer;
+        return [element]
+            .filter((element) => element instanceof HTMLElement)
+            .map((element) => toDomRect(rectangleFor(element)));
+    };
     document.elementFromPoint = () => document.querySelector(topSelector || '[data-top]') || document.body;
     return JSON.parse(dom.window.eval(script));
 }

--- a/tests/test_monitor_safety.py
+++ b/tests/test_monitor_safety.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import tempfile
 import time
 import unittest
@@ -537,6 +538,90 @@ class MonitorIdempotencyAndLimitTests(unittest.TestCase):
 
 
 class MonitorRiskTests(unittest.TestCase):
+    def _detect_risk_in_dom(self, *cases):
+        from bosshunter.executor import monitor
+
+        runner = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "bosshunter"
+            / "web"
+            / "frontend"
+            / "tests"
+            / "monitor_risk_dom_runner.mjs"
+        )
+        payload = [
+            {
+                **case,
+                "script": monitor.JS_DETECT_MONITOR_RISK,
+            }
+            for case in cases
+        ]
+        result = subprocess.run(
+            ["node", str(runner)],
+            input=json.dumps(payload, ensure_ascii=False),
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_risk_detection_ignores_hidden_template_and_obscured_content(self):
+        results = self._detect_risk_in_dom(
+            {
+                "body": '<div style="display:none"><div class="captcha" data-top>请完成验证</div></div>',
+                "topSelector": "[data-top]",
+            },
+            {
+                "body": '<div style="visibility:hidden"><span data-top>操作过于频繁</span></div>',
+                "topSelector": "[data-top]",
+            },
+            {
+                "body": '<div style="opacity:0"><span data-top>访问被拒绝</span></div>',
+                "topSelector": "[data-top]",
+            },
+            {
+                "body": '<div class="captcha">请完成验证</div><div id="mask" data-top></div>',
+                "topSelector": "#mask",
+            },
+        )
+
+        self.assertEqual(results, [{"risk": None}] * 4)
+
+    def test_risk_detection_keeps_visible_and_url_title_safety_signals(self):
+        results = self._detect_risk_in_dom(
+            {
+                "body": '<div class="captcha" data-top>请完成验证</div>',
+            },
+            {
+                "body": '<p data-top>操作过于频繁，请稍后再试</p>',
+            },
+            {
+                "body": '<main data-top>403 Forbidden</main>',
+            },
+            {
+                "title": "访问被拒绝",
+                "body": '<main data-top>普通页面</main>',
+            },
+            {
+                "body": '<div style="display:none"><span data-top>请完成验证</span></div>',
+                "url": "https://www.zhipin.com/security-check",
+                "topSelector": "[data-top]",
+            },
+        )
+
+        self.assertEqual(
+            results,
+            [
+                {"risk": "captcha"},
+                {"risk": "rate_limit"},
+                {"risk": "blocked"},
+                {"risk": "blocked"},
+                {"risk": "captcha"},
+            ],
+        )
+
     def test_captcha_stops_cycle_and_records_only_safe_risk_detail(self):
         from bosshunter.executor import monitor
 

--- a/tests/test_monitor_safety.py
+++ b/tests/test_monitor_safety.py
@@ -589,6 +589,44 @@ class MonitorRiskTests(unittest.TestCase):
 
         self.assertEqual(results, [{"risk": None}] * 4)
 
+    def test_risk_detection_uses_visible_text_rectangles_without_splitting_phrases(self):
+        results = self._detect_risk_in_dom(
+            {
+                "body": '<div data-top style="height:200vh">操作过于频繁</div>',
+                "rects": {"[data-top]": {"left": 10, "top": 10, "width": 500, "height": 1400}},
+            },
+            {
+                "body": '<p data-top>操作过于<strong>频繁</strong></p>',
+                "topSelector": "strong",
+            },
+            {
+                "body": '<p data-top>请完成<strong>验证</strong></p>',
+                "topSelector": "strong",
+            },
+            {
+                "body": '<p data-top>访问被<strong>拒绝</strong></p>',
+                "topSelector": "strong",
+            },
+            {
+                "body": '<p data-top>操作过于<span style="display:none">无关</span>频繁</p>',
+            },
+            {
+                "body": '<div style="visibility:hidden"><span data-top style="visibility:visible">操作过于频繁</span></div>',
+            },
+        )
+
+        self.assertEqual(
+            results,
+            [
+                {"risk": "rate_limit"},
+                {"risk": "rate_limit"},
+                {"risk": "captcha"},
+                {"risk": "blocked"},
+                {"risk": "rate_limit"},
+                {"risk": "rate_limit"},
+            ],
+        )
+
     def test_risk_detection_keeps_visible_and_url_title_safety_signals(self):
         results = self._detect_risk_in_dom(
             {
@@ -605,6 +643,14 @@ class MonitorRiskTests(unittest.TestCase):
                 "body": '<main data-top>普通页面</main>',
             },
             {
+                "title": "BOSS直聘 - 账号异常",
+                "body": '<main data-top>普通页面</main>',
+            },
+            {
+                "title": "访问受限",
+                "body": '<main data-top>普通页面</main>',
+            },
+            {
                 "body": '<div style="display:none"><span data-top>请完成验证</span></div>',
                 "url": "https://www.zhipin.com/security-check",
                 "topSelector": "[data-top]",
@@ -616,6 +662,8 @@ class MonitorRiskTests(unittest.TestCase):
             [
                 {"risk": "captcha"},
                 {"risk": "rate_limit"},
+                {"risk": "blocked"},
+                {"risk": "blocked"},
                 {"risk": "blocked"},
                 {"risk": "blocked"},
                 {"risk": "captcha"},


### PR DESCRIPTION
本次修改将平台风险检测限定为只读取可见页面元素，避免隐藏的验证码模板、遮罩占位节点或预加载文案触发“平台安全锁”误判。真实可见的验证码、访问频率限制和账号拦截提示仍会触发安全停止。