### PR TITLE
docs: 更新多平台功能与社区贡献榜

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ BossHunter 适合这些用户：
 
 | 能力 | 说明 |
 |------|------|
-| 智能采集 | 基于关键词与城市自动翻页采集岗位，内置去重 |
+| 多平台采集 | BOSS 直聘、智联招聘和前程无忧 51job 串行采集，支持独立关键词、城市、页数、排序与来源去重 |
 | AI 两阶段评分 | 快速预筛（关键词匹配） → 深度评分（AI 分析 JD） |
-| 定制招呼语 | AI 根据岗位 JD + 个人简历生成个性化开场白 |
+| 定制招呼语 | AI 根据岗位 JD + 个人简历生成个性化开场白，支持风格偏好、长度和套话约束 |
 | 人工确认 | 投递前必须经过确认，支持逐个/批量审核 |
 | 低频发送策略 | 随机间隔、时间窗口、每日上限、发送前浏览 |
 | HR 回复监听 | 自动检测 HR 回复，触发建议回复或定制简历生成 |
 | 简历请求识别 | 识别附件简历请求卡片，生成定制简历并等待手动发送 |
-| Web Dashboard | 可视化看板，实时查看漏斗数据、岗位状态与监测执行 |
+| Web Dashboard | 可视化看板，支持岗位池分页、排序、AI 评分、原平台链接、投递队列与状态管理 |
 | 自动跟进 | 超过设定时间未回复时自动发送一次跟进消息 |
 
 ### 平台能力边界
@@ -108,10 +108,10 @@ BossHunter 适合这些用户：
 | 平台 | 采集 | AI 评分/招呼语 | 发送/监听 |
 |------|------|------------------|-----------|
 | BOSS 直聘 | 支持 | 支持 | 保留人工确认后支持 |
-| 智联招聘 | 候选能力，需登录态小范围验证 | 支持离线处理已采集岗位 | **服务端锁定** |
-| 前程无忧 51job | 候选能力，当前只开放已验证的上海城市码 | 支持离线处理已采集岗位 | **服务端锁定** |
+| 智联招聘 | 支持只读采集，使用独立城市目录 | 支持处理已采集岗位 | **自动发送/监听锁定；提供原平台链接和手动“已发送”回填** |
+| 前程无忧 51job | 支持只读采集，当前验证北京、上海城市码 | 支持处理已采集岗位 | **自动发送/监听锁定；提供原平台链接和手动“已发送”回填** |
 
-新平台严格串行采集，详情页之间保留最低间隔。检测到验证码、频率限制、登录墙或无法识别的页面结构时，会停止整个采集队列，不尝试绕过验证。
+三个平台严格串行采集，分别配置关键词、城市、每组合最大页数和排序。智联与 51job 不进入自动发送、简历发送或消息监听；用户可从岗位池打开经域名校验的原平台链接，人工投递后再手动标记“已发送”。检测到验证码、频率限制、登录墙或无法识别的页面结构时不会尝试绕过验证。
 
 ---
 
@@ -362,6 +362,7 @@ A: 项目通过 CDP (Chrome DevTools Protocol) 直连你日常使用的浏览器
 
 | 日期 | 版本号 | 类型 | 更新内容 |
 |------|--------|------|----------|
+| 2026-08-25 | main（待发布） | 多平台与安全整合 | 合入智联/51job 只读采集、外部平台人工投递闭环、岗位池与筛选增强、Windows 兼容、招呼语与消息判定修复，并重整 BOSS 页面访问保护设置。 |
 | 2026-08-13 | v2.3.0 | 功能与可恢复性 | 增加多范围岗位导出、离线城市目录、任务安全的岗位回收站和可独立重试的 AI 评分；同步改进配置安全、岗位筛选与投递队列。 |
 | 2026-08-02 | v2.2.0 | 功能与稳定性 | 单岗位失败不再中断全流程；额度未完成岗位下次优先续发；加强首次沟通、历史会话、任务停止、后台页面与最新配置生效逻辑，并简化工作台。 |
 | 2026-07-30 | v2.1.1 | 稳定性修复 | 修复 AI 评分与招呼语可能因 Token 限制中断的问题：回答被截断时增大输出上限重试，上下文过长时压缩请求，额度或限流异常会保留进度并在工作台显示原因。 |
