### PR TITLE
fix(db): 防止 mark_external_jobs_sent 在未知平台触发 KeyError

### DIFF
--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -350,7 +350,10 @@ def mark_external_jobs_sent(conn: sqlite3.Connection, job_ids: Any, *, confirmed
         for row in pending_rows:
             job_id = str(row["id"])
             platform = str(row.get("source_platform") or "")
-            detail = f"用户在{platform_labels[platform]}完成投递后手动标记"
+            # 用 .get 兜底，避免未来扩展 EXTERNAL_MANUAL_SEND_PLATFORMS 时
+            # 出现未登记平台导致 KeyError 使整批标记失败。
+            platform_label = platform_labels.get(platform, platform)
+            detail = f"用户在{platform_label}完成投递后手动标记"
             conn.execute(
                 "UPDATE jobs SET status = 'sent', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND deleted_at IS NULL",
                 (job_id,),

--- a/tests/test_manual_external_sent.py
+++ b/tests/test_manual_external_sent.py
@@ -78,3 +78,35 @@ def test_manual_sent_requires_explicit_confirmation():
                 mark_external_jobs_sent(db, ["external"], confirmed=False)
         finally:
             db.close()
+
+
+def test_manual_sent_falls_back_to_platform_code_when_label_missing(monkeypatch):
+    """Regression: unknown source_platform must not raise KeyError.
+
+    If EXTERNAL_MANUAL_SEND_PLATFORMS is later extended (e.g. to include
+    'boss'), the detail string must fall back to the raw platform code
+    instead of crashing the whole batch with a KeyError.
+    """
+    import bosshunter.db as db_module
+
+    monkeypatch.setattr(
+        db_module,
+        "EXTERNAL_MANUAL_SEND_PLATFORMS",
+        db_module.EXTERNAL_MANUAL_SEND_PLATFORMS | {"boss"},
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        db = get_db(Path(temporary) / "jobs.db")
+        try:
+            insert_job(db, _job("boss-extra", "boss"))
+            result = mark_external_jobs_sent(db, ["boss-extra"], confirmed=True)
+            history = db.execute(
+                "SELECT action, detail FROM history WHERE job_id = ? ORDER BY id",
+                ("boss-extra",),
+            ).fetchall()
+        finally:
+            db.close()
+
+    assert result["affected_count"] == 1
+    assert [(row["action"], row["detail"]) for row in history] == [
+        ("manual_sent", "用户在boss完成投递后手动标记"),
+    ]


### PR DESCRIPTION
platform_labels 改用 .get(platform, platform) 兜底，避免未来扩展 EXTERNAL_MANUAL_SEND_PLATFORMS 时未登记平台导致整批手动标记失败。新增回归测试验证未知平台回退到平台代码而非崩溃。

## 这次改变了什么

请说明修改内容和原因。

## 证据与影响范围

- 关联 Issue：
- 影响的项目或规则：
- 是否涉及许可证、资金、权限或个人信息：否

## 自检

- [ ] 项目状态、赞助、金额、用户反馈和维护信息均有真实依据
- [ ] 贡献署名和贡献者名单继续由对应项目维护
- [ ] 中英文主页的共同事实已同步
