### PR TITLE
test: 整理运行边界与 51job 安全回归 (#95 #97 #98 #99)

### DIFF
--- a/src/bosshunter/collection/orchestrator.py
+++ b/src/bosshunter/collection/orchestrator.py
@@ -160,13 +160,15 @@ def validate_collection_options(options: dict[str, Any]) -> dict[str, Any]:
                 names = "、".join(missing_cities)
                 raise ValueError(f"智联暂未内置城市编码：{names}；请换用采集窗口提供的城市名称，不能填写 BOSS 编码")
         if platform == "51job":
+            unsupported_cities: list[str] = []
             for city in cities:
                 resolved = get_51job_city_code(city)
                 if resolved:
                     city_codes[city] = resolved
-            missing_cities = [city for city in cities if not city_codes.get(city)]
-            if missing_cities:
-                names = "、".join(missing_cities)
+                else:
+                    unsupported_cities.append(city)
+            if unsupported_cities:
+                names = "、".join(unsupported_cities)
                 raise ValueError(f"51job 当前只开放已验证城市：{names} 尚未支持；不会猜测城市编码")
         try:
             max_pages = int(value.get("max_pages", 3))

--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -350,7 +350,8 @@ def mark_external_jobs_sent(conn: sqlite3.Connection, job_ids: Any, *, confirmed
         for row in pending_rows:
             job_id = str(row["id"])
             platform = str(row.get("source_platform") or "")
-            detail = f"用户在{platform_labels[platform]}完成投递后手动标记"
+            platform_label = platform_labels.get(platform, platform)
+            detail = f"用户在{platform_label}完成投递后手动标记"
             conn.execute(
                 "UPDATE jobs SET status = 'sent', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND deleted_at IS NULL",
                 (job_id,),

--- a/tests/test_collection_51job_city_validation.py
+++ b/tests/test_collection_51job_city_validation.py
@@ -1,0 +1,69 @@
+"""51job 城市编码校验的 fail-closed 边界测试（平台适配域）。
+
+项目在 collection/orchestrator.py 对 51job 做了"未知城市必须核验、
+否则 ValueError 拒绝"的安全边界，防止用猜测的城市编码发起采集。
+此前该分支没有任何测试覆盖，本文件补齐。
+"""
+
+import unittest
+
+from bosshunter.collection.orchestrator import normalize_collection_options
+
+
+def _options_for_51job(cities, *, city_codes=None):
+    return {
+        "platform_order": ["51job"],
+        "auto_score": False,
+        "platforms": {
+            "51job": {
+                "keywords": ["AI"],
+                "cities": cities,
+                "city_codes": city_codes or {},
+                "max_pages": 1,
+                "sort": "default",
+            },
+        },
+    }
+
+
+class Job51CityValidationTests(unittest.TestCase):
+    def test_known_city_passes_and_resolves_code(self):
+        result = normalize_collection_options({}, _options_for_51job(["上海"]))
+        codes = result["platforms"]["51job"]["city_codes"]
+        self.assertEqual(codes, {"上海": "020000"})
+
+    def test_city_name_normalization_is_applied(self):
+        # "上海市" 应归一化为 "上海" 后被快照识别，而非当成未知城市。
+        result = normalize_collection_options({}, _options_for_51job(["上海市"]))
+        codes = result["platforms"]["51job"]["city_codes"]
+        self.assertEqual(codes, {"上海市": "020000"})
+
+    def test_unknown_city_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            normalize_collection_options({}, _options_for_51job(["广州"]))
+        self.assertIn("尚未支持", str(ctx.exception))
+        self.assertIn("不会猜测城市编码", str(ctx.exception))
+
+    def test_mixed_cities_all_rejected_when_any_unknown(self):
+        # 已知城市不应被悄悄放行：只要有一个未知城市，整批被拒。
+        with self.assertRaises(ValueError) as ctx:
+            normalize_collection_options({}, _options_for_51job(["上海", "广州"]))
+        self.assertIn("广州", str(ctx.exception))
+        self.assertIn("尚未支持", str(ctx.exception))
+
+    def test_external_city_code_override_still_requires_verified_city(self):
+        # 即便传入了自定义 city_codes，未知城市仍须经过 get_51job_city_code
+        # 核验，不能通过外部编码绕过快照校验。
+        with self.assertRaises(ValueError):
+            normalize_collection_options(
+                {}, _options_for_51job(["广州"], city_codes={"广州": "999999"})
+            )
+
+    def test_only_verified_cities_appear_in_normalized_codes(self):
+        # 已知 + 未知混合时，归一化结果不应包含任何未核验城市。
+        with self.assertRaises(ValueError):
+            normalize_collection_options({}, _options_for_51job(["上海", "广州"]))
+        # 成功路径下，city_codes 只含快照已核验城市。
+        result = normalize_collection_options({}, _options_for_51job(["上海"]))
+        self.assertEqual(set(result["platforms"]["51job"]["city_codes"].keys()), {"上海"})
+

--- a/tests/test_job51_collector.py
+++ b/tests/test_job51_collector.py
@@ -74,6 +74,7 @@ class Job51CollectorTests(TestCase):
         def evaluate(_target, script):
             return list_payload if ".joblist-item" in script else detail_payload
 
+        sleeps = []
         browser = Job51Browser(
             new_tab=lambda url, **_kwargs: url,
             close_tab=lambda _target: True,
@@ -172,6 +173,123 @@ class Job51CollectorTests(TestCase):
         self.assertEqual(sleeps, [0.75, 0.75])
 
 
+    def test_multi_page_collection_clicks_next_and_applies_pacing(self):
+        # 覆盖 page>1 的翻页分支（此前无测试）：第一页采集后点击下一页，
+        # 第二页再次渲染出岗位；翻页安全间隔应被施加一次。
+        list_calls = {"n": 0}
+        next_clicks = []
+
+        def evaluate(target, script):
+            if ".joblist-item" in script:
+                list_calls["n"] += 1
+                if list_calls["n"] == 1:
+                    return json.dumps({"status": "ready", "jobs": [{
+                        "source_job_id": "job-p1",
+                        "title": "AI 算法工程师",
+                        "company": "示例公司",
+                        "city": "上海",
+                        "url": "https://jobs.51job.com/shanghai/job-p1.html",
+                    }]})
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": "job-p2",
+                    "title": "AI 数据工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": "https://jobs.51job.com/shanghai/job-p2.html",
+                }]})
+            if "btn-next" in script:
+                next_clicks.append(script)
+                return True  # 模拟存在下一页按钮
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 平台研发。",
+            })
+
+        sleeps = []
+        browser = Job51Browser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = Job51Collector(
+            browser=browser,
+            sleep=sleeps.append,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=2),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual(
+            [c.storage_id for c in collected],
+            ["51job:job-p1", "51job:job-p2"],
+        )
+        # 第二页触发了一次 JS_CLICK_NEXT 调用
+        self.assertEqual(len(next_clicks), 1)
+        # 一次翻页间隔，另一次是第二个详情页之前的安全间隔。
+        self.assertEqual(sleeps, [33.0, 33.0])
+
+    def test_last_page_without_next_button_completes_gracefully(self):
+        # 翻到第二页时若已无下一页按钮（JS_CLICK_NEXT 返回 False），
+        # 应优雅结束而非报错。
+        list_calls = {"n": 0}
+
+        def evaluate(target, script):
+            if ".joblist-item" in script:
+                list_calls["n"] += 1
+                return json.dumps({"status": "ready", "jobs": [{
+                    "source_job_id": f"job-{list_calls['n']}",
+                    "title": "AI 工程师",
+                    "company": "示例公司",
+                    "city": "上海",
+                    "url": f"https://jobs.51job.com/shanghai/job-{list_calls['n']}.html",
+                }]})
+            if "btn-next" in script:
+                return False  # 最后一页，无下一页按钮
+            return json.dumps({
+                "status": "ready", "title": "AI 工程师", "company": "示例公司",
+                "city": "上海", "jd": "负责 AI 研发。",
+            })
+
+        browser = Job51Browser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=evaluate,
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        collected = []
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda candidate: collected.append(candidate) or True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = Job51Collector(
+            browser=browser,
+            sleep=lambda _s: None,
+            uniform=lambda _low, _high: 33.0,
+        ).collect(
+            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=3),
+            hooks,
+        )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "search_exhausted")
+        self.assertEqual([c.storage_id for c in collected], ["51job:job-1"])
 class JobDescriptionCleanupTests(TestCase):
     def test_known_platform_source_noise_is_removed(self):
         dirty = "[岗位kanzhun职责]1.公司业务后台开发 来自BOSS直聘 2.掌握 SQL"

