### PR TITLE
ci: ruff 强制化 + 全量测试进 CI + 清理存量 lint 违规

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,23 @@ on:
     branches: [main]
 
 jobs:
-  smoke-test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff (version pinned in pyproject [dev])
+        run: pip install "ruff==0.16.0"
+
+      - name: Lint (blocking)
+        run: ruff check src/
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,8 +37,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package
-        run: pip install -e .
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Verify CLI entry point
         run: bosshunter --help
@@ -33,8 +49,5 @@ jobs:
       - name: Run import check
         run: python -c "import bosshunter; print(bosshunter.__version__)"
 
-      - name: Lint with ruff (if available)
-        run: |
-          pip install ruff
-          ruff check src/
-        continue-on-error: true
+      - name: Run tests
+        run: python -m pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,13 @@
 1. Fork 仓库
 2. 基于 `main` 创建功能分支：`git checkout -b feat/your-feature`
 3. 提交代码，确保 `bosshunter --help` 正常运行
-4. 运行相关测试；涉及前端时同时确认前端可以构建
+4. 运行相关测试（`python -m pytest`）；涉及前端时同时确认前端可以构建
 5. 推送并创建 Pull Request
 6. 等待对应维护域的 review
 
 ### 代码风格
 
-- Python: 遵循 ruff 默认规则，行长 120
+- Python: 遵循 ruff 规则（`E4`/`E7`/`E9`/`F`，显式声明于 pyproject），行长 120
 - 提交信息：中文或英文均可，简洁描述改动
 
 ## 本地开发
@@ -52,6 +52,9 @@ pip install -e ".[dev]"
 
 # 检查代码风格
 ruff check src/
+
+# 运行测试
+python -m pytest
 
 # 运行 CLI
 bosshunter --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
 pdf = [
     "xhtml2pdf>=0.2.11",
 ]
+dev = [
+    "pytest>=8.0",
+    "ruff==0.16.0",
+]
 
 [project.scripts]
 bosshunter = "bosshunter.main:cli"
@@ -43,6 +47,10 @@ pythonpath = ["src"]
 [tool.ruff]
 line-length = 120
 indent-width = 4
+
+[tool.ruff.lint]
+# 显式声明，避免依赖 ruff 默认规则集随版本漂移（新版默认集远大于 E/F）
+select = ["E4", "E7", "E9", "F"]
 
 [tool.ruff.format]
 indent-style = "tab"

--- a/src/bosshunter/cities.py
+++ b/src/bosshunter/cities.py
@@ -8,7 +8,6 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import urlparse
 
 import httpx
 

--- a/src/bosshunter/collection/platforms/boss.py
+++ b/src/bosshunter/collection/platforms/boss.py
@@ -13,7 +13,7 @@ from urllib.parse import quote
 
 from bosshunter.ai.prefilter import quick_score
 from bosshunter.browser import close_tab, evaluate, navigate, new_tab, scroll, wait_for_load
-from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.collection.base import CollectorHooks
 from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
 from bosshunter.config import CITY_CODES
 from bosshunter.db import add_risk_event
@@ -307,10 +307,13 @@ class BossCollector:
                         return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
                     hooks.on_event(phase="loading_list", keyword=keyword, city=city, page=page)
                     search_url = SEARCH_URL.format(keyword=quote(keyword), city_code=city_code)
-                    if request.sort == "newest": search_url += "&sortType=2"
-                    if page > 1: search_url += f"&page={page}"
+                    if request.sort == "newest":
+                        search_url += "&sortType=2"
+                    if page > 1:
+                        search_url += f"&page={page}"
                     try:
-                        if guard is not None: guard.reserve("search_page", daily_limit=search_limit)
+                        if guard is not None:
+                            guard.reserve("search_page", daily_limit=search_limit)
                     except PlatformSafetyStop as exc:
                         return limited(exc.reason)
                     opened = self.browser.new_tab(search_url, background=True) if worker_target is None else self.browser.navigate(worker_target, search_url)
@@ -318,7 +321,8 @@ class BossCollector:
                         worker_target = str(opened)
                     if not opened or worker_target is None:
                         page_failures += 1
-                        if page_failures >= failure_limit: return page_failure_stop()
+                        if page_failures >= failure_limit:
+                            return page_failure_stop()
                         continue
                     if _wait_or_stop(hooks.stop_event, 3 * delay_multiplier, self.sleep):
                         return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
@@ -326,7 +330,8 @@ class BossCollector:
                     signal = confirm_risk(worker_target)
                     if signal and signal["kind"] == "user_stopped":
                         return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                    if signal: return risk(signal["kind"], signal["evidence"])
+                    if signal:
+                        return risk(signal["kind"], signal["evidence"])
                     self.browser.scroll(worker_target, y=2000)
                     if _wait_or_stop(hooks.stop_event, 1.5 * delay_multiplier, self.sleep):
                         return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
@@ -338,16 +343,19 @@ class BossCollector:
                         jobs = None
                     if not isinstance(jobs, list):
                         page_failures += 1
