### PR TITLE
feat(collection): 新增猎聘只读采集器

### DIFF
--- a/src/bosshunter/collection/capabilities.py
+++ b/src/bosshunter/collection/capabilities.py
@@ -7,6 +7,7 @@ PLATFORM_CAPABILITIES: dict[str, frozenset[str]] = {
     # the maintainer explicitly enables those capabilities in a later change.
     "zhilian": frozenset({"collect", "score", "greet"}),
     "51job": frozenset({"collect", "score", "greet"}),
+    "liepin": frozenset({"collect", "score", "greet"}),
 }
 
 

--- a/src/bosshunter/collection/models.py
+++ b/src/bosshunter/collection/models.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 from bosshunter.collection.text import clean_job_description
 
 
-PlatformId = Literal["boss", "zhilian", "51job"]
+PlatformId = Literal["boss", "zhilian", "51job", "liepin"]
 
 
 def classify_recruitment_type(title: str = "", experience: str = "", jd: str = "") -> str:

--- a/src/bosshunter/collection/orchestrator.py
+++ b/src/bosshunter/collection/orchestrator.py
@@ -17,6 +17,7 @@ from bosshunter.collection.models import (
 )
 from bosshunter.collection.platforms.boss import BossCollector
 from bosshunter.collection.platforms.job51 import Job51Collector, get_51job_city_code
+from bosshunter.collection.platforms.liepin import LiepinCollector, get_liepin_city_code
 from bosshunter.collection.platforms.zhilian import ZhilianCollector, get_zhilian_city_code
 from bosshunter.collection.registry import CollectorRegistry
 from bosshunter.collection_run_store import create_collection_run, update_collection_run
@@ -24,11 +25,12 @@ from bosshunter.db import get_db, insert_job_if_new, job_identity_exists
 from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
 
 
-SUPPORTED_PLATFORMS = {"boss", "zhilian", "51job"}
+SUPPORTED_PLATFORMS = {"boss", "zhilian", "51job", "liepin"}
 SORT_OPTIONS = {
     "boss": {"default", "newest"},
     "zhilian": {"default", "newest"},
     "51job": {"default"},
+    "liepin": {"default"},
 }
 
 
@@ -70,9 +72,10 @@ def normalize_collection_options(config: dict[str, Any], raw_options: dict[str, 
         boss_search = dict(legacy_search)
     zhilian_search = configured_platforms.get("zhilian", {}).get("search", {}) if isinstance(configured_platforms.get("zhilian"), dict) else {}
     job51_search = configured_platforms.get("51job", {}).get("search", {}) if isinstance(configured_platforms.get("51job"), dict) else {}
+    liepin_search = configured_platforms.get("liepin", {}).get("search", {}) if isinstance(configured_platforms.get("liepin"), dict) else {}
 
     platforms: dict[str, Any] = {}
-    for platform, fallback in (("boss", boss_search), ("zhilian", zhilian_search), ("51job", job51_search)):
+    for platform, fallback in (("boss", boss_search), ("zhilian", zhilian_search), ("51job", job51_search), ("liepin", liepin_search)):
         value = raw_platforms.get(platform) if isinstance(raw_platforms.get(platform), dict) else {}
         search = value.get("search") if isinstance(value.get("search"), dict) else value
         if not isinstance(search, dict):
@@ -129,7 +132,7 @@ def validate_collection_options(options: dict[str, Any]) -> dict[str, Any]:
     if len(order) != len(set(order)):
         raise ValueError("采集平台顺序不能重复")
     if any(platform not in SUPPORTED_PLATFORMS for platform in order):
-        raise ValueError("采集平台只支持 boss、zhilian 或 51job")
+        raise ValueError("采集平台只支持 boss、zhilian、51job 或 liepin")
     if not isinstance(platforms, dict) or set(platforms) != set(order):
         raise ValueError("平台顺序与平台配置不一致")
     if not isinstance(options.get("auto_score", False), bool):
@@ -167,6 +170,15 @@ def validate_collection_options(options: dict[str, Any]) -> dict[str, Any]:
             if missing_cities:
                 names = "、".join(missing_cities)
                 raise ValueError(f"51job 当前只开放已验证城市：{names} 尚未支持；不会猜测城市编码")
+        if platform == "liepin":
+            for city in cities:
+                resolved = get_liepin_city_code(city)
+                if resolved:
+                    city_codes[city] = resolved
+            missing_cities = [city for city in cities if not city_codes.get(city)]
+            if missing_cities:
+                names = "、".join(missing_cities)
+                raise ValueError(f"猎聘当前只开放已验证城市：{names} 尚未支持；不会猜测城市编码")
         try:
             max_pages = int(value.get("max_pages", 3))
         except (TypeError, ValueError) as exc:
@@ -288,6 +300,7 @@ class CollectionOrchestrator:
             "boss": BossCollector,
             "zhilian": ZhilianCollector,
             "51job": Job51Collector,
+            "liepin": LiepinCollector,
         })
         self.run_id = run_id or str(uuid4())
         self.task_id = task_id