--- a/tests/test_manual_external_sent.py
+++ b/tests/test_manual_external_sent.py
@@ -78,3 +78,29 @@ def test_manual_sent_requires_explicit_confirmation():
                 mark_external_jobs_sent(db, ["external"], confirmed=False)
         finally:
             db.close()
+
+
+def test_manual_sent_falls_back_to_platform_code_when_label_missing(monkeypatch):
+    import bosshunter.db as db_module
+
+    monkeypatch.setattr(
+        db_module,
+        "EXTERNAL_MANUAL_SEND_PLATFORMS",
+        db_module.EXTERNAL_MANUAL_SEND_PLATFORMS | {"boss"},
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        db = get_db(Path(temporary) / "jobs.db")
+        try:
+            insert_job(db, _job("boss-extra", "boss"))
+            result = mark_external_jobs_sent(db, ["boss-extra"], confirmed=True)
+            history = db.execute(
+                "SELECT action, detail FROM history WHERE job_id = ? ORDER BY id",
+                ("boss-extra",),
+            ).fetchall()
+        finally:
+            db.close()
+
+    assert result["affected_count"] == 1
+    assert [(row["action"], row["detail"]) for row in history] == [
+        ("manual_sent", "用户在boss完成投递后手动标记"),
+    ]

--- a/tests/test_run_store_boundaries.py
+++ b/tests/test_run_store_boundaries.py
@@ -1,0 +1,171 @@
+"""Boundary tests for collection/scoring run stores (DB layer).
+
+These cover JSON round-tripping, terminal-status side effects, limit
+clamping and orphan recovery without touching network or AI paths.
+"""
+
+import tempfile
+from pathlib import Path
+
+from bosshunter.collection_run_store import (
+    create_collection_run,
+    get_collection_run,
+    list_collection_runs,
+    mark_orphaned_collection_runs_stopped,
+    update_collection_run,
+)
+from bosshunter.scoring_run_store import (
+    TERMINAL_RUN_STATUSES,
+    create_scoring_run,
+    get_scoring_run,
+    list_scoring_runs,
+    mark_orphaned_scoring_runs_paused,
+    update_scoring_run,
+)
+
+
+def _tmp_db() -> Path:
+    return Path(tempfile.mkdtemp()) / "runs.db"
+
+
+# ---------------------------------------------------------------------------
+# collection_run_store
+# ---------------------------------------------------------------------------
+
+
+def test_create_then_get_decodes_json_fields():
+    db = _tmp_db()
+    create_collection_run(
+        db,
+        run_id="run-1",
+        options={"city": "北京", "keyword": "Python"},
+        platform_states={"zhilian": {"page": 3}},
+    )
+    row = get_collection_run(db, "run-1")
+    assert row is not None
+    assert row["options"] == {"city": "北京", "keyword": "Python"}
+    assert row["platform_states"] == {"zhilian": {"page": 3}}
+    assert row["collected_job_ids"] == []
+
+
+def test_get_missing_collection_run_returns_none():
+    db = _tmp_db()
+    assert get_collection_run(db, "nope") is None
+
+
+def test_terminal_status_sets_finished_at():
+    db = _tmp_db()
+    create_collection_run(db, run_id="run-1", options={}, platform_states={})
+    update_collection_run(db, "run-1", status="completed")
+    row = get_collection_run(db, "run-1")
+    assert row["status"] == "completed"
+    assert row["finished_at"] is not None
+
+
+def test_non_terminal_status_does_not_set_finished_at():
+    db = _tmp_db()
+    create_collection_run(db, run_id="run-1", options={}, platform_states={})
+    update_collection_run(db, "run-1", status="running")
+    row = get_collection_run(db, "run-1")
+    assert row["finished_at"] is None
+
+
+def test_list_collection_runs_clamps_limit():
+    db = _tmp_db()
+    for i in range(5):
+        create_collection_run(db, run_id=f"run-{i}", options={}, platform_states={})
+    assert len(list_collection_runs(db, limit=0)) == 1      # <1 clamped to 1
+    assert len(list_collection_runs(db, limit=2)) == 2
+    assert len(list_collection_runs(db, limit=9999)) == 5    # >100 clamped (only 5 exist)
+
+
+def test_mark_orphaned_collection_runs_only_affects_active():
+    db = _tmp_db()
+    create_collection_run(db, run_id="active", options={}, platform_states={})
+    create_collection_run(db, run_id="done", options={}, platform_states={})
+    update_collection_run(db, "done", status="completed")
+
+    affected = mark_orphaned_collection_runs_stopped(db)
+    assert affected == 1
+    assert get_collection_run(db, "active")["status"] == "stopped"
+    assert get_collection_run(db, "done")["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# scoring_run_store
+# ---------------------------------------------------------------------------
+
+
+def test_create_scoring_run_initializes_progress():
+    db = _tmp_db()
+    run = create_scoring_run(db, run_id="s-1", options={"model": "x"}, job_ids=["a", "b", "c"])
+    assert run["options"] == {"model": "x"}
+    assert run["remaining_job_ids"] == ["a", "b", "c"]
+    assert run["progress"] == {"selected": 3, "completed": 0}
+    assert run["recoverable"] is False
+
+
+def test_recoverable_true_only_when_paused_with_remaining():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="paused", remaining_job_ids=["a"])
+    assert get_scoring_run(db, "s-1")["recoverable"] is True
+
+    update_scoring_run(db, "s-1", status="paused", remaining_job_ids=[])
+    assert get_scoring_run(db, "s-1")["recoverable"] is False
+
+
+def test_scoring_terminal_status_sets_finished_at():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="completed")
+    assert get_scoring_run(db, "s-1")["finished_at"] is not None
+
+
+def test_scoring_running_resumes_paused_and_clears_error():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="paused", error="boom")
+    update_scoring_run(db, "s-1", status="running")
+    row = get_scoring_run(db, "s-1")
+    assert row["status"] == "running"
+    assert row["finished_at"] is None
+    assert row["error"] is None
+
+
+def test_scoring_running_cannot_resurrect_terminal_run():
+    # 已终态的 run 不应被 update_scoring_run(running=...) 改回 running，
+    # 这是由 WHERE status NOT IN (终态) 保护的安全边界。
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={}, job_ids=["a"])
+    update_scoring_run(db, "s-1", status="completed")
+    update_scoring_run(db, "s-1", status="running")
+    assert get_scoring_run(db, "s-1")["status"] == "completed"
+
+
+def test_mark_orphaned_scoring_runs_pauses_active_only():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="active", options={}, job_ids=["a"])
+    create_scoring_run(db, run_id="done", options={}, job_ids=["b"])
+    update_scoring_run(db, "done", status="completed")
+
+    affected = mark_orphaned_scoring_runs_paused(db)
+    assert affected == 1
+    assert get_scoring_run(db, "active")["status"] == "paused"
+    assert get_scoring_run(db, "done")["status"] == "completed"
+
+
+def test_list_scoring_runs_returns_decoded_rows():
+    db = _tmp_db()
+    create_scoring_run(db, run_id="s-1", options={"k": 1}, job_ids=["a"])
+    rows = list_scoring_runs(db, limit=10)
+    assert len(rows) == 1
+    assert rows[0]["options"] == {"k": 1}
+    assert rows[0]["remaining_job_ids"] == ["a"]
+
+
+def test_terminal_run_statuses_are_consistent():
+    # 防御性测试：确保 TERMINAL_RUN_STATUSES 与 update 逻辑认知一致，
+    # 后续若有人改动常量不会破坏终态判断。
+    assert TERMINAL_RUN_STATUSES == {"completed", "completed_with_errors", "failed", "stopped"}
+


### PR DESCRIPTION
从维护人 @yuppiez99999 的 #95、#97、#98、#99 中，仅提取相对最新 `main` 仍有效的内容，并整理为单个无历史叠加的提交。

包含：
- #95：手动标记外部投递时，未知平台标签回退为平台代码，避免 `KeyError`。
- #97：collection/scoring run store 的 JSON、终态、恢复、limit 与孤儿任务边界测试；修正了原测试中“终态可恢复运行”的矛盾假设。
- #98：51job 翻页、末页安全结束及等待间隔测试。
- #99：51job 城市验证测试，并收紧为只接受内置已核验城市，外部 `city_codes` 不能绕过安全校验。

作者署名保留为 @yuppiez99999。没有带入各旧分支落后或重复的历史提交。

验证：
- 相关测试：41 passed
- 完整测试：495 passed, 16 subtests passed
- `git diff --check`：通过

合并本 PR 后，原 #95/#97/#98/#99 可由本 PR 替代并关闭。