### PR TITLE
docs: 记录平台适配候选维护者 yuppiez99999

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,6 +29,7 @@
 | GitHub | 维护域 | 观察期开始 | 推荐/带教人 | 状态 |
 |---|---|---|---|---|
 | [@yukinoshi](https://github.com/yukinoshi) | 核心与安全 | 2026-08-28 | [@powerycy](https://github.com/powerycy) | 观察中（Triage） |
+| [@yuppiez99999](https://github.com/yuppiez99999) | 平台适配 | 2026-08-28 | [@powerycy](https://github.com/powerycy) | 观察中（Triage；[申请 #96](https://github.com/shengjidaguai-china/BossHunter/issues/96)） |
 
 ## 历任维护者
 


### PR DESCRIPTION
## 变更内容

- 将 `@yuppiez99999` 记录为「平台适配」候选维护者
- 观察期从 2026-08-28 开始
- 权限级别为 Triage
- 关联候选申请 Issue #96

## 权限边界

- Triage 不提供代码写入或主分支合并权限
- 所有代码修改仍须通过 PR 和 CI
- 高风险平台修改转核心与安全域复核

## 验证

- `git diff --check` 通过
- 仅修改维护者记录，无运行时代码变更