-                        if page_failures >= failure_limit: return page_failure_stop()
+                        if page_failures >= failure_limit:
+                            return page_failure_stop()
                         hooks.on_parse_failed("BOSS 列表解析失败")
                         continue
                     page_failures = 0
-                    if not jobs: break
+                    if not jobs:
+                        break
                     for raw in jobs:
                         if hooks.stop_event is not None and hooks.stop_event.is_set():
                             return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
                         candidate = self._list_candidate(raw, city, city_code, keyword)
-                        if not candidate or not hooks.on_list_candidate(candidate): continue
+                        if not candidate or not hooks.on_list_candidate(candidate):
+                            continue
                         if self.config and quick_score(raw if isinstance(raw, dict) else {}, self.config)[0] <= 0:
                             hooks.on_event(message="BOSS 列表预筛不通过", increment_filtered=True)
                             continue
@@ -355,13 +363,15 @@ class BossCollector:
                             return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
                         detail_url = f"https://www.zhipin.com{candidate.url}"
                         try:
-                            if guard is not None: guard.reserve("detail_page", daily_limit=detail_limit)
+                            if guard is not None:
+                                guard.reserve("detail_page", daily_limit=detail_limit)
                         except PlatformSafetyStop as exc:
                             return limited(exc.reason)
                         if not self.browser.navigate(worker_target, detail_url):
                             page_failures += 1
                             hooks.on_parse_failed("无法打开 BOSS 详情页")
-                            if page_failures >= failure_limit: return page_failure_stop()
+                            if page_failures >= failure_limit:
+                                return page_failure_stop()
                             continue
                         if _wait_or_stop(hooks.stop_event, 2 * delay_multiplier, self.sleep):
                             return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
@@ -369,7 +379,8 @@ class BossCollector:
                         signal = confirm_risk(worker_target)
                         if signal and signal["kind"] == "user_stopped":
                             return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                        if signal: return risk(signal["kind"], signal["evidence"])
+                        if signal:
+                            return risk(signal["kind"], signal["evidence"])
                         detail_result = self.browser.evaluate(worker_target, JS_EXTRACT_DETAIL)
                         try:
                             detail = json.loads(detail_result) if detail_result else None
@@ -378,7 +389,8 @@ class BossCollector:
                         if not isinstance(detail, dict):
                             page_failures += 1
                             hooks.on_parse_failed("BOSS 详情解析失败")
-                            if page_failures >= failure_limit: return page_failure_stop()
+                            if page_failures >= failure_limit:
+                                return page_failure_stop()
                             continue
                         page_failures = 0
                         merged = self._merge_detail(candidate, detail, detail_url)

--- a/src/bosshunter/collection_run_store.py
+++ b/src/bosshunter/collection_run_store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
 from typing import Any
 

--- a/src/bosshunter/scraper/jobs.py
+++ b/src/bosshunter/scraper/jobs.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import time
 
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn
+
+# 模块内未直接使用，但 tests 通过 mock.patch("bosshunter.scraper.jobs.Progress") 依赖此属性
+from rich.progress import Progress, SpinnerColumn, TextColumn  # noqa: F401
 
 from bosshunter.browser import close_tab, evaluate, navigate, new_tab, scroll, wait_for_load
 from bosshunter.cancellation import get_stop_event

--- a/src/bosshunter/web/preflight.py
+++ b/src/bosshunter/web/preflight.py
@@ -6,7 +6,6 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
 
 import httpx
 

--- a/src/bosshunter/web/server.py
+++ b/src/bosshunter/web/server.py
@@ -517,7 +517,7 @@ def _execute_monitor(task: WorkbenchTask, config: dict, *, initial_cooldown: boo
 	monitor_config["_workbench_stop_event"] = task.stop_requested
 	interval_min = get_effective_monitor_interval_minutes(config)
 	interval_sec = max(interval_min * 60, 1)
-	queue_lock = task.context.setdefault("monitor_queue_lock", Lock())
+	task.context.setdefault("monitor_queue_lock", Lock())
 	wakeup_event = task.context.setdefault("monitor_wakeup_event", Event())
 	task.context["monitoring"] = True
 	try:
@@ -1698,7 +1698,6 @@ def api_config_get():
 @app.route("/api/config", method="POST")
 def api_config_post():
 	try:
-		import yaml
 		data = request.json
 		if not data:
 			return _json_response({"error": "Empty body"}, 400)
@@ -2003,7 +2002,6 @@ def api_resume_get():
 @app.route("/api/resume/upload", method="POST")
 def api_resume_upload():
 	try:
-		import yaml
 		upload = request.files.get("file")
 		if not upload:
 			return _json_response({"error": "No file uploaded"}, 400)
@@ -2041,7 +2039,6 @@ def api_resume_upload():
 @app.route("/api/resume", method="DELETE")
 def api_resume_delete():
 	try:
-		import yaml
 		config = load_config(CONFIG_PATH)
 
 		# Never delete the master resume from disk; only detach it from config.

--- a/tests/test_ai_services.py
+++ b/tests/test_ai_services.py
@@ -13,7 +13,7 @@ from bosshunter.main import cli
 
 class AiServiceConfigTests(unittest.TestCase):
 	def test_legacy_openai_compatible_config_is_preserved_as_custom_service(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"provider": "openai_compatible", "model": "legacy-model"}}),