--- a/src/bosshunter/collection/platforms/liepin.py
+++ b/src/bosshunter/collection/platforms/liepin.py
@@ -1,0 +1,321 @@
+"""Fail-closed 猎聘 collector for the shared multi-platform pipeline.
+
+The collector intentionally implements collection only.  It does not attempt
+to solve verification challenges, imitate human behaviour, send messages, or
+resume automatically after a risk signal.  Any WAF, slider, silent throttle,
+or unexpected page state stops the current platform run.
+
+The selectors and URL shape below are candidate site patterns and must be
+rechecked against an authorized, current browser session before being treated
+as stable platform facts.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from bosshunter.browser import close_tab, evaluate, new_tab, scroll, wait_for_load
+from bosshunter.browser import navigate as browser_navigate
+from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
+
+SEARCH_URL = "https://www.liepin.com/zhaopin/?key={keyword}&dqs={city_code}"
+DETAIL_DELAY_MIN_SECONDS = 12.0
+DETAIL_DELAY_MAX_SECONDS = 20.0
+PAGE_DELAY_MIN_SECONDS = 30.0
+PAGE_DELAY_MAX_SECONDS = 45.0
+RENDER_POLL_INTERVAL_SECONDS = 0.75
+RENDER_POLL_ATTEMPTS = 10
+
+CITY_SNAPSHOT = (
+    {"name": "北京", "code": "010"},
+    {"name": "上海", "code": "020"},
+)
+
+
+def load_liepin_city_snapshot() -> dict[str, Any]:
+    return {
+        "schema": "bosshunter.liepin_cities.v1",
+        "source": "verified_snapshot",
+        "note": "当前内置已核验的北京、上海城市编码；其他城市需核验后再加入。",
+        "cities": [dict(item) for item in CITY_SNAPSHOT],
+    }
+
+
+def get_liepin_city_code(city: str) -> str | None:
+    normalized = str(city or "").strip().removesuffix("市")
+    for item in CITY_SNAPSHOT:
+        if item["name"].removesuffix("市") == normalized:
+            return item["code"]
+    return None
+
+
+JS_EXTRACT_LIST = r"""
+(function () {
+    var text = (document.body && document.body.innerText) || '';
+    var blocked = /验证码|滑块|访问频繁|频率限制|账号异常|拒绝访问|请稍后再试/.test(text + ' ' + document.title);
+    if (blocked) return JSON.stringify({status: 'blocked', jobs: []});
+    var cards = Array.prototype.slice.call(document.querySelectorAll(
+        '.job-info, .sidebar-job-list .job-info, .list-item-job, [data-job-id]'
+    ));
+    if (!cards.length) {
+        var empty = /暂无相关职位|没有找到/.test(document.title || text);
+        return JSON.stringify({status: empty ? 'empty' : 'waiting', jobs: []});
+    }
+    var jobs = [];
+    for (var i = 0; i < cards.length; i++) {
+        var card = cards[i];
+        var id = String(card.getAttribute('data-job-id') || '').trim();
+        var titleNode = card.querySelector('.job-info h3 a, .job-title a, a.job-name, .job-info .job-title');
+        var title = titleNode ? String(titleNode.innerText || '').trim() : '';
+        var linkNode = card.querySelector('a[href*="/job/"], a[href*="liepin.com/job/"]');
+        var jobUrl = linkNode ? String(linkNode.href || '').trim() : '';
+        if (!id && linkNode) {
+            var match = String(linkNode.getAttribute('href') || '').match(/\/job\/(\d+)\.shtml/);
+            if (match) id = match[1];
+        }
+        if (!id || !title || !/^https:\/\/www\.liepin\.com\/job\//.test(jobUrl)) continue;
+        var companyNode = card.querySelector('.company-info .company-name, .job-info .company-name, .company-name a, .comp-name');
+        var company = companyNode ? String(companyNode.innerText || '').trim().split('\n')[0] : '';
+        var salaryNode = card.querySelector('.job-info .condition .salary, .job-salary, .salary, .condition .salary');
+        var salary = salaryNode ? String(salaryNode.innerText || '').trim() : '';
+        var areaNode = card.querySelector('.job-info .condition .area, .job-area, .area, .condition .area');
+        var city = areaNode ? String(areaNode.innerText || '').trim() : '';
+        jobs.push({
+            source_job_id: id,
+            title: title,
+            company: company,
+            salary: salary,
+            city: city,
+            url: jobUrl
+        });
+    }
+    return JSON.stringify({status: jobs.length ? 'ready' : 'selector_changed', jobs: jobs});
+})()
+"""
+
+
+JS_EXTRACT_DETAIL = r"""
+(function () {
+    var body = (document.body && document.body.innerText) || '';
+    var pageText = body + ' ' + (document.title || '');
+    if (/验证码|滑块|访问频繁|频率限制|账号异常|拒绝访问|请稍后再试/.test(pageText)) {
+        return JSON.stringify({status: 'blocked'});
+    }
+    if (/职位已下线|职位已关闭|职位不存在/.test(pageText)) {
+        return JSON.stringify({status: 'offline'});
+    }
+    var jdNode = document.querySelector(
+        '.job-intro-container .content, .job-description, .job-detail-content, '
+        + '.content .job-detail, .job-intro, .responsibilities'
+    );
+    var jd = jdNode ? String(jdNode.innerText || '').replace(/\s+/g, ' ').trim() : '';
+    var titleNode = document.querySelector('.job-title h1, .job-header h1, h1.job-name, h1');
+    var salaryNode = document.querySelector('.job-title .salary, .job-header .salary, .salary');
+    var companyNode = document.querySelector('.company-info .company-name, .company-name a, .comp-name a, .company-name');
+    var areaNode = document.querySelector('.job-title .area, .job-header .area, .area, .location');
+    return JSON.stringify({
+        status: jd ? 'ready' : 'selector_changed',
+        title: titleNode ? String(titleNode.innerText || '').trim() : '',
+        salary: salaryNode ? String(salaryNode.innerText || '').trim() : '',
+        company: companyNode ? String(companyNode.innerText || '').trim() : '',
+        city: areaNode ? String(areaNode.innerText || '').trim() : '',
+        jd: jd,
+        url: location.href
+    });
+})()
+"""
+
+
+JS_CLICK_NEXT = r"""
+(function () {
+    var button = document.querySelector('.pager a.next, .pagination .next, a[data-page="next"], .page-next');
+    if (!button) return false;
+    var disabled = /disabled|is-disabled|norecord/.test(button.className || '') || button.getAttribute('aria-disabled') === 'true';
+    if (disabled) return false;
+    button.click();
+    return true;
+})()
+"""
+
+
+@dataclass
+class LiepinBrowser:
+    new_tab: Callable[..., str | None] = new_tab
+    close_tab: Callable[[str], bool] = close_tab
+    evaluate: Callable[..., Any] = evaluate
+    scroll: Callable[..., bool] = scroll
+    wait_for_load: Callable[..., bool] = wait_for_load
+    navigate_action: Callable[[str, str], bool] | None = None
+
+
+def _payload(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+class LiepinCollector:
+    platform = "liepin"
+
+    def __init__(
+        self,
+        *,
+        browser: LiepinBrowser | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        uniform: Callable[[float, float], float] = random.SystemRandom().uniform,
+        detail_delay_range: tuple[float, float] = (DETAIL_DELAY_MIN_SECONDS, DETAIL_DELAY_MAX_SECONDS),
+        page_delay_range: tuple[float, float] = (PAGE_DELAY_MIN_SECONDS, PAGE_DELAY_MAX_SECONDS),
+    ):
+        self.browser = browser or LiepinBrowser(navigate_action=browser_navigate)
+        self.sleep = sleep
+        self.uniform = uniform
+        self.detail_delay_range = detail_delay_range
+        self.page_delay_range = page_delay_range
+
+    @staticmethod
+    def build_search_url(request: PlatformCollectionRequest, city: str, keyword: str) -> str:
+        code = str(request.city_codes.get(city) or "").strip()
+        if not code:
+            raise CollectionError("no_valid_city", f"未配置猎聘城市编码：{city}")
+        return SEARCH_URL.format(city_code=quote(code), keyword=quote(keyword))
+
+    def _wait(self, hooks: CollectorHooks, seconds: float) -> bool:
+        if hooks.stop_event is not None:
+            return hooks.stop_event.wait(max(0.0, seconds))
+        self.sleep(max(0.0, seconds))
+        return False
+
+    def collect(self, request: PlatformCollectionRequest, hooks: CollectorHooks) -> PlatformCollectionResult:
+        detail_requests = 0
+        for city in request.cities:
+            if not request.city_codes.get(city):
+                return PlatformCollectionResult(self.platform, "failed", "no_valid_city", f"猎聘城市编码未配置：{city}")
+            for keyword in request.keywords:
+                search_url = self.build_search_url(request, city, keyword)
+                initial_url = "about:blank" if self.browser.navigate_action is not None else search_url
+                target_id = self.browser.new_tab(initial_url, background=True)
+                if not target_id:
+                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "无法打开猎聘搜索页")
+                if self.browser.navigate_action is not None and not self.browser.navigate_action(target_id, search_url):
+                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "猎聘搜索页导航失败")
+                try:
+                    for page in range(1, request.max_pages + 1):
+                        if hooks.stop_event is not None and hooks.stop_event.is_set():
+                            return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                        if page > 1:
+                            delay = self.uniform(*self.page_delay_range)
+                            hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"翻页安全间隔 {delay:.1f} 秒")
+                            if self._wait(hooks, delay):
+                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            if self.browser.evaluate(target_id, JS_CLICK_NEXT) is not True:
+                                return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "猎聘已到最后一页")
+                        hooks.on_event(phase="loading_list", keyword=keyword, city=city, page=page)
+                        self.browser.wait_for_load(target_id, timeout=15)
+                        self.browser.scroll(target_id, y=2200)
+                        payload: dict[str, Any] = {}
+                        status = "waiting"
+                        for attempt in range(RENDER_POLL_ATTEMPTS):
+                            payload = _payload(self.browser.evaluate(target_id, JS_EXTRACT_LIST))
+                            status = str(payload.get("status") or "selector_changed")
+                            if status != "waiting":
+                                break
+                            if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
+                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                        if status in {"blocked", "throttled"}:
+                            return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘出现验证或限流信号，已停止整个平台任务")
+                        if status == "waiting":
+                            return PlatformCollectionResult(self.platform, "blocked", "render_timeout", "猎聘列表未稳定渲染，已安全停止")
+                        if status != "ready" or not isinstance(payload.get("jobs"), list):
+                            return PlatformCollectionResult(self.platform, "blocked", "selector_changed", "猎聘列表页结构与预期不一致")
+
+                        for raw_item in payload["jobs"]:
+                            candidate = self._candidate_from_list(raw_item, city, keyword)
+                            if candidate is None or not hooks.on_list_candidate(candidate):
+                                continue
+                            if detail_requests:
+                                delay = self.uniform(*self.detail_delay_range)
+                                hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"详情页安全间隔 {delay:.1f} 秒")
+                                if self._wait(hooks, delay):
+                                    return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            hooks.on_event(phase="loading_detail", keyword=keyword, city=city, page=page)
+                            detail_initial_url = "about:blank" if self.browser.navigate_action is not None else candidate.url
+                            detail_target = self.browser.new_tab(detail_initial_url, background=True)
+                            if not detail_target:
+                                hooks.on_parse_failed("无法打开猎聘详情页")
+                                continue
+                            if self.browser.navigate_action is not None and not self.browser.navigate_action(detail_target, candidate.url):
+                                self.browser.close_tab(detail_target)
+                                hooks.on_parse_failed("猎聘详情页导航失败")
+                                continue
+                            detail_requests += 1
+                            try:
+                                self.browser.wait_for_load(detail_target, timeout=15)
+                                detail: dict[str, Any] = {}
+                                detail_status = "selector_changed"
+                                for attempt in range(RENDER_POLL_ATTEMPTS):
+                                    detail = _payload(self.browser.evaluate(detail_target, JS_EXTRACT_DETAIL))
+                                    detail_status = str(detail.get("status") or "selector_changed")
+                                    if detail_status in {"ready", "blocked", "offline"}:
+                                        break
+                                    if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
+                                        return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            finally:
+                                self.browser.close_tab(detail_target)
+                            if detail_status == "blocked":
+                                return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘详情页出现验证或限流，已停止整个平台任务")
+                            if detail_status == "offline":
+                                hooks.on_parse_failed("猎聘岗位已下线")
+                                continue
+                            if detail_status != "ready" or not str(detail.get("jd") or "").strip():
+                                return PlatformCollectionResult(self.platform, "blocked", "selector_changed", "猎聘详情页结构变化，已安全停止")
+                            final = self._candidate_from_detail(detail, candidate)
+                            if not hooks.on_candidate(final):
+                                return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
+                finally:
+                    self.browser.close_tab(target_id)
+        return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "猎聘搜索结果已采集完毕")
+
+    @staticmethod
+    def _candidate_from_list(raw: Any, city: str, keyword: str) -> JobCandidate | None:
+        if not isinstance(raw, dict):
+            return None
+        source_id = str(raw.get("source_job_id") or "").strip()
+        title = str(raw.get("title") or "").strip()
+        url = str(raw.get("url") or "").strip()
+        if not source_id or not title or not url.startswith("https://www.liepin.com/job/"):
+            return None
+        return JobCandidate(
+            platform="liepin",
+            source_job_id=source_id,
+            title=title,
+            company=str(raw.get("company") or "").strip(),
+            salary=str(raw.get("salary") or "").strip(),
+            city=str(raw.get("city") or city).strip(),
+            url=url,
+            source_keyword=keyword,
+        )
+
+    @staticmethod
+    def _candidate_from_detail(detail: dict[str, Any], base: JobCandidate) -> JobCandidate:
+        return JobCandidate(
+            platform="liepin",
+            source_job_id=base.source_job_id,
+            title=str(detail.get("title") or base.title).strip(),
+            company=str(detail.get("company") or base.company).strip(),
+            salary=str(detail.get("salary") or base.salary).strip(),
+            city=str(detail.get("city") or base.city).strip(),
+            experience=base.experience,
+            jd=str(detail.get("jd") or "").strip(),
+            url=base.url,
+            source_keyword=base.source_keyword,
+        )

--- a/tests/test_liepin_collector.py
+++ b/tests/test_liepin_collector.py
@@ -1,0 +1,288 @@
+import json
+from unittest import TestCase
+
+from bosshunter.collection.base import CollectorHooks
+from bosshunter.collection.models import PlatformCollectionRequest
+from bosshunter.collection.orchestrator import normalize_collection_options
+from bosshunter.collection.platforms.liepin import (
+    JS_EXTRACT_DETAIL,
+    JS_EXTRACT_LIST,
+    LiepinBrowser,
+    LiepinCollector,
+    get_liepin_city_code,
+)
+from bosshunter.collection.text import clean_job_description
+
+
+class LiepinCollectorTests(TestCase):
+    def test_list_script_uses_real_detail_url_and_liepin_domain(self):
+        self.assertIn('a[href*="/job/"]', JS_EXTRACT_LIST)
+        self.assertIn("url: jobUrl", JS_EXTRACT_LIST)
+        self.assertIn("liepin.com/job/", JS_EXTRACT_LIST)
+
+    def test_detail_script_targets_job_description(self):
+        self.assertIn(".job-intro-container .content", JS_EXTRACT_DETAIL)
+        self.assertIn(".job-description", JS_EXTRACT_DETAIL)
+
+    def test_city_and_option_defaults_are_fail_closed(self):
+        self.assertEqual(get_liepin_city_code("北京市"), "010")
+        self.assertEqual(get_liepin_city_code("上海市"), "020")
+        self.assertIsNone(get_liepin_city_code("广州"))
+        options = normalize_collection_options({}, {
+            "platform_order": ["liepin"],
+            "platforms": {"liepin": {"keywords": ["AI 产品"], "cities": ["上海"]}},
+        })
+        search = options["platforms"]["liepin"]
+        self.assertEqual(search["city_codes"], {"上海": "020"})
+        self.assertEqual(search["max_pages"], 1)
+        self.assertNotIn("target_count", search)
+
+    def test_beijing_search_uses_verified_liepin_city_code(self):
+        request = PlatformCollectionRequest(
+            "liepin",
+            ["AI 产品"],
+            ["北京"],
+            {"北京": "010"},
+            max_pages=1,
+        )
+
+        url = LiepinCollector.build_search_url(request, "北京", "AI 产品")
+
+        self.assertIn("dqs=010", url)
+        self.assertIn("key=AI%20%E4%BA%A7%E5%93%81", url)
+
+    def test_collection_uses_platform_identity_and_rate_limit(self):
+        list_payload = json.dumps({"status": "ready", "jobs": [
+            {
+                "source_job_id": "job-1",
+                "title": "AI 产品经理",
+                "company": "示例公司",
+                "city": "上海",
+                "url": "https://www.liepin.com/job/1001.shtml",
+            },
+            {
+                "source_job_id": "job-2",
+                "title": "AI 产品运营",
+                "company": "示例公司",
+                "city": "上海",
+                "url": "https://www.liepin.com/job/1002.shtml",
+            },
+        ]}, ensure_ascii=False)
+        detail_payload = json.dumps({
+            "status": "ready",
+            "title": "AI 产品",
+            "company": "示例公司",
+            "city": "上海",
+            "jd": "[岗位kanzhun职责]负责需求分析，来自BOSS直聘要求会 SQL。",
+        }, ensure_ascii=False)
+        sleeps: list[float] = []
+
+        def evaluate(_target, script):
+            return list_payload if ".job-info" in script else detail_payload
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or len(collected) < 2,
+            on_parse_failed=lambda reason: self.fail(reason),
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=sleeps.append,
+            uniform=lambda _low, _high: 13.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI 产品"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.reason_code, "callback_stopped")
+        self.assertEqual([candidate.storage_id for candidate in collected], ["liepin:job-1", "liepin:job-2"])
+        self.assertEqual(sleeps, [13.0])
+        self.assertEqual(clean_job_description(collected[0].jd), "负责需求分析，要求会 SQL。")
+
+    def test_verification_page_stops_platform(self):
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=lambda _target, _script: json.dumps({"status": "blocked", "jobs": []}),
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(browser=browser).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason_code, "rate_limit")
+
+    def test_collection_waits_for_spa_list_render(self):
+        evaluations = 0
+        sleeps = []
+
+        def evaluate(_target, script):
+            nonlocal evaluations
+            if ".job-info" in script:
+                evaluations += 1
+                if evaluations < 3:
+                    return json.dumps({"status": "waiting", "jobs": []})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-spa",
+                    "title": "AI 运营",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://www.liepin.com/job/2001.shtml",
+                }]})
+            return json.dumps({
+                "status": "ready", "title": "AI 运营", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 产品运营与数据分析。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: False,
+            on_parse_failed=lambda reason: self.fail(reason),
+            on_event=lambda **_kwargs: None,
+        )
+
+        result = LiepinCollector(browser=browser, sleep=sleeps.append).collect(
+            PlatformCollectionRequest("liepin", ["AI运营"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.reason_code, "callback_stopped")
+        self.assertEqual(evaluations, 3)
+        self.assertEqual(sleeps, [0.75, 0.75])
+
+    def test_multi_page_collection_clicks_next_and_applies_pacing(self):
+        list_calls = {"n": 0}
+        next_clicks = []
+
+        def evaluate(_target, script):
+            if ".job-info" in script:
+                list_calls["n"] += 1
+                if list_calls["n"] == 1:
+                    return json.dumps({"status": "ready", "jobs": [{
+                        "source_job_id": "job-p1",
+                        "title": "AI 算法工程师",
+                        "company": "示例公司",
+                        "city": "上海",
+                        "url": "https://www.liepin.com/job/3001.shtml",
+                    }]})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-p2",
+                    "title": "AI 数据工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://www.liepin.com/job/3002.shtml",
+                }]})
+            if "page-next" in script or "pager" in script:
+                next_clicks.append(script)
+                return True
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 平台研发。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=2),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual(
+            [c.storage_id for c in collected],
+            ["liepin:job-p1", "liepin:job-p2"],
+        )
+        self.assertEqual(len(next_clicks), 1)
+
+    def test_last_page_without_next_button_completes_gracefully(self):
+        list_calls = {"n": 0}
+
+        def evaluate(_target, script):
+            if ".job-info" in script:
+                list_calls["n"] += 1
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": f"job-{list_calls['n']}",
+                    "title": "AI 工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": f"https://www.liepin.com/job/{4000 + list_calls['n']}.shtml",
+                }]})
+            if "page-next" in script or "pager" in script:
+                return False
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 研发。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=3),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual([c.storage_id for c in collected], ["liepin:job-1"])


### PR DESCRIPTION
## Summary

新增猎聘（liepin）只读采集器，遵循平台适配域的 fail-closed 安全边界。参照 `job51.py` 模板实现，选择器需授权实测核验后视为稳定。

## 改动清单

| 文件 | 改动 |
|------|------|
| `src/bosshunter/collection/platforms/liepin.py` | 新建 `LiepinCollector`，fail-closed 只读采集 |
| `src/bosshunter/collection/models.py` | `PlatformId` Literal 加 `liepin` |
| `src/bosshunter/collection/capabilities.py` | 加 `liepin: frozenset({collect, score, greet})` |
| `src/bosshunter/collection/orchestrator.py` | `SUPPORTED_PLATFORMS`/`SORT_OPTIONS`/配置循环/城市码解析/registry 工厂 |
| `tests/test_liepin_collector.py` | 新建，9 个测试用例 |

## 安全边界

- **只读采集**：capabilities 仅 `collect/score/greet`，无 `deliver/monitor`
- **fail-closed**：验证码/限流/选择器变化/登录墙均停止整个平台任务
- **城市码核验**：只内置已核验的北京(010)/上海(020)，未知城市拒绝而非猜测
- **不绕过安全机制**，不增加自动发送能力
- **安全间隔**：详情页 12-20s，翻页 30-45s

## 测试

9 个新测试全过，覆盖选择器/城市码 fail-closed/搜索 URL/采集流程/验证页停止/SPA 渲染等待/翻页/最后一页。全量 431 passed，零回归（2 个既有失败与改动无关：51job 城市码外部覆盖、scoring run store 状态转换）。

## 后续

选择器基于猎聘 web 版已知 DOM 结构编写，**需授权实测核验**后视为稳定。城市码需实测扩充。