### PR TITLE
Test/51job pagination

### DIFF
--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -350,7 +350,10 @@ def mark_external_jobs_sent(conn: sqlite3.Connection, job_ids: Any, *, confirmed
         for row in pending_rows:
             job_id = str(row["id"])
             platform = str(row.get("source_platform") or "")
-            detail = f"用户在{platform_labels[platform]}完成投递后手动标记"
+            # 用 .get 兜底，避免未来扩展 EXTERNAL_MANUAL_SEND_PLATFORMS 时
+            # 出现未登记平台导致 KeyError 使整批标记失败。
+            platform_label = platform_labels.get(platform, platform)
+            detail = f"用户在{platform_label}完成投递后手动标记"
             conn.execute(
                 "UPDATE jobs SET status = 'sent', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND deleted_at IS NULL",
                 (job_id,),

--- a/tests/test_job51_collector.py
+++ b/tests/test_job51_collector.py
@@ -172,6 +172,122 @@ class Job51CollectorTests(TestCase):
         self.assertEqual(sleeps, [0.75, 0.75])
 
 
+    def test_multi_page_collection_clicks_next_and_applies_pacing(self):
+        # 覆盖 page>1 的翻页分支（此前无测试）：第一页采集后点击下一页，
+        # 第二页再次渲染出岗位；翻页安全间隔应被施加一次。
+        list_calls = {"n": 0}
+        next_clicks = []
+
+        def evaluate(target, script):
+            if ".joblist-item" in script:
+                list_calls["n"] += 1
+                if list_calls["n"] == 1:
+                    return json.dumps({"status": "ready", "jobs": [{
+                        "source_job_id": "job-p1",
+                        "title": "AI 算法工程师",
+                        "company": "示例公司",
+                        "city": "上海",
+                        "url": "https://jobs.51job.com/shanghai/job-p1.html",
+                    }]})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-p2",
+                    "title": "AI 数据工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://jobs.51job.com/shanghai/job-p2.html",
+                }]})
+            if "btn-next" in script:
+                next_clicks.append(script)
+                return True  # 模拟存在下一页按钮
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 平台研发。",
+            })
+
+        browser = Job51Browser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = Job51Collector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=2),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual(
+            [c.storage_id for c in collected],
+            ["51job:job-p1", "51job:job-p2"],
+        )
+        # 第二页触发了一次 JS_CLICK_NEXT 调用
+        self.assertEqual(len(next_clicks), 1)
+
+    def test_last_page_without_next_button_completes_gracefully(self):
+        # 翻到第二页时若已无下一页按钮（JS_CLICK_NEXT 返回 False），
+        # 应优雅结束而非报错。
+        list_calls = {"n": 0}
+
+        def evaluate(target, script):
+            if ".joblist-item" in script:
+                list_calls["n"] += 1
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": f"job-{list_calls['n']}",
+                    "title": "AI 工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": f"https://jobs.51job.com/shanghai/job-{list_calls['n']}.html",
+                }]})
+            if "btn-next" in script:
+                return False  # 最后一页，无下一页按钮
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 研发。",
+            })
+
+        browser = Job51Browser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = Job51Collector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=3),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual([c.storage_id for c in collected], ["51job:job-1"])
+
+
 class JobDescriptionCleanupTests(TestCase):
     def test_known_platform_source_noise_is_removed(self):
         dirty = "[岗位kanzhun职责]1.公司业务后台开发 来自BOSS直聘 2.掌握 SQL"

--- a/tests/test_manual_external_sent.py
+++ b/tests/test_manual_external_sent.py
@@ -78,3 +78,35 @@ def test_manual_sent_requires_explicit_confirmation():
                 mark_external_jobs_sent(db, ["external"], confirmed=False)
         finally:
             db.close()
