### PR TITLE
test(capabilities): 补齐 capabilities.py 测试覆盖率 0% → 100%

### DIFF
--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,37 @@
+import unittest
+
+from bosshunter.collection.capabilities import PLATFORM_CAPABILITIES, platform_supports
+
+
+class PlatformCapabilitiesTests(unittest.TestCase):
+    def test_boss_has_full_capabilities(self):
+        self.assertTrue(platform_supports("boss", "collect"))
+        self.assertTrue(platform_supports("boss", "score"))
+        self.assertTrue(platform_supports("boss", "greet"))
+        self.assertTrue(platform_supports("boss", "deliver"))
+        self.assertTrue(platform_supports("boss", "monitor"))
+
+    def test_new_platforms_are_read_only(self):
+        for platform in ("zhilian", "51job", "liepin"):
+            self.assertTrue(platform_supports(platform, "collect"))
+            self.assertTrue(platform_supports(platform, "score"))
+            self.assertTrue(platform_supports(platform, "greet"))
+            self.assertFalse(platform_supports(platform, "deliver"))
+            self.assertFalse(platform_supports(platform, "monitor"))
+
+    def test_unknown_platform_supports_nothing(self):
+        self.assertFalse(platform_supports("unknown", "collect"))
+        self.assertFalse(platform_supports("nonexistent", "score"))
+
+    def test_unknown_capability_returns_false(self):
+        self.assertFalse(platform_supports("boss", "nonexistent"))
+
+    def test_capability_map_keys(self):
+        self.assertEqual(
+            set(PLATFORM_CAPABILITIES),
+            {"boss", "zhilian", "51job", "liepin"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

补齐 `collection/capabilities.py` 的单元测试，覆盖率从 **0% → 100%**。

## 新增测试（5 个）

| 用例 | 覆盖目标 |
|------|---------|
| boss 全能力 | `platform_supports(boss, deliver/monitor)` = True |
| 新平台只读 | zhilian/51job/liepin 无 deliver/monitor |
| 未知平台 | 返回 False |
| 未知能力 | 返回 False |
| 能力映射键 | `{boss, zhilian, 51job, liepin}` |

## 验证

```
tests/test_capabilities.py: 5 passed
coverage: capabilities.py 100% (3 stmts, 0 miss)
```

## 安全约束

纯测试文件，无功能变更。同时验证了平台适配域安全约束：新平台（zhilian/51job/liepin）均为只读，无 deliver/monitor。