@@ -27,7 +27,7 @@ class AiServiceConfigTests(unittest.TestCase):
 		self.assertEqual(config["ai"]["model"], "legacy-model")
 
 	def test_deepseek_service_selects_openai_compatible_protocol(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"service": "deepseek", "model": "provider-current-model"}}),
@@ -43,7 +43,7 @@ class AiServiceConfigTests(unittest.TestCase):
 class AiStatusCliTests(unittest.TestCase):
 	def test_ai_status_reports_connection_without_printing_key(self):
 		original_cwd = Path.cwd()
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"service": "deepseek", "model": "provider-current-model"}}),

--- a/tests/test_browser_runtime.py
+++ b/tests/test_browser_runtime.py
@@ -11,7 +11,7 @@ from bosshunter.config import load_config
 
 class BrowserRuntimeConfigTests(unittest.TestCase):
     def test_browser_defaults_are_loaded(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config = load_config(Path(tmp) / "missing.yaml")
 
         self.assertEqual(config["browser"]["runtime"], "builtin")
@@ -23,7 +23,7 @@ class BrowserRuntimeConfigTests(unittest.TestCase):
         self.assertTrue(config["browser"]["site_patterns"])
 
     def test_browser_config_overrides_merge_with_defaults(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = Path(tmp) / "config.yaml"
             config_path.write_text(
                 yaml.dump({"browser": {"proxy_port": 4567, "auto_start_proxy": False}}, sort_keys=False),

--- a/tests/test_collection_orchestrator.py
+++ b/tests/test_collection_orchestrator.py
@@ -76,7 +76,7 @@ class CollectionOrchestratorTests(TestCase):
             "boss": lambda: _FakeCollector("boss", events, boss_candidates),
             "zhilian": lambda: _FakeCollector("zhilian", events, zhilian_candidates),
         })
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "collection.db"
             db = get_db(db_path)
             try:
@@ -114,7 +114,7 @@ class CollectionOrchestratorTests(TestCase):
     def test_auto_score_is_opt_in_and_receives_only_this_run_ids(self):
         candidates = [_candidate("boss", "new-1")]
         registry = CollectorRegistry({"boss": lambda: _FakeCollector("boss", [], candidates)})
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "collection.db"
             with patch("bosshunter.ai.scorer.score_jobs") as score_jobs:
                 result = CollectionOrchestrator({}, db_path=db_path, registry=registry).run(
@@ -127,7 +127,7 @@ class CollectionOrchestratorTests(TestCase):
         self.assertFalse(kwargs["force_rescore"])
         self.assertEqual(result["collected_job_ids"], ["new-1"])
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             with patch("bosshunter.ai.scorer.score_jobs") as score_jobs:
                 CollectionOrchestrator({}, db_path=Path(tmp) / "collection.db", registry=registry).run(
                     _options(auto_score=False)
@@ -141,7 +141,7 @@ class CollectionOrchestratorTests(TestCase):
             "boss": lambda: _FakeCollector("boss", events, [_candidate("boss", "one")], stop=True),
             "zhilian": lambda: _FakeCollector("zhilian", events, [_candidate("zhilian", "two")]),
         })
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config = {"_workbench_stop_event": stop_event}
             with patch("bosshunter.ai.scorer.score_jobs") as score_jobs:
                 result = CollectionOrchestrator(config, db_path=Path(tmp) / "collection.db", registry=registry).run(

--- a/tests/test_collection_runs.py
+++ b/tests/test_collection_runs.py
@@ -14,7 +14,7 @@ from bosshunter.db import get_db, insert_job
 
 class CollectionRunAndMigrationTests(TestCase):
     def test_source_migration_is_idempotent_and_preserves_legacy_boss_rows(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             path = Path(tmp) / "jobs.db"
             db = get_db(path)
             insert_job(db, {
@@ -44,7 +44,7 @@ class CollectionRunAndMigrationTests(TestCase):
         self.assertEqual(dict(legacy), {"id": "legacy-boss-1", "source_platform": "boss", "source_job_id": None})
 
     def test_collection_run_checkpoint_persists_platform_progress_and_restart_stop(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             path = Path(tmp) / "runs.db"
             options = {"platform_order": ["boss", "zhilian"], "auto_score": False}
             initial_states = {"boss": {"status": "queued"}, "zhilian": {"status": "queued"}}

--- a/tests/test_collection_safety.py
+++ b/tests/test_collection_safety.py
@@ -31,7 +31,7 @@ class CollectionSafetyTests(unittest.TestCase):
         self.assertNotIn("max_search_pages_per_cycle", collection)
 
     def test_retired_count_limits_are_removed_from_existing_config(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = Path(tmp) / "config.yaml"
             config_path.write_text(
                 """
@@ -63,7 +63,7 @@ platforms:
             self.assertNotIn("target_count", config["platforms"][platform]["search"])
 
     def test_daily_access_limit_stops_before_the_next_page(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             guard = PlatformAccessGuard(db, {"safety": {"daily_platform_page_limit": 500}}, "collection")
             for _ in range(30):
@@ -80,7 +80,7 @@ platforms:
             db.close()
 
     def test_global_page_budget_is_shared_across_workflows(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             config = {"safety": {"daily_platform_page_limit": 2}}
             PlatformAccessGuard(db, config, "collection").reserve("search_page")
@@ -93,7 +93,7 @@ platforms:
             db.close()
 
     def test_external_page_events_do_not_consume_boss_page_budget(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             add_platform_access(db, "collection", "search_page", platform="zhilian")
             guard = PlatformAccessGuard(db, {"safety": {"daily_platform_page_limit": 1}}, "collection")
@@ -106,7 +106,7 @@ platforms:
             db.close()
 
     def test_risk_lock_survives_a_new_database_connection(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "bosshunter.db"
             db = get_db(db_path)
             set_platform_safety_lock(db, "captcha", minutes=30)

--- a/tests/test_education_recruitment.py
+++ b/tests/test_education_recruitment.py
@@ -27,7 +27,7 @@ def test_platform_job_record_keeps_education_and_recruitment_type():
 
 
 def test_database_stores_structured_education_fields():
-    with tempfile.TemporaryDirectory() as temporary:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
         db = get_db(Path(temporary) / "jobs.db")
         try:
             inserted = insert_job_if_new(db, {

--- a/tests/test_job_selection.py
+++ b/tests/test_job_selection.py
@@ -539,7 +539,7 @@ class JobSelectionTests(unittest.TestCase):
         job = _job("retry-chat-input")
         job["greeting"] = "您好，我对这个岗位很感兴趣。"
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -569,7 +569,7 @@ class JobSelectionTests(unittest.TestCase):
         job = _job("failed-first-contact")
         job["greeting"] = "您好，我对这个岗位很感兴趣。"
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -603,7 +603,7 @@ class JobSelectionTests(unittest.TestCase):
         for job in jobs:
             job["greeting"] = f"您好，我对 {job['id']} 很感兴趣。"
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -652,7 +652,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual(report["stop_reason"], "daily_limit")
 
     def test_pending_confirmation_excludes_jobs_with_greetings(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 insert_job(db, _job("scored"))
@@ -671,7 +671,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in jobs], ["scored"])
 
     def test_pending_confirmation_keeps_approved_jobs_without_greetings_recoverable(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 insert_job(db, _job("approved"))
@@ -694,7 +694,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in jobs], ["approved"])
 
     def test_rescore_reset_only_requeues_jobs_filtered_by_ai_score(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 for job_id, reason in (
@@ -726,7 +726,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual(rows["ai-failed-spaced"]["status"], "filtered")
 
     def test_funnel_counts_ai_low_scores_but_excludes_prefilter_and_ai_failures(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 for job_id, reason in (
@@ -748,7 +748,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertEqual(stats["AI评分"], 2)
 
     def test_ready_to_send_requires_a_non_empty_greeting(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 insert_job(db, _job("no-greeting"))
@@ -773,7 +773,7 @@ class JobSelectionTests(unittest.TestCase):
         self.assertCountEqual([job["id"] for job in jobs], ["approved", "sendable"])
 
     def test_send_errors_return_only_jobs_with_generated_greetings(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db = get_db(Path(tmp) / "bosshunter.db")
             try:
                 insert_job(db, _job("send-failed"))
@@ -795,7 +795,7 @@ class JobSelectionTests(unittest.TestCase):
 
     def test_send_greetings_force_bypasses_send_window_restriction(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "bosshunter.db"
             db = get_db(db_path)
             try:

--- a/tests/test_manual_external_sent.py
+++ b/tests/test_manual_external_sent.py
@@ -24,7 +24,7 @@ def _job(job_id: str, platform: str) -> dict:
 
 
 def test_external_manual_sent_is_atomic_and_idempotent():
-    with tempfile.TemporaryDirectory() as temporary:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
         db = get_db(Path(temporary) / "jobs.db")
         try:
             insert_job(db, _job("zhilian-manual", "zhilian"))
@@ -48,7 +48,7 @@ def test_external_manual_sent_is_atomic_and_idempotent():
 
 
 def test_manual_sent_rejects_boss_and_does_not_partially_update_external_jobs():
-    with tempfile.TemporaryDirectory() as temporary:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
         db = get_db(Path(temporary) / "jobs.db")
         try:
             insert_job(db, _job("external", "51job"))
@@ -70,7 +70,7 @@ def test_manual_sent_rejects_boss_and_does_not_partially_update_external_jobs():
 
 
 def test_manual_sent_requires_explicit_confirmation():
-    with tempfile.TemporaryDirectory() as temporary:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
         db = get_db(Path(temporary) / "jobs.db")
         try:
             insert_job(db, _job("external", "51job"))

--- a/tests/test_monitor_reply_dismiss.py
+++ b/tests/test_monitor_reply_dismiss.py
@@ -35,7 +35,7 @@ class MonitorReplyDismissTests(unittest.TestCase):
         ]
         pending_detail = monitor._build_reply_detail(messages, "可以，我有AI内容运营经验。")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -94,7 +94,7 @@ class MonitorReplyDismissTests(unittest.TestCase):
         ]
         pending_detail = monitor._build_reply_detail(dismissed_messages, "可以，我有AI内容运营经验。")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -236,7 +236,7 @@ class MonitorReplyDismissTests(unittest.TestCase):
             {"sender": "hr", "text": "可以"},
         ]
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             generated_resume = Path(tmp) / "tailored.md"
             generated_resume.write_text("# 定制简历", encoding="utf-8")
@@ -289,7 +289,7 @@ class MonitorReplyDismissTests(unittest.TestCase):
             {"sender": "hr", "text": "方便发一份你的简历过来吗？"},
         ]
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -343,7 +343,7 @@ class MonitorReplyDismissTests(unittest.TestCase):
             {"sender": "hr", "text": "请发一份简历。"},
         ]
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:

--- a/tests/test_monitor_safety.py
+++ b/tests/test_monitor_safety.py
@@ -132,7 +132,7 @@ class MonitorIdempotencyAndLimitTests(unittest.TestCase):
             {"sender": "hr", "text": "也请补充一个最近的项目案例。"},
         ]
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -189,7 +189,7 @@ class MonitorIdempotencyAndLimitTests(unittest.TestCase):
     def test_chat_list_skips_same_pending_before_opening_and_caps_new_items(self):
         from bosshunter.executor import monitor
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -240,7 +240,7 @@ class MonitorRiskTests(unittest.TestCase):
     def test_captcha_stops_cycle_and_records_only_safe_risk_detail(self):
         from bosshunter.executor import monitor
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
             db = get_db(db_path)
             try:
@@ -272,7 +272,7 @@ class MonitorRiskTests(unittest.TestCase):
     def test_consecutive_page_failures_stop_at_configured_threshold(self):
         from bosshunter.executor import monitor
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             db_path = Path(tmp) / "data" / "bosshunter.db"
 
             def open_db():

--- a/tests/test_platform_delivery_guard.py
+++ b/tests/test_platform_delivery_guard.py
@@ -45,7 +45,7 @@ class PlatformDeliveryGuardTests(TestCase):
             ("zhilian", "zhilian:zl-1", "https://www.zhaopin.com/jobdetail/zl-1.htm"),
             ("51job", "51job:job-1", "https://jobs.51job.com/shanghai/job-1.html"),
         ):
-            with self.subTest(platform=platform), tempfile.TemporaryDirectory() as tmp:
+            with self.subTest(platform=platform), tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
                 base_dir = Path(tmp)
                 db = get_db(base_dir / "data" / "bosshunter.db")
                 try:

--- a/tests/test_regression_small_fixes.py
+++ b/tests/test_regression_small_fixes.py
@@ -92,7 +92,7 @@ class ConfigValidationTests(unittest.TestCase):
     def test_load_config_rejects_unsupported_ai_provider(self):
         from bosshunter.config import load_config
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = Path(tmp) / "config.yaml"
             config_path.write_text("ai:\n  provider: openai\n", encoding="utf-8")
 
@@ -102,7 +102,7 @@ class ConfigValidationTests(unittest.TestCase):
     def test_load_config_defaults_to_not_allowing_internships(self):
         from bosshunter.config import load_config
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = Path(tmp) / "config.yaml"
             config_path.write_text("profile:\n  salary_min: 10\n", encoding="utf-8")
 
@@ -114,7 +114,7 @@ class ConfigValidationTests(unittest.TestCase):
     def test_load_config_defaults_to_disabled_follow_up(self):
         from bosshunter.config import load_config
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = Path(tmp) / "config.yaml"
             config_path.write_text("profile:\n  salary_min: 10\n", encoding="utf-8")
 

--- a/tests/test_resume_pdf_runtime.py
+++ b/tests/test_resume_pdf_runtime.py
@@ -142,7 +142,7 @@ class ResumeArtifactTests(unittest.TestCase):
             f"{RESUME_COMPLETION_MARKER}"
         )
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             resume_path.write_text(
@@ -187,7 +187,7 @@ class ResumeArtifactTests(unittest.TestCase):
         call_claude.return_value = "## 岗位匹配亮点\n以下内容基于原始简历整理。"
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -227,7 +227,7 @@ class ResumeArtifactTests(unittest.TestCase):
         call_claude.return_value = "# 候选人\n\n## 基本信息\n\n面向周围神经外科领域专家及临床医生的专业学术交流项目，围绕周围神经疾病诊疗、手术技术、病例"
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -283,7 +283,7 @@ class ResumeArtifactTests(unittest.TestCase):
         call_claude.return_value = tailored
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -326,7 +326,7 @@ class ResumeArtifactTests(unittest.TestCase):
         get_db.return_value = db
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -398,7 +398,7 @@ class ResumeArtifactTests(unittest.TestCase):
         call_claude.return_value = tailored
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -472,7 +472,7 @@ class ResumeArtifactTests(unittest.TestCase):
         call_claude.side_effect = [overlong_tailored, compressed_tailored]
         render_pdf.return_value = False
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -546,7 +546,7 @@ class ResumeArtifactTests(unittest.TestCase):
 
         render_pdf.side_effect = write_four_page_pdf
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             root = Path(tmp)
             resume_path = root / "resume.md"
             output_dir = root / "out"
@@ -581,7 +581,7 @@ class ResumePdfRuntimeTests(unittest.TestCase):
     def test_render_pdf_via_cdp_uses_browser_facade(self, new_tab, print_pdf, close_tab):
         from bosshunter.ai.resume import _render_pdf_via_cdp
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             output = Path(tmp) / "resume.pdf"
             new_tab.return_value = "target-1"
             print_pdf.side_effect = lambda target, file_path: output.write_bytes(b"pdf") or True
@@ -601,7 +601,7 @@ class ResumePdfRuntimeTests(unittest.TestCase):
     def test_render_pdf_via_cdp_rejects_missing_output_file(self, new_tab, print_pdf, close_tab):
         from bosshunter.ai.resume import _render_pdf_via_cdp
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             output = Path(tmp) / "missing.pdf"
             new_tab.return_value = "target-1"
             print_pdf.return_value = True

--- a/tests/test_scoring_config.py
+++ b/tests/test_scoring_config.py
@@ -19,7 +19,7 @@ class ScoringConfigTests(unittest.TestCase):
         self.assertEqual(get_scoring_concurrency({"ai": {"scoring_concurrency": "invalid"}}), 1)
 
     def test_malformed_config_sections_fall_back_to_safe_defaults(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             path = Path(tmp) / "config.yaml"
             path.write_text("profile: null\nai: invalid\nscoring: null\nmonitor: []\n", encoding="utf-8")
 

--- a/tests/test_web_api_routes.py
+++ b/tests/test_web_api_routes.py
@@ -153,7 +153,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_missing_api_route_returns_json_404_not_spa_html(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             server.set_base_dir(Path(tmp))
 
             # Act
@@ -166,7 +166,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertNotIn("<!doctype html", body.lower())
 
     def test_web_assets_serve_javascript_with_windows_safe_mime_type(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             frontend_dir = Path(tmp)
             assets_dir = frontend_dir / "assets"
             assets_dir.mkdir()
@@ -181,7 +181,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_workbench_preflight_full_returns_json_payload(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             resume_path = base_dir / "resume.md"
             resume_path.write_text("# Resume", encoding="utf-8")
@@ -219,7 +219,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(json.loads(body), {"ok": True, "messages": [], "checks": ready_checks})
 
     def test_web_api_workbench_preflight_supports_rescore_mode(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             resume_path = base_dir / "resume.md"
             resume_path.write_text("# Resume", encoding="utf-8")
@@ -256,7 +256,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_workbench_preflight_full_requires_ai_key(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             resume_path = base_dir / "resume.md"
             resume_path.write_text("# Resume", encoding="utf-8")
@@ -301,7 +301,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_ai_diagnostics_returns_structured_feedback(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -330,7 +330,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_activity_returns_json_without_runtime_name_error(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             server.set_base_dir(Path(tmp))
 
             # Act
@@ -342,7 +342,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(json.loads(body), [])
 
     def test_job_search_filters_keyword_score_salary_and_status(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -387,7 +387,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(payload["offset"], 0)
 
     def test_job_search_salary_overlap_excludes_unparseable_and_paginates(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -417,7 +417,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in payload["items"]], ["middle", "low"])
 
     def test_job_search_supports_whitelisted_column_sorting(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -444,7 +444,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertTrue(invalid_order_status.startswith("400"), invalid_order_body)
 
     def test_job_search_decodes_chinese_keyword_as_utf8(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -462,7 +462,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in payload["items"]], ["chinese-keyword"])
 
     def test_job_search_orders_newest_jobs_before_higher_scored_older_jobs(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -494,7 +494,7 @@ class WebApiRouteTests(unittest.TestCase):
         )
 
     def test_job_search_filters_jobs_by_collection_time(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -528,7 +528,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in today_payload["items"]], ["today"])
 
     def test_job_search_rejects_invalid_numeric_ranges(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             server.set_base_dir(Path(tmp))
             paths = [
                 "/api/jobs/search?min_score=not-a-number",
@@ -544,7 +544,7 @@ class WebApiRouteTests(unittest.TestCase):
                 self.assertIn("error", json.loads(body))
 
     def test_legacy_jobs_endpoint_still_returns_an_array(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -560,7 +560,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_workbench_pending_confirmation_returns_ready_jobs(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -581,7 +581,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual([job["id"] for job in payload["pending_confirmation"]], ["ready-job"])
 
     def test_workbench_excludes_collection_only_platforms_from_automatic_delivery(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -601,7 +601,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(payload["pending_confirmation"], [])
 
     def test_web_api_workbench_reports_daily_send_quota(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -623,7 +623,7 @@ class WebApiRouteTests(unittest.TestCase):
         })
 
     def test_web_api_workbench_shows_approved_job_when_greeting_was_interrupted(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -644,7 +644,7 @@ class WebApiRouteTests(unittest.TestCase):
         )
 
     def test_workbench_returns_today_and_cumulative_funnel_counts(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -692,7 +692,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner._executors["full"] = lambda task, config: server._execute_full(task, config)
 
         # Act
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -840,7 +840,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner._executors["full"] = lambda task, config: server._execute_full(task, config)
 
         # Act
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             server.set_base_dir(Path(tmp))
             with patch.object(server, "_execute_collect", side_effect=fake_collect):
                 task = runner.start("full", {})
@@ -864,7 +864,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner = WorkbenchTaskRunner()
         runner._tasks[full_task.id] = full_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -912,7 +912,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(json.loads(response_body)["id"], "full-task")
 
     def test_web_api_manual_sent_records_external_send_without_using_boss_quota(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -950,7 +950,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual([item["action"] for item in history], ["manual_sent"])
 
     def test_web_api_deliver_rejects_already_sent_jobs(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -971,7 +971,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(json.loads(body)["invalid_ids"], ["already-sent"])
 
     def test_web_api_direct_send_requires_a_retryable_greeting(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -995,7 +995,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner = WorkbenchTaskRunner()
         runner._tasks[full_task.id] = full_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1040,7 +1040,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner = WorkbenchTaskRunner()
         runner._tasks[full_task.id] = full_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1111,7 +1111,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner = WorkbenchTaskRunner()
         runner._tasks[active_task.id] = active_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1201,7 +1201,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner._tasks[stale_task.id] = stale_task
         runner._tasks[active_task.id] = active_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1255,7 +1255,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner = WorkbenchTaskRunner()
         runner._tasks[active_task.id] = active_task
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1310,7 +1310,7 @@ class WebApiRouteTests(unittest.TestCase):
         runner._executors["full"] = lambda task, config: server._execute_full(task, config)
 
         # Act
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1350,7 +1350,7 @@ class WebApiRouteTests(unittest.TestCase):
             "delivery_requested": True,
         })
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1392,7 +1392,7 @@ class WebApiRouteTests(unittest.TestCase):
             calls.append("collect")
 
         # Act
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1466,7 +1466,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_workbench_reject_marks_selected_ready_jobs_rejected(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1542,7 +1542,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_workbench_reject_removes_jobs_from_pending_confirmation(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1591,7 +1591,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_resume_delete_only_detaches_config_and_keeps_master_resume_file(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             resume_path = base_dir / "data" / "resumes" / "_AI_Homepage.md"
             resume_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1614,7 +1614,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_resume_upload_preserves_chinese_markdown_filename(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1651,7 +1651,7 @@ class WebApiRouteTests(unittest.TestCase):
         with ZipFile(docx_buffer, "w") as archive:
             archive.writestr("word/document.xml", document_xml)
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1690,7 +1690,7 @@ class WebApiRouteTests(unittest.TestCase):
         pdf = io.BytesIO()
         writer.write(pdf)
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1711,7 +1711,7 @@ class WebApiRouteTests(unittest.TestCase):
         pdf = io.BytesIO()
         writer.write(pdf)
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1721,7 +1721,7 @@ class WebApiRouteTests(unittest.TestCase):
         self.assertEqual(json.loads(body), {"error": "PDF 已加密，请上传未加密的简历"})
 
     def test_web_api_resume_upload_rejects_damaged_pdf(self):
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1736,7 +1736,7 @@ class WebApiRouteTests(unittest.TestCase):
         pdf = io.BytesIO()
         writer.write(pdf)
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1747,7 +1747,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_resume_upload_rejects_legacy_doc_format(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             (base_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
             server.set_base_dir(base_dir)
@@ -1761,7 +1761,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_history_dismiss_reply_adds_dismissed_history_without_rejecting_job(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1831,7 +1831,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_history_reply_records_resolution_history(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1901,7 +1901,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_unresolved_count_includes_resume_failures_and_excludes_resolved_rows(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1928,7 +1928,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_history_can_include_unresolved_resume_failures_outside_recent_limit(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:
@@ -1956,7 +1956,7 @@ class WebApiRouteTests(unittest.TestCase):
 
     def test_web_api_history_exposes_structured_failure_reason_and_resolution_state(self):
         # Arrange
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             base_dir = Path(tmp)
             db = get_db(base_dir / "data" / "bosshunter.db")
             try:

--- a/tests/test_web_config_api.py
+++ b/tests/test_web_config_api.py
@@ -33,7 +33,7 @@ class WebConfigApiTests(unittest.TestCase):
 		self.assertNotIn("auth_token_masked", payload)
 
 	def test_write_config_replaces_the_file_without_leaving_a_temp_file(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text("ai:\n  model: old\n", encoding="utf-8")
 
@@ -44,7 +44,7 @@ class WebConfigApiTests(unittest.TestCase):
 			self.assertEqual(list(Path(tmp).glob(".config.*.tmp")), [])
 
 	def test_sanitize_config_strips_display_fields_and_preserves_blank_key(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"api_key": "test-api-key-12345678", "model": "old"}}, sort_keys=False),
@@ -81,7 +81,7 @@ class WebConfigApiTests(unittest.TestCase):
 			self.assertEqual(cleaned["platforms"][platform]["search"], {})
 
 	def test_sanitize_config_preserves_omitted_api_key(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"api_key": "test-api-key-12345678", "model": "old"}}, sort_keys=False),
@@ -101,7 +101,7 @@ class WebConfigApiTests(unittest.TestCase):
 		self.assertNotIn("api_key_masked", cleaned["ai"])
 
 	def test_sanitize_config_accepts_new_api_key(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"api_key": "test-api-key-old", "model": "old"}}, sort_keys=False),
@@ -121,7 +121,7 @@ class WebConfigApiTests(unittest.TestCase):
 
 	def test_sanitize_config_forces_fixed_anthropic_provider(self):
 		# Arrange
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(yaml.dump({"ai": {"provider": "anthropic"}}, sort_keys=False), encoding="utf-8")
 
@@ -134,7 +134,7 @@ class WebConfigApiTests(unittest.TestCase):
 		self.assertEqual(cleaned["ai"]["model"], "claude-sonnet-4-6")
 
 	def test_sanitize_config_maps_deepseek_service_and_clears_old_credentials(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump(
@@ -166,7 +166,7 @@ class WebConfigApiTests(unittest.TestCase):
 		self.assertNotIn("clear_credentials", cleaned["ai"])
 
 	def test_sanitize_config_keeps_new_key_while_clearing_old_auth_token(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump(
@@ -205,7 +205,7 @@ class WebConfigApiTests(unittest.TestCase):
 		self.assertEqual(config["ai"]["auth_token"], "auth-token-12345678")
 
 	def test_sanitize_config_strips_auth_token_display_fields_and_preserves_blank_token(self):
-		with tempfile.TemporaryDirectory() as tmp:
+		with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
 			config_path = Path(tmp) / "config.yaml"
 			config_path.write_text(
 				yaml.dump({"ai": {"auth_token": "auth-token-12345678", "model": "old"}}, sort_keys=False),


### PR DESCRIPTION
## 背景

GOVERNANCE.md 要求默认分支改动必须过 PR + CI 检查，但当前 CI 存在两个缺口：

1. **ruff 不挡合并且未锁版本**——新版 ruff（0.16+）默认规则集大幅扩大，`ruff check src/` 实际已报 ~144 个违规，一直被 `continue-on-error: true` 掩盖；一旦有人去掉该开关 CI 会直接变红
2. **pytest 从未在 CI 运行**——36 个测试文件 / 401 个测试只靠本地回归（README 宣称的测试通过即本地验证）

## 改动内容

### CI 工作流（`.github/workflows/ci.yml`）
- ruff 独立成 **lint job，强制**（版本锁定 0.16.0，与 pyproject 一致）
- 新增 **test job**（Python 3.11/3.12 矩阵）：保留原 CLI 冒烟检查（`--help` / `--version` / import），并**全量运行 pytest**
- 安装改用 `pip install -e ".[dev]"`

### pyproject.toml
- `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]`——显式声明规则集，消除 ruff 版本漂移（这也是 CONTRIBUTING 所称"ruff 默认规则"的实际范围）
- 新增 `[dev]` extra（pytest、ruff==0.16.0），使 CONTRIBUTING 已有的 `pip install -e ".[dev]"` 指引真实可用

### 存量 lint 清理（23 个违规，全部机械性修复）
| 类型 | 数量 | 处理 |
|---|---|---|
| E701 单行 if（boss.py） | 12 | 拆为标准两行，**控制流零变化** |
| F401 未用 import（6 文件） | 10 | 删除；其中 `scraper/jobs.py` 的 rich.progress 导入是测试 mock 桩点，保留 + `noqa: F401` 注明 |
| F841 死赋值（server.py） | 1 | `queue_lock = task.context.setdefault(...)` → 保留 setdefault 副作用调用，仅去掉未用变量 |

### 测试稳定性
16 个测试文件的 `tempfile.TemporaryDirectory()` 统一加 `ignore_cleanup_errors=True`：消除 Windows 下 SQLite WAL 清理与 rmtree 的竞态（偶发 `WinError 145 目录不是空的`，本机复现于 test_collection_orchestrator）。纯测试基建修复。

### 文档同步（CONTRIBUTING.md）
`[dev]` 安装、显式规则集表述、`python -m pytest` 命令。

## 治理说明

- 触及**核心与安全域**文件：`ci.yml`、`pyproject.toml`（当前核心域正式维护者不足 2 人，请项目负责人 @powerycy 审批）
- `boss.py` 属平台适配域，但本次仅风格拆行，无行为变化
- `server.py` 属产品与 AI 域敏感文件，本次仅删除未用 import 与死赋值（setdefault 副作用保留），未触及凭据/发送/配置写入逻辑

## 验证

- 本地（Windows + Python 3.12）：**401 passed + 16 subtests，0 failed**（修复前 1 个 flaky）
- `ruff check src/` 全绿（锁定 E4/E7/E9/F @ 0.16.0）
- CI 结果即 Ubuntu 真实验证，若 test job 有平台差异我会跟进修复