+
+
+def test_manual_sent_falls_back_to_platform_code_when_label_missing(monkeypatch):
+    """Regression: unknown source_platform must not raise KeyError.
+
+    If EXTERNAL_MANUAL_SEND_PLATFORMS is later extended (e.g. to include
+    'boss'), the detail string must fall back to the raw platform code
+    instead of crashing the whole batch with a KeyError.
+    """
+    import bosshunter.db as db_module
+
+    monkeypatch.setattr(
+        db_module,
+        "EXTERNAL_MANUAL_SEND_PLATFORMS",
+        db_module.EXTERNAL_MANUAL_SEND_PLATFORMS | {"boss"},
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        db = get_db(Path(temporary) / "jobs.db")
+        try:
+            insert_job(db, _job("boss-extra", "boss"))
+            result = mark_external_jobs_sent(db, ["boss-extra"], confirmed=True)
+            history = db.execute(
+                "SELECT action, detail FROM history WHERE job_id = ? ORDER BY id",
+                ("boss-extra",),
+            ).fetchall()
+        finally:
+            db.close()
+
+    assert result["affected_count"] == 1
+    assert [(row["action"], row["detail"]) for row in history] == [
+        ("manual_sent", "用户在boss完成投递后手动标记"),
+    ]

--- a/tests/test_run_store_boundaries.py
+++ b/tests/test_run_store_boundaries.py
@@ -1,0 +1,170 @@
+"""Boundary tests for collection/scoring run stores (DB layer).
+
+These cover JSON round-tripping, terminal-status side effects, limit
+clamping and orphan recovery without touching network or AI paths.
+"""
+
+import tempfile
+from pathlib import Path
+
+from bosshunter.collection_run_store import (
+    create_collection_run,
+    get_collection_run,
+    list_collection_runs,
+    mark_orphaned_collection_runs_stopped,
+    update_collection_run,
+)
+from bosshunter.scoring_run_store import (
+    TERMINAL_RUN_STATUSES,
+    create_scoring_run,
+    get_scoring_run,
+    list_scoring_runs,
+    mark_orphaned_scoring_runs_paused,
+    update_scoring_run,
+)
+
+
+def _tmp_db() -> Path:
+    return Path(tempfile.mkdtemp()) / "runs.db"
+
+
+# ---------------------------------------------------------------------------
+# collection_run_store
+# ---------------------------------------------------------------------------
+
+
+def test_create_then_get_decodes_json_fields():
+    db = _tmp_db()
+    create_collection_run(
+        db,
+        run_id="run-1",
+        options={"city": "北京", "keyword": "Python"},
+        platform_states={"zhilian": {"page": 3}},
+    )
+    row = get_collection_run(db, "run-1")
+    assert row is not None
+    assert row["options"] == {"city": "北京", "keyword": "Python"}
+    assert row["platform_states"] == {"zhilian": {"page": 3}}
+    assert row["collected_job_ids"] == []
+
+
+def test_get_missing_collection_run_returns_none():
+    db = _tmp_db()
+    assert get_collection_run(db, "nope") is None
+
+
+def test_terminal_status_sets_finished_at():
+    db = _tmp_db()
+    create_collection_run(db, run_id="run-1", options={}, platform_states={})
+    update_collection_run(db, "run-1", status="completed")
+    row = get_collection_run(db, "run-1")
+    assert row["status"] == "completed"
+    assert row["finished_at"] is not None
+
+
+def test_non_terminal_status_does_not_set_finished_at():
+    db = _tmp_db()
+    create_collection_run(db, run_id="run-1", options={}, platform_states={})
+    update_collection_run(db, "run-1", status="running")
+    row = get_collection_run(db, "run-1")
+    assert row["finished_at"] is None
+
+
+def test_list_collection_runs_clamps_limit():
+    db = _tmp_db()
+    for i in range(5):
+        create_collection_run(db, run_id=f"run-{i}", options={}, platform_states={})
+    assert len(list_collection_runs(db, limit=0)) == 1      # <1 clamped to 1
+    assert len(list_collection_runs(db, limit=2)) == 2
+    assert len(list_collection_runs(db, limit=9999)) == 5    # >100 clamped (only 5 exist)
+
+
+def test_mark_orphaned_collection_runs_only_affects_active():
+    db = _tmp_db()
+    create_collection_run(db, run_id="active", options={}, platform_states={})
+    create_collection_run(db, run_id="done", options={}, platform_states={})
+    update_collection_run(db, "done", status="completed")
+
+    affected = mark_orphaned_collection_runs_stopped(db)
+    assert affected == 1
+    assert get_collection_run(db, "active")["status"] == "stopped"
+    assert get_collection_run(db, "done")["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# scoring_run_store
+# ---------------------------------------------------------------------------
+
+
+def test_create_scoring_run_initializes_progress():
+    db = _tmp_db()
+    run = create_scoring_run(db, run_id="s-1", options={"model": "x"}, job_ids=["a", "b", "c"])
+    assert run["options"] == {"model": "x"}
+    assert run["remaining_job_ids"] == ["a", "b", "c"]
+    assert run["progress"] == {"selected": 3, "completed": 0}
+    assert run["recoverable"] is False
+
+
+def test_recoverable_true_only_when_paused_with_remaining():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="paused", remaining_job_ids=["a"])
+    assert get_scoring_run(db, "s-1")["recoverable"] is True
+
+    update_scoring_run(db, "s-1", status="paused", remaining_job_ids=[])
+    assert get_scoring_run(db, "s-1")["recoverable"] is False
+
+
+def test_scoring_terminal_status_sets_finished_at():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="completed")
+    assert get_scoring_run(db, "s-1")["finished_at"] is not None
+
+
+def test_scoring_running_clears_finished_and_error():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="failed", error="boom")
+    update_scoring_run(db, "s-1", status="running")
+    row = get_scoring_run(db, "s-1")
+    assert row["status"] == "running"
+    assert row["finished_at"] is None
+    assert row["error"] is None
+
+
+def test_scoring_running_cannot_resurrect_terminal_run():
+    # 已终态的 run 不应被 update_scoring_run(running=...) 改回 running，
+    # 这是由 WHERE status NOT IN (终态) 保护的安全边界。
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="completed")
+    update_scoring_run(db, "s-1", status="running")
+    assert get_scoring_run(db, "s-1")["status"] == "completed"
+
+
+def test_mark_orphaned_scoring_runs_pauses_active_only():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="active", options={}, job_ids=["a"])
+    create_scoring_run(db, run_id="done", options={}, job_ids=["b"])
+    update_scoring_run(db, "done", status="completed")
+
+    affected = mark_orphaned_scoring_runs_paused(db)
+    assert affected == 1
+    assert get_scoring_run(db, "active")["status"] == "paused"
+    assert get_scoring_run(db, "done")["status"] == "completed"
+
+
+def test_list_scoring_runs_returns_decoded_rows():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={"k": 1}, job_ids=["a"])
+    rows = list_scoring_runs(db, limit=10)
+    assert len(rows) == 1
+    assert rows[0]["options"] == {"k": 1}
+    assert rows[0]["remaining_job_ids"] == ["a"]
+
+
+def test_terminal_run_statuses_are_consistent():
+    # 防御性测试：确保 TERMINAL_RUN_STATUSES 与 update 逻辑认知一致，
+    # 后续若有人改动常量不会破坏终态判断。
+    assert TERMINAL_RUN_STATUSES == {"completed", "completed_with_errors", "failed", "stopped"}