@@ -370,6 +371,35 @@ A: 项目通过 CDP (Chrome DevTools Protocol) 直连你日常使用的浏览器
 | 2026-06-29 | v2.0.0 | 稳定性 | 修复工作台任务可能卡住的问题；自动跟进默认关闭，把发送决定留给用户。 |
 
 > 查看每个版本的完整说明：[CHANGELOG.md](CHANGELOG.md)
+
+<details>
+<summary><strong>展开查看 2026-08-25 main 多平台与安全整合</strong></summary>
+
+### 多平台与人工投递闭环
+
+- **智联与 51job 只读采集**：三个平台统一串行编排，但保留独立关键词、城市、页数、排序和来源身份；51job 已验证北京、上海城市码。
+- **外部平台不自动发送**：智联与 51job 岗位只在本地评分、生成招呼语并提供原平台链接；用户人工投递后可二次确认标记“已发送”，不占用 BOSS 自动发送额度。
+- **BOSS 能力边界不变**：自动发送继续限定 BOSS 岗位，且必须经过人工确认、发送时间窗口、随机间隔和每日发送额度检查。
+
+### 岗位池、筛选与沟通可靠性
+
+- **筛选和评分增强**：增加学历、招聘类型、未知学历处理与评分上下文；支持招呼语风格偏好及确定性的长度、开头去重、套话和技术堆叠约束。
+- **岗位池增强**：增加分页、页码跳转、白名单排序、城市与来源展示、一键 AI 评分、投递队列、延期原因和额度提示。
+- **消息判定更可靠**：发送结果需从对应会话确认，不再把输入框清空当作成功；监听区分 HR、本人和平台系统消息。
+
+### 安全、兼容与设置
+
+- **BOSS 页面访问保护**：按搜索页、详情页和平台页面总量控制 BOSS 页面访问；采集计划超过单日搜索页上限时，配置页会提前提醒。采集结果数量不再作为安全上限，智联与 51job 也不占用 BOSS 页面额度。
+- **风险误报收敛**：不再因正文中孤立的风险词直接判定拦截；明确风险会复核，并采用可配置的短时随机冷却。项目不会绕过验证码或平台限制。
+- **采集与监测共用页面访问设置**：相关配置集中到“反监测设置”，采集后投递冷却和风险暂停使用最少/最多分钟区间，界面合并展示以减少配置项。
+- **Windows 兼容**：支持系统保留端口自动回退，并加入可选的一键启动器、桌面快捷方式、隐藏后台窗口和 Python 路径覆盖。
+- **简历上传校验**：先吸收 Markdown UTF-8 编码验证；完整简历工作室仍作为独立功能继续审查。
+
+### 本轮整合与验证
+
+主要来源为 [#45](https://github.com/powerycy/BossHunter/pull/45)、[#48](https://github.com/powerycy/BossHunter/pull/48)、[#49](https://github.com/powerycy/BossHunter/pull/49)、[#50](https://github.com/powerycy/BossHunter/pull/50)、[#51](https://github.com/powerycy/BossHunter/pull/51)、[#55](https://github.com/powerycy/BossHunter/pull/55)、[#57](https://github.com/powerycy/BossHunter/pull/57)、[#58](https://github.com/powerycy/BossHunter/pull/58)、[#61](https://github.com/powerycy/BossHunter/pull/61)、[#64](https://github.com/powerycy/BossHunter/pull/64)、[#65](https://github.com/powerycy/BossHunter/pull/65) 和 [#66](https://github.com/powerycy/BossHunter/pull/66)，统一由 [#62](https://github.com/powerycy/BossHunter/pull/62) 选择性整合。最终回归为 **401 项测试、16 个子测试通过**，GitHub CI 的 Python 3.11 / 3.12 均通过，并完成本地真实环境验收。
+
+</details>
 
 <details>
 <summary><strong>展开查看 v2.3.0 功能与可恢复性更新</strong></summary>
@@ -485,28 +515,38 @@ BossHunter 感谢每一位参与改进的开发者。下面的榜单记录外部
 ```mermaid
 pie showData
     title 已采纳贡献的影响力占比
-    "GioiaZheng" : 21
-    "atticus-zhou" : 16
-    "haohao-fly" : 14
-    "zhenian-666" : 14
-    "meixiaoxie" : 13
-    "yukinoshi" : 9
-    "Nourishman" : 8
-    "elowenzhouyb-source" : 5
+    "zhenian-666" : 16
+    "GioiaZheng" : 14
+    "atticus-zhou" : 11
+    "haohao-fly" : 10
+    "meixiaoxie" : 9
+    "shuaigechz-cloud" : 9
+    "hdfhssg" : 9
+    "yukinoshi" : 7
+    "Nourishman" : 5
+    "Henry369-0" : 4
+    "yuj-029" : 3
+    "elowenzhouyb-source" : 2
+    "Colin-Cai0318" : 1
 ```
 
 | 排名 | 贡献者 | 贡献度 | 状态 | 主要贡献 | 相关 PR |
 |:---:|---|:---:|:---:|---|---|
-| 🥇 | [@GioiaZheng](https://github.com/GioiaZheng) | **21%** | ✅ 已合并 | 🛡️ API Key 脱敏与安全读取；PDF 依赖降级；修正人工确认、招呼语和发送的岗位选择；清理未支持的服务商说明 | [#6](https://github.com/powerycy/BossHunter/pull/6) · [#7](https://github.com/powerycy/BossHunter/pull/7) · [#8](https://github.com/powerycy/BossHunter/pull/8) · [#9](https://github.com/powerycy/BossHunter/pull/9) · [#10](https://github.com/powerycy/BossHunter/pull/10) · [#12](https://github.com/powerycy/BossHunter/pull/12) |
-| 🥈 | [@atticus-zhou](https://github.com/atticus-zhou) | **16%** | ✅ 已合并 | 🤖 实现 AI 评分与招呼语重试、前台浏览器交互、送达状态验证和防重复发送 | [#27](https://github.com/powerycy/BossHunter/pull/27) → [#28](https://github.com/powerycy/BossHunter/pull/28) |
-| 🥉 | [@haohao-fly](https://github.com/haohao-fly) | **14%** | ✅ 已合并 | 📊 岗位筛选、分页与统计；结构化评分与失败重试；投递队列和重复任务保护 | [#38](https://github.com/powerycy/BossHunter/pull/38) → [#39](https://github.com/powerycy/BossHunter/pull/39) |
-| 4 | [@zhenian-666](https://github.com/zhenian-666) | **14%** | ✅ 已合并 | 📦 多范围岗位导出、离线城市目录、任务安全的回收站、独立 AI 评分与失败恢复 | [#40](https://github.com/powerycy/BossHunter/pull/40) → [#41](https://github.com/powerycy/BossHunter/pull/41) · [#42](https://github.com/powerycy/BossHunter/pull/42) · [#43](https://github.com/powerycy/BossHunter/pull/43) |
-| 5 | [@meixiaoxie](https://github.com/meixiaoxie) | **13%** | ✅ 已合并 | 🔐 配置原子写入与无凭据下载；公司屏蔽；自定义城市查询；Windows WSGI 回归测试 | [#37](https://github.com/powerycy/BossHunter/pull/37) → [#39](https://github.com/powerycy/BossHunter/pull/39) |
-| 6 | [@yukinoshi](https://github.com/yukinoshi) | **9%** | ✅ 已合并 | 🧠 Thinking 模式、多 AI 响应兼容和 Windows JavaScript MIME 兼容 | [#25](https://github.com/powerycy/BossHunter/pull/25) → [#28](https://github.com/powerycy/BossHunter/pull/28) |
-| 7 | [@Nourishman](https://github.com/Nourishman) | **8%** | ✅ PR #29 部分改进已适配合入 | 📄 带文字层 PDF 简历上传与错误提示；DeepSeek 模型 ID 调用期规范化；已批准岗位恢复与确认交接竞态修复 | [#29](https://github.com/powerycy/BossHunter/pull/29) |
-| 8 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **5%** | ✅ 已合并 | 🧭 提交并组织 AI 评分、招呼语与发送可靠性改进方案，推动问题定位和整体验证 | [#27](https://github.com/powerycy/BossHunter/pull/27) → [#28](https://github.com/powerycy/BossHunter/pull/28) |
+| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | **16%** | ✅ 已适配合入 | 📦 多范围岗位导出、城市目录、回收站与独立 AI 评分；新增统一平台采集架构和智联只读采集 | [#40](https://github.com/powerycy/BossHunter/pull/40) → [#41](https://github.com/powerycy/BossHunter/pull/41) · [#42](https://github.com/powerycy/BossHunter/pull/42) · [#43](https://github.com/powerycy/BossHunter/pull/43) · [#45](https://github.com/powerycy/BossHunter/pull/45) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 🥈 | [@GioiaZheng](https://github.com/GioiaZheng) | **14%** | ✅ 已合并 | 🛡️ API Key 脱敏与安全读取；PDF 依赖降级；修正人工确认、招呼语和发送的岗位选择；清理未支持的服务商说明 | [#6](https://github.com/powerycy/BossHunter/pull/6) · [#7](https://github.com/powerycy/BossHunter/pull/7) · [#8](https://github.com/powerycy/BossHunter/pull/8) · [#9](https://github.com/powerycy/BossHunter/pull/9) · [#10](https://github.com/powerycy/BossHunter/pull/10) · [#12](https://github.com/powerycy/BossHunter/pull/12) |
+| 🥉 | [@atticus-zhou](https://github.com/atticus-zhou) | **11%** | ✅ 已合并 | 🤖 实现 AI 评分与招呼语重试、前台浏览器交互、送达状态验证和防重复发送 | [#27](https://github.com/powerycy/BossHunter/pull/27) → [#28](https://github.com/powerycy/BossHunter/pull/28) |
+| 4 | [@haohao-fly](https://github.com/haohao-fly) | **10%** | ✅ 已合并 | 📊 岗位筛选、分页与统计；结构化评分与失败重试；投递队列和重复任务保护 | [#38](https://github.com/powerycy/BossHunter/pull/38) → [#39](https://github.com/powerycy/BossHunter/pull/39) |
+| 5 | [@meixiaoxie](https://github.com/meixiaoxie) | **9%** | ✅ 已合并 | 🔐 配置原子写入与无凭据下载；公司屏蔽；自定义城市查询；Windows WSGI 回归测试 | [#37](https://github.com/powerycy/BossHunter/pull/37) → [#39](https://github.com/powerycy/BossHunter/pull/39) |
+| 5 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **9%** | ✅ 已适配合入 | 💬 会话级送达确认、HR/本人/系统消息方向识别，以及确定性的招呼语风格约束 | [#49](https://github.com/powerycy/BossHunter/pull/49) · [#50](https://github.com/powerycy/BossHunter/pull/50) · [#51](https://github.com/powerycy/BossHunter/pull/51) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 5 | [@hdfhssg](https://github.com/hdfhssg) | **9%** | ✅ 已适配合入 | 🎓 学历与校招/社招筛选、评分上下文、个人偏好；岗位池分页排序、投递队列和额度提示 | [#54](https://github.com/powerycy/BossHunter/pull/54) · [#55](https://github.com/powerycy/BossHunter/pull/55) · [#64](https://github.com/powerycy/BossHunter/pull/64) · [#65](https://github.com/powerycy/BossHunter/pull/65) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 8 | [@yukinoshi](https://github.com/yukinoshi) | **7%** | ✅ 已适配合入 | 🧠 Thinking 模式、多 AI 响应和 Windows JavaScript MIME 兼容；Windows 系统保留端口自动回退 | [#25](https://github.com/powerycy/BossHunter/pull/25) → [#28](https://github.com/powerycy/BossHunter/pull/28) · [#48](https://github.com/powerycy/BossHunter/pull/48) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 9 | [@Nourishman](https://github.com/Nourishman) | **5%** | ✅ 部分适配合入 | 📄 带文字层 PDF 简历上传与错误提示；DeepSeek 模型 ID 规范化；已批准岗位恢复与确认交接竞态修复 | [#29](https://github.com/powerycy/BossHunter/pull/29) |
+| 10 | [@Henry369-0](https://github.com/Henry369-0) | **4%** | ✅ 已适配合入 | 🪟 Windows 一键启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/powerycy/BossHunter/pull/57) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 11 | [@yuj-029](https://github.com/yuj-029) | **3%** | ✅ 部分适配合入 | 🔎 51job 页面研究与只读采集核心；复用主线统一来源字段、数据库和节流机制 | [#58](https://github.com/powerycy/BossHunter/pull/58) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
+| 12 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **2%** | ✅ 已合并 | 🧭 提交并组织 AI 评分、招呼语与发送可靠性改进方案，推动问题定位和整体验证 | [#27](https://github.com/powerycy/BossHunter/pull/27) → [#28](https://github.com/powerycy/BossHunter/pull/28) |
+| 13 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **1%** | ✅ 部分适配合入 | 🧾 Markdown 简历上传 UTF-8 编码校验；完整简历工作室继续独立审查 | [#61](https://github.com/powerycy/BossHunter/pull/61) → [#62](https://github.com/powerycy/BossHunter/pull/62) |
 
-> **计算口径**：产品影响 40% + 可靠性与安全 25% + 测试与可维护性 20% + 采纳状态 15%。本次按实际适配合入的三类低风险改进，保守计入 Nourishman **8%**；Windows 启停、发送安全行为、旧文档与已被当前版本覆盖的停止逻辑均未计入。为保持总和 100%，其他已采纳贡献按原比例近似缩放并取整。百分比不代表代码所有权、奖金分配或单纯的代码行数。项目发起人和 AI 工具提交不参与本榜单。数据更新于 **2026-08-13**；如署名或功能描述需要修正，欢迎提交 Issue。
+> **计算口径**：产品影响 40% + 可靠性与安全 25% + 测试与可维护性 20% + 采纳状态 15%。本榜单只计算实际进入主线的内容；选择性整合按最终采用范围计分，未采用或仍在审查的部分不计入。为保持总和 100%，历史贡献会随新增贡献按相同口径重新归一化。百分比不代表代码所有权、奖金分配或单纯的代码行数。项目发起人和 AI 工具提交不参与本榜单。数据更新于 **2026-08-25**；如署名或功能描述需要修正，欢迎提交 Issue。
 
 ---
 


### PR DESCRIPTION
## 更新内容

- 更新首页平台能力边界：智联与 51job 只读采集、原平台人工投递与手动已发送回填
- 增加 2026-08-25 main 多平台与安全整合说明
- 按实际进入主线的内容更新贡献饼图、贡献表、PR 链接与采纳状态
- 饼图共 13 位外部贡献者，比例合计 100%

## 校验

- `git diff --check` 通过
- Mermaid 饼图合计 100
- `<details>` 标签 5 组完整闭合
- 仅修改 README，无运行时代码变更