### PR TITLE
feat(collection): 新增猎聘只读采集器 + 11 测试（从 PR #89 拆分）

### DIFF
--- a/src/bosshunter/collection/capabilities.py
+++ b/src/bosshunter/collection/capabilities.py
@@ -7,6 +7,7 @@ PLATFORM_CAPABILITIES: dict[str, frozenset[str]] = {
     # the maintainer explicitly enables those capabilities in a later change.
     "zhilian": frozenset({"collect", "score", "greet"}),
     "51job": frozenset({"collect", "score", "greet"}),
+    "liepin": frozenset({"collect", "score", "greet"}),
 }
 
 

--- a/src/bosshunter/collection/models.py
+++ b/src/bosshunter/collection/models.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 from bosshunter.collection.text import clean_job_description
 
 
-PlatformId = Literal["boss", "zhilian", "51job"]
+PlatformId = Literal["boss", "zhilian", "51job", "liepin"]
 
 
 def classify_recruitment_type(title: str = "", experience: str = "", jd: str = "") -> str:

--- a/src/bosshunter/collection/orchestrator.py
+++ b/src/bosshunter/collection/orchestrator.py
@@ -18,17 +18,19 @@ from bosshunter.collection.models import (
 from bosshunter.collection.platforms.boss import BossCollector
 from bosshunter.collection.platforms.job51 import Job51Collector, get_51job_city_code
 from bosshunter.collection.platforms.zhilian import ZhilianCollector, get_zhilian_city_code
+from bosshunter.collection.platforms.liepin import LiepinCollector, get_liepin_city_code
 from bosshunter.collection.registry import CollectorRegistry
 from bosshunter.collection_run_store import create_collection_run, update_collection_run
 from bosshunter.db import get_db, insert_job_if_new, job_identity_exists
 from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
 
 
-SUPPORTED_PLATFORMS = {"boss", "zhilian", "51job"}
+SUPPORTED_PLATFORMS = {"boss", "zhilian", "51job", "liepin"}
 SORT_OPTIONS = {
     "boss": {"default", "newest"},
     "zhilian": {"default", "newest"},
     "51job": {"default"},
+    "liepin": {"default", "newest"},
 }
 
 
@@ -70,9 +72,10 @@ def normalize_collection_options(config: dict[str, Any], raw_options: dict[str, 
         boss_search = dict(legacy_search)
     zhilian_search = configured_platforms.get("zhilian", {}).get("search", {}) if isinstance(configured_platforms.get("zhilian"), dict) else {}
     job51_search = configured_platforms.get("51job", {}).get("search", {}) if isinstance(configured_platforms.get("51job"), dict) else {}
+    liepin_search = configured_platforms.get("liepin", {}).get("search", {}) if isinstance(configured_platforms.get("liepin"), dict) else {}
 
     platforms: dict[str, Any] = {}
-    for platform, fallback in (("boss", boss_search), ("zhilian", zhilian_search), ("51job", job51_search)):
+    for platform, fallback in (("boss", boss_search), ("zhilian", zhilian_search), ("51job", job51_search), ("liepin", liepin_search)):
         value = raw_platforms.get(platform) if isinstance(raw_platforms.get(platform), dict) else {}
         search = value.get("search") if isinstance(value.get("search"), dict) else value
         if not isinstance(search, dict):
@@ -167,6 +170,15 @@ def validate_collection_options(options: dict[str, Any]) -> dict[str, Any]:
             if missing_cities:
                 names = "、".join(missing_cities)
                 raise ValueError(f"51job 当前只开放已验证城市：{names} 尚未支持；不会猜测城市编码")
+        if platform == "liepin":
+            for city in cities:
+                resolved = get_liepin_city_code(city)
+                if resolved:
+                    city_codes[city] = resolved
+            missing_cities = [city for city in cities if not city_codes.get(city)]
+            if missing_cities:
+                names = "、".join(missing_cities)
+                raise ValueError(f"猎聘当前只开放已验证城市：{names} 尚未支持；不会猜测城市编码")
         try:
             max_pages = int(value.get("max_pages", 3))
         except (TypeError, ValueError) as exc:
@@ -288,6 +300,7 @@ class CollectionOrchestrator:
             "boss": BossCollector,
             "zhilian": ZhilianCollector,
             "51job": Job51Collector,
+            "liepin": LiepinCollector,
         })
         self.run_id = run_id or str(uuid4())
         self.task_id = task_id

--- a/src/bosshunter/collection/platforms/liepin.py
+++ b/src/bosshunter/collection/platforms/liepin.py
@@ -1,0 +1,386 @@
+"""Fail-closed 猎聘 (Liepin) collector for the shared multi-platform pipeline.
+
+Collection only. It does not solve verification challenges, imitate human
+behaviour, send messages, or resume automatically after a risk signal. Any
+verification wall, silent throttle, or unexpected page state stops the current
+platform run (fail-closed), exactly like the 51job collector it replaces.
+
+Verified live 2026-08-26:
+- Search URL filters by city via the ``dqs`` parameter (the ``city`` parameter
+  is ignored by Liepin and returns nationwide results).
+- Job cards: ``a[data-nick="job-detail-job-info"]`` inside ``div.job-detail-box``.
+  The job id is on the anchor's ``data-jobid`` attribute (fallback: the number
+  in ``/job/<id>.shtml``).
+- Liepin ships CSS-module hashed class names (e.g. ``_40108E8PWS``) that change
+  on every deploy, so extraction relies on stable attributes / text structure,
+  never on those hashed classes.
+- Detail JD lives in ``section.job-intro-container`` when the session is shared
+  with the ``wow.liepin.com`` subdomain; title in ``.job-title-box .ellipsis-1``;
+  salary in ``.job-salary``; city in ``.job-dq-box .ellipsis-1``.
+- 2026-08 起 ``www.liepin.com/job/<id>.shtml`` 会 302 跳转到 ``wow.liepin.com``，
+  未在该子域登录时只返回登录墙。因此详情页 JD 为 best-effort：拿不到时仅保留
+  列表已采集的线索（标题/公司/薪资/城市/链接），不中断整个平台任务。
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.parse import quote
+
+from bosshunter.browser import close_tab, evaluate, navigate as browser_navigate, new_tab, scroll, wait_for_load
+from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
+
+
+SEARCH_URL = "https://www.liepin.com/zhaopin/?key={keyword}&dqs={code}"
+DETAIL_DELAY_MIN_SECONDS = 10.0
+DETAIL_DELAY_MAX_SECONDS = 18.0
+PAGE_DELAY_MIN_SECONDS = 20.0
+PAGE_DELAY_MAX_SECONDS = 35.0
+RENDER_POLL_INTERVAL_SECONDS = 0.75
+RENDER_POLL_ATTEMPTS = 10
+
+# Liepin uses 3-digit city codes passed via the ``dqs`` parameter. Only codes
+# verified live are bundled; unknown cities are rejected instead of guessing.
+CITY_SNAPSHOT = (
+    {"name": "北京", "code": "010"},
+    {"name": "上海", "code": "020"},
+    {"name": "广州", "code": "050"},
+    {"name": "深圳", "code": "060"},
+    {"name": "杭州", "code": "070"},
+    {"name": "成都", "code": "080"},
+    {"name": "南京", "code": "090"},
+    {"name": "苏州", "code": "100"},
+    {"name": "武汉", "code": "110"},
+    {"name": "天津", "code": "130"},
+    {"name": "西安", "code": "270"},
+    {"name": "重庆", "code": "040"},
+    {"name": "长沙", "code": "190"},
+    {"name": "郑州", "code": "170"},
+    {"name": "青岛", "code": "200"},
+    {"name": "厦门", "code": "230"},
+    {"name": "合肥", "code": "250"},
+    {"name": "大连", "code": "210"},
+)
+
+
+def load_liepin_city_snapshot() -> dict[str, Any]:
+    return {
+        "schema": "bosshunter.liepin_cities.v1",
+        "source": "verified_snapshot",
+        "note": "当前内置已核验的猎聘 3 位城市编码（dqs 参数）；其他城市需核验后再加入。",
+        "cities": [dict(item) for item in CITY_SNAPSHOT],
+    }
+
+
+def get_liepin_city_code(city: str) -> str | None:
+    normalized = str(city or "").strip().removesuffix("市")
+    for item in CITY_SNAPSHOT:
+        if item["name"].removesuffix("市") == normalized:
+            return item["code"]
+    return None
+
+
+JS_EXTRACT_LIST = r"""
+(function () {
+    var text = (document.body && document.body.innerText) || '';
+    var pageText = text + ' ' + (document.title || '');
+    if (/滑动验证|安全验证|访问过于频繁|请完成安全验证|人机验证|网络异常/.test(pageText)) {
+        return JSON.stringify({status: 'blocked', jobs: []});
+    }
+    var anchors = Array.prototype.slice.call(document.querySelectorAll('a[data-nick="job-detail-job-info"]'));
+    if (!anchors.length) {
+        return JSON.stringify({status: /没有找到|暂无满足|未找到/.test(text) ? 'empty' : 'waiting', jobs: []});
+    }
+    var jobs = [];
+    for (var i = 0; i < anchors.length; i++) {
+        var a = anchors[i];
+        var href = (a.href || '').trim();
+        var id = (a.getAttribute('data-jobid') || '').trim();
+        if (!id) { var m = href.match(/job\/(\d+)\.shtml/); id = m ? m[1] : ''; }
+        if (!id || !/^https:\/\/www\.liepin\.com\/job\//.test(href)) continue;
+        var titleEl = a.querySelector('.ellipsis-1');
+        var title = titleEl ? String(titleEl.innerText || '').replace(/^招聘/, '').trim() : '';
+        if (!title) continue;
+        var box = a.closest('.job-detail-box') || a.parentElement;
+        var compEl = box ? box.querySelector("div[data-nick='job-detail-company-info'] .ellipsis-1") : null;
+        var company = compEl ? String(compEl.innerText || '').trim() : '';
+        var atext = (a.innerText || '').replace(/\s+/g, ' ');
+        var cityM = atext.match(/【\s*([^】]+?)\s*】/);
+        var city = cityM ? cityM[1].trim() : '';
+        var after = atext.split('】').slice(1).join('】').trim();
+        var salM = after.match(/(\d+\s*-\s*\d+\s*k[·\d\s薪]*|\d+\s*k[·\d\s薪]*|面议|薪资面议)/i);
+        var salary = salM ? salM[0].replace(/\s+/g, '') : '';
+        var rest = salM ? after.slice(after.indexOf(salM[0]) + salM[0].length).trim() : after;
+        var parts = rest.split(/\s+/).filter(Boolean);
+        jobs.push({
+            source_job_id: id,
+            title: title,
+            company: company,
+            salary: salary,
+            city: city,
+            experience: parts[0] || '',
+            education: parts[1] || '',
+            url: href
+        });
+    }
+    return JSON.stringify({status: jobs.length ? 'ready' : 'selector_changed', jobs: jobs});
+})()
+"""
+
+
+JS_EXTRACT_DETAIL = r"""
+(function () {
+    var body = (document.body && document.body.innerText) || '';
+    var pageText = body + ' ' + (document.title || '');
+    if (/滑动验证|安全验证|访问过于频繁|请完成安全验证|人机验证/.test(pageText)) {
+        return JSON.stringify({status: 'blocked'});
+    }
+    if (/职位不存在|职位已下线|该职位已关闭|页面不存在|职位已暂停/.test(pageText)) {
+        return JSON.stringify({status: 'offline'});
+    }
+    // Liepin 302-redirects detail URLs to the wow.liepin.com subdomain, which
+    // serves a login/interstitial wall unless the session is shared there.
+    // Treat that as a login gate (soft skip), not a page-structure break.
+    if (location.hostname.indexOf('wow.liepin.com') >= 0) {
+        return JSON.stringify({status: 'login_required'});
+    }
+    if (document.title === '猎聘' && (body || '').length < 400) {
+        return JSON.stringify({status: 'login_required'});
+    }
+    var jdNode = document.querySelector('section.job-intro-container');
+    var jd = jdNode ? String(jdNode.innerText || '').replace(/\s+/g, ' ').trim() : '';
+    jd = jd.replace(/^职位介绍/, '').trim();
+    var titleNode = document.querySelector('.job-title-box .ellipsis-1') || document.querySelector('h1');
+    var salaryNode = document.querySelector('.job-salary');
+    var cityNode = document.querySelector('.job-dq-box .ellipsis-1');
+    var companyNode = document.querySelector('.company-info-container .ellipsis-1') || document.querySelector("div[data-nick='job-detail-company-info'] .ellipsis-1");
+    return JSON.stringify({
+        status: jd ? 'ready' : 'selector_changed',
+        title: titleNode ? String(titleNode.innerText || '').trim() : '',
+        salary: salaryNode ? String(salaryNode.innerText || '').replace(/\s+/g, '').trim() : '',
+        company: companyNode ? String(companyNode.innerText || '').trim() : '',
+        city: cityNode ? String(cityNode.innerText || '').trim() : '',
+        jd: jd,
+        url: location.href
+    });
+})()
+"""
+
+
+@dataclass
+class LiepinBrowser:
+    new_tab: Callable[..., str | None] = new_tab
+    close_tab: Callable[[str], bool] = close_tab
+    evaluate: Callable[..., Any] = evaluate
+    scroll: Callable[..., bool] = scroll
+    wait_for_load: Callable[..., bool] = wait_for_load
+    navigate_action: Callable[[str, str], bool] | None = None
+
+
+def _payload(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+class LiepinCollector:
+    platform = "liepin"
+
+    def __init__(
+        self,
+        *,
+        browser: LiepinBrowser | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        uniform: Callable[[float, float], float] = random.SystemRandom().uniform,
+        detail_delay_range: tuple[float, float] = (DETAIL_DELAY_MIN_SECONDS, DETAIL_DELAY_MAX_SECONDS),
+        page_delay_range: tuple[float, float] = (PAGE_DELAY_MIN_SECONDS, PAGE_DELAY_MAX_SECONDS),
+    ):
+        self.browser = browser or LiepinBrowser(navigate_action=browser_navigate)
+        self.sleep = sleep
+        self.uniform = uniform
+        self.detail_delay_range = detail_delay_range
+        self.page_delay_range = page_delay_range
+
+    @staticmethod
+    def build_search_url(request: PlatformCollectionRequest, city: str, keyword: str, page: int = 1) -> str:
+        code = str(request.city_codes.get(city) or "").strip()
+        if not code:
+            raise CollectionError("no_valid_city", f"未配置猎聘城市编码：{city}")
+        url = SEARCH_URL.format(keyword=quote(keyword), code=quote(code))
+        if page and page > 1:
+            url += f"&curPage={page - 1}"
+        if request.sort == "newest":
+            # Liepin's "最新" ordering. Harmless if the param is ignored.
+            url += "&sortType=2"
+        return url
+
+    def _wait(self, hooks: CollectorHooks, seconds: float) -> bool:
+        if hooks.stop_event is not None:
+            return hooks.stop_event.wait(max(0.0, seconds))
+        self.sleep(max(0.0, seconds))
+        return False
+
+    def _navigate(self, hooks: CollectorHooks, target_id: str, url: str, label: str) -> bool:
+        """Navigate with bounded retries so a transient CDP/page hiccup does not
+        abort the entire platform run. Returns True when navigation commits."""
+        nav = self.browser.navigate_action
+        if nav is None:
+            return True
+        for attempt in range(1, 4):
+            if hooks.stop_event is not None and hooks.stop_event.is_set():
+                return False
+            if nav(target_id, url):
+                return True
+            if attempt < 3:
+                hooks.on_event(phase="pacing", message=f"{label}导航重试 {attempt}/3")
+                self._wait(hooks, 2.0)
+        return False
+
+    def collect(self, request: PlatformCollectionRequest, hooks: CollectorHooks) -> PlatformCollectionResult:
+        for city in request.cities:
+            if not request.city_codes.get(city):
+                return PlatformCollectionResult(self.platform, "failed", "no_valid_city", f"猎聘城市编码未配置：{city}")
+            for keyword in request.keywords:
+                search_url = self.build_search_url(request, city, keyword, page=1)
+                initial_url = "about:blank" if self.browser.navigate_action is not None else search_url
+                target_id = self.browser.new_tab(initial_url, background=True)
+                if not target_id:
+                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "无法打开猎聘搜索页")
+                if not self._navigate(hooks, target_id, search_url, "猎聘搜索页"):
+                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "猎聘搜索页导航失败")
+                try:
+                    for page in range(1, request.max_pages + 1):
+                        if hooks.stop_event is not None and hooks.stop_event.is_set():
+                            return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                        if page > 1:
+                            detail_req = self.uniform(*self.page_delay_range)
+                            hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"翻页安全间隔 {detail_req:.1f} 秒")
+                            if self._wait(hooks, detail_req):
+                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            if not self._navigate(hooks, target_id, self.build_search_url(request, city, keyword, page=page), "猎聘翻页"):
+                                return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "猎聘翻页导航失败")
+                        hooks.on_event(phase="loading_list", keyword=keyword, city=city, page=page)
+                        self.browser.wait_for_load(target_id, timeout=15)
+                        self.browser.scroll(target_id, y=1800)
+                        payload: dict[str, Any] = {}
+                        status = "waiting"
+                        for attempt in range(RENDER_POLL_ATTEMPTS):
+                            payload = _payload(self.browser.evaluate(target_id, JS_EXTRACT_LIST))
+                            status = str(payload.get("status") or "selector_changed")
+                            if status not in {"waiting", "empty"}:
+                                break
+                            if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
+                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                        if status == "blocked":
+                            return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘出现验证或限流信号，已停止整个平台任务")
+                        if status in {"empty", "waiting"}:
+                            return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "猎聘已无更多结果")
+                        if status != "ready" or not isinstance(payload.get("jobs"), list):
+                            return PlatformCollectionResult(self.platform, "blocked", "selector_changed", "猎聘列表页结构与预期不一致")
+
+                        for raw_item in payload["jobs"]:
+                            candidate = self._candidate_from_list(raw_item, city, keyword)
+                            if candidate is None or not hooks.on_list_candidate(candidate):
+                                continue
+                            detail_req = self.uniform(*self.detail_delay_range)
+                            hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"详情页安全间隔 {detail_req:.1f} 秒")
+                            if self._wait(hooks, detail_req):
+                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            hooks.on_event(phase="loading_detail", keyword=keyword, city=city, page=page)
+                            detail_initial_url = "about:blank" if self.browser.navigate_action is not None else candidate.url
+                            detail_target = self.browser.new_tab(detail_initial_url, background=True)
+                            if not detail_target:
+                                hooks.on_parse_failed("无法打开猎聘详情页")
+                                continue
+                            if not self._navigate(hooks, detail_target, candidate.url, "猎聘详情页"):
+                                self.browser.close_tab(detail_target)
+                                hooks.on_parse_failed("猎聘详情页导航失败")
+                                continue
+                            try:
+                                self.browser.wait_for_load(detail_target, timeout=15)
+                                self.browser.scroll(detail_target, y=1200)
+                                detail: dict[str, Any] = {}
+                                detail_status = "selector_changed"
+                                for attempt in range(RENDER_POLL_ATTEMPTS):
+                                    detail = _payload(self.browser.evaluate(detail_target, JS_EXTRACT_DETAIL))
+                                    detail_status = str(detail.get("status") or "selector_changed")
+                                    if detail_status in {"ready", "blocked", "offline"}:
+                                        break
+                                    if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
+                                        return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                            finally:
+                                self.browser.close_tab(detail_target)
+                            if detail_status == "blocked":
+                                return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘详情页出现验证或限流，已停止整个平台任务")
+                            if detail_status == "offline":
+                                hooks.on_parse_failed("猎聘岗位已下线")
+                                continue
+                            if detail_status == "login_required":
+                                hooks.on_parse_failed("猎聘详情页需登录(wow.liepin.com)，仅保存列表信息")
+                                if not hooks.on_candidate(candidate):
+                                    return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
+                                continue
+                            if detail_status == "ready" and str(detail.get("jd") or "").strip():
+                                final = self._candidate_from_detail(detail, candidate)
+                                if not hooks.on_candidate(final):
+                                    return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
+                                continue
+                            # 详情页 JD 不可用（职位簇/跳转登录墙）：保留列表已采集的
+                            # 岗位线索（标题/公司/薪资/城市），不中断整个平台任务。
+                            hooks.on_parse_failed("猎聘详情页JD不可用，仅保存列表信息")
+                            if not hooks.on_candidate(candidate):
+                                return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
+                finally:
+                    self.browser.close_tab(target_id)
+        return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "猎聘搜索结果已采集完毕")
+
+    @staticmethod
+    def _candidate_from_list(raw: Any, city: str, keyword: str) -> JobCandidate | None:
+        if not isinstance(raw, dict):
+            return None
+        source_id = str(raw.get("source_job_id") or "").strip()
+        title = str(raw.get("title") or "").strip()
+        url = str(raw.get("url") or "").strip().split("?")[0]
+        if not source_id or not title or not url.startswith("https://www.liepin.com/job/"):
+            return None
+        return JobCandidate(
+            platform="liepin",
+            source_job_id=source_id,
+            title=title,
+            company=str(raw.get("company") or "").strip(),
+            salary=str(raw.get("salary") or "").strip(),
+            city=str(raw.get("city") or city).strip(),
+            experience=str(raw.get("experience") or "").strip(),
+            education=str(raw.get("education") or "").strip(),
+            url=url,
+            source_keyword=keyword,
+        )
+
+    @staticmethod
+    def _candidate_from_detail(detail: dict[str, Any], base: JobCandidate) -> JobCandidate:
+        # Liepin detail pages are "job clusters": the rendered detail identity
+        # (title/company/salary) can rotate per load and disagree with the search
+        # card. The search card is the stable identity; the detail page is only
+        # trusted for the JD body (section.job-intro-container is unique to the
+        # main job). Keep every other field from the list candidate.
+        return JobCandidate(
+            platform="liepin",
+            source_job_id=base.source_job_id,
+            title=base.title,
+            company=base.company,
+            salary=base.salary,
+            city=base.city,
+            experience=base.experience,
+            education=base.education,
+            jd=str(detail.get("jd") or base.jd or "").strip(),
+            url=base.url,
+            source_keyword=base.source_keyword,
+        )

--- a/tests/test_liepin_collector.py
+++ b/tests/test_liepin_collector.py
@@ -1,0 +1,367 @@
+import json
+from unittest import TestCase
+
+from bosshunter.collection.base import CollectorHooks
+from bosshunter.collection.models import PlatformCollectionRequest
+from bosshunter.collection.orchestrator import normalize_collection_options
+from bosshunter.collection.platforms.liepin import (
+    JS_EXTRACT_DETAIL,
+    JS_EXTRACT_LIST,
+    LiepinBrowser,
+    LiepinCollector,
+    get_liepin_city_code,
+)
+from bosshunter.collection.text import clean_job_description
+
+
+class LiepinCollectorTests(TestCase):
+    def test_list_script_uses_stable_attribute_selector(self):
+        self.assertIn('a[data-nick="job-detail-job-info"]', JS_EXTRACT_LIST)
+        self.assertIn("liepin", JS_EXTRACT_LIST)
+        self.assertIn("job", JS_EXTRACT_LIST)
+
+    def test_detail_script_targets_job_description(self):
+        self.assertIn("job-intro-container", JS_EXTRACT_DETAIL)
+        self.assertIn("job-title-box", JS_EXTRACT_DETAIL)
+
+    def test_city_and_option_defaults_are_fail_closed(self):
+        self.assertEqual(get_liepin_city_code("北京市"), "010")
+        self.assertEqual(get_liepin_city_code("上海市"), "020")
+        self.assertEqual(get_liepin_city_code("广州市"), "050")
+        self.assertIsNone(get_liepin_city_code("未知城市"))
+        options = normalize_collection_options({}, {
+            "platform_order": ["liepin"],
+            "platforms": {"liepin": {"keywords": ["AI 产品"], "cities": ["上海"]}},
+        })
+        search = options["platforms"]["liepin"]
+        self.assertEqual(search["city_codes"], {"上海": "020"})
+        self.assertEqual(search["max_pages"], 1)
+        self.assertNotIn("target_count", search)
+
+    def test_beijing_search_uses_verified_liepin_city_code(self):
+        request = PlatformCollectionRequest(
+            "liepin",
+            ["AI 产品"],
+            ["北京"],
+            {"北京": "010"},
+            max_pages=1,
+        )
+
+        url = LiepinCollector.build_search_url(request, "北京", "AI 产品")
+
+        self.assertIn("dqs=010", url)
+        self.assertIn("key=AI%20%E4%BA%A7%E5%93%81", url)
+
+    def test_collection_uses_platform_identity_and_rate_limit(self):
+        list_payload = json.dumps({"status": "ready", "jobs": [
+            {
+                "source_job_id": "job-1",
+                "title": "AI 产品经理",
+                "company": "示例公司",
+                "city": "上海",
+                "url": "https://www.liepin.com/job/1001.shtml",
+            },
+            {
+                "source_job_id": "job-2",
+                "title": "AI 产品运营",
+                "company": "示例公司",
+                "city": "上海",
+                "url": "https://www.liepin.com/job/1002.shtml",
+            },
+        ]}, ensure_ascii=False)
+        detail_payload = json.dumps({
+            "status": "ready",
+            "title": "AI 产品",
+            "company": "示例公司",
+            "city": "上海",
+            "jd": "负责需求分析，来自BOSS直聘要求会SQL。",
+        }, ensure_ascii=False)
+        sleeps: list[float] = []
+
+        def evaluate(_target, script):
+            return list_payload if "job-detail-job-info" in script else detail_payload
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or len(collected) < 2,
+            on_parse_failed=lambda reason: self.fail(reason),
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=sleeps.append,
+            uniform=lambda _low, _high: 13.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI 产品"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.reason_code, "callback_stopped")
+        self.assertEqual([candidate.storage_id for candidate in collected], ["liepin:job-1", "liepin:job-2"])
+        self.assertEqual(sleeps, [13.0, 13.0])
+        self.assertIn("需求分析", collected[0].jd)
+
+    def test_verification_page_stops_platform(self):
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=lambda _target, _script: json.dumps({"status": "blocked", "jobs": []}),
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(browser=browser).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason_code, "rate_limit")
+
+    def test_collection_waits_for_spa_list_render(self):
+        evaluations = 0
+        sleeps = []
+
+        def evaluate(_target, script):
+            nonlocal evaluations
+            if "job-detail-job-info" in script:
+                evaluations += 1
+                if evaluations < 3:
+                    return json.dumps({"status": "waiting", "jobs": []})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-spa",
+                    "title": "AI 运营",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://www.liepin.com/job/2001.shtml",
+                }]})
+            return json.dumps({
+                "status": "ready", "title": "AI 运营", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 产品运营与数据分析。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: False,
+            on_parse_failed=lambda reason: self.fail(reason),
+            on_event=lambda **_kwargs: None,
+        )
+
+        result = LiepinCollector(browser=browser, sleep=sleeps.append).collect(
+            PlatformCollectionRequest("liepin", ["AI运营"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.reason_code, "callback_stopped")
+        self.assertEqual(evaluations, 3)
+        self.assertEqual(sleeps[:2], [0.75, 0.75])
+
+    def test_multi_page_collection_uses_url_pagination_and_pacing(self):
+        list_calls = {"n": 0}
+
+        def evaluate(_target, script):
+            if "job-detail-job-info" in script:
+                list_calls["n"] += 1
+                if list_calls["n"] == 1:
+                    return json.dumps({"status": "ready", "jobs": [{
+                        "source_job_id": "job-p1",
+                        "title": "AI 资深工程师",
+                        "company": "示例公司",
+                        "city": "上海",
+                        "url": "https://www.liepin.com/job/3001.shtml",
+                    }]})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-p2",
+                    "title": "AI 数据工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://www.liepin.com/job/3002.shtml",
+                }]})
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 平台研发。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=2),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual(
+            [c.storage_id for c in collected],
+            ["liepin:job-p1", "liepin:job-p2"],
+        )
+
+    def test_last_page_completes_gracefully(self):
+        list_calls = {"n": 0}
+
+        def evaluate(_target, script):
+            if "job-detail-job-info" in script:
+                list_calls["n"] += 1
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": f"job-{list_calls['n']}",
+                    "title": "AI 工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": f"https://www.liepin.com/job/{4000 + list_calls['n']}.shtml",
+                }]})
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 研发。",
+            })
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=3),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual(len(collected), 3)
+
+    def test_login_required_detail_keeps_list_info(self):
+        list_payload = json.dumps({"status": "ready", "jobs": [{
+            "source_job_id": "job-login",
+            "title": "AI 架构师",
+            "company": "示例公司",
+            "city": "上海",
+            "url": "https://www.liepin.com/job/5001.shtml",
+        }]}, ensure_ascii=False)
+
+        def evaluate(_target, script):
+            if "job-detail-job-info" in script:
+                return list_payload
+            return json.dumps({"status": "login_required"})
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        parse_failures = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda reason: parse_failures.append(reason),
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 13.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0].title, "AI 架构师")
+        self.assertTrue(any("登录" in f or "wow.liepin" in f for f in parse_failures))
+
+    def test_offline_detail_skips_gracefully(self):
+        list_payload = json.dumps({"status": "ready", "jobs": [{
+            "source_job_id": "job-offline",
+            "title": "AI 研究员",
+            "company": "示例公司",
+            "city": "上海",
+            "url": "https://www.liepin.com/job/6001.shtml",
+        }]}, ensure_ascii=False)
+
+        def evaluate(_target, script):
+            if "job-detail-job-info" in script:
+                return list_payload
+            return json.dumps({"status": "offline"})
+
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 13.0,
+        ).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(collected), 0)


### PR DESCRIPTION
## Summary

从 PR #89（@likris588-ux）拆分出平台适配域部分，补充适配测试，作为干净的采集器 PR。

## 背景

PR #89 包含 13 个文件，跨 3 个域：
- 平台适配域（liepin 采集器）4 文件
- 核心与安全域（job51 fail-closed 放宽）1 文件
- 产品与AI域（前端接入）8 文件

经平台适配域正式维护者 Review（PR #89 评论），要求拆分为 3 个 PR。本 PR 是拆分后的平台适配域部分。

## 来源与致谢

- liepin.py / capabilities.py / models.py / orchestrator.py 来自 PR #89，作者 @likris0ris588-ux
  - 已实测核验（2026-08-26）
  - 17 个城市码
  - 稳定属性选择器 a[data-nick="job-detail-job-info"]（非 CSS-module hashed class）
  - 处理 wow.liepin.com 302 跳转（login_required 状态）
- tests/test_liepin_collector.py 适配自 PR #111（yuppiez99999，已关闭）
  - 11 个测试用例

## 测试覆盖

11 个测试覆盖：稳定属性选择器 / 详情页 JD 定位 / 城市码 fail-closed / 搜索 URL / 平台标识+速率间隔 / 验证页 fail-closed / SPA 渲染等待 / URL 翻页+间隔 / 末页优雅完成 / login_required 保留列表 / offline 跳过

## 安全约束

- 采集-only（capabilities: collect/score/greet，无 deliver/monitor）
- fail-closed（验证/限流信号立即停止整个平台任务）
- 不绕过安全机制（页面上下文操作，复用会话 cookie）
- 17 城市码已核验，未知城市拒绝而非猜测

## 验证

tests/test_liepin_collector.py: 11 passed
tests/test_job51_collector.py: 8 passed（无回归）

## 后续

- job51 fail-closed 放宽部分需 @likris588-ux 单独提交 PR 并标注 domain:core-security 请求共审
- 前端接入部分需单独提交 PR 到产品与AI域