### PR DESCRIPTION
## 申请维护域

- [ ] 核心与安全
- [x] 产品与 AI
- [x] 平台适配

> 说明：首选「平台适配」域（当前空缺、由项目负责人代管，且我的已有贡献集中在该域的 collection/scoring 数据层）；同时勾选「产品与 AI」作为次选，因为我对 ai/ 评分相关测试也有兴趣。如项目负责人认为更合适只挂一个域，以平台适配为准。

## 相关贡献
https://github.com/yuppiez99999/BossHunter/pull/new/fix/platform-labels-keyerror
https://github.com/yuppiez99999/BossHunter/pull/new/test/run-store-boundaries
https://github.com/yuppiez99999/BossHunter/pull/new/test/51job-pagination

## 可持续投入

未来 1–3 个月预计每周可投入 5–10 小时；通常能在 24–48 小时内响应负责范围内的 Issue 与 PR Review。

## 维护经验

工程方向：Python 后端、数据库与测试工程。希望负责的具体范围：平台适配域下的 `collection/`、`scraper/`、`cities.py`、`job_filters.py`、只读采集 fixture 及其测试；并愿意承担该域 Issue 分类、PR Review 与回归守护。

## 安全边界确认

- [x] 我不会提交或批准绕过人工确认的功能。
- [x] 我不会提交或批准提高默认发送频率、降低节流或规避平台安全机制的功能。
- [x] 我不会收集、上传或外发用户的简历、凭据和本地求职数据。
- [x] 我理解候选观察期通常为 2–4 周，申请不代表立即获得 `Write` 权限。
- [x] 我同意维护者身份、任期和负责范围在正式晋升后公开记录。

## 利益冲突

无。

