### PR TITLE
fix(liepin): 添加搜索页登录墙检测 + 改进验证码错误提示

### DIFF
--- a/src/bosshunter/collection/platforms/liepin.py
+++ b/src/bosshunter/collection/platforms/liepin.py
@@ -92,6 +92,14 @@ JS_EXTRACT_LIST = r"""
     if (/滑动验证|安全验证|访问过于频繁|请完成安全验证|人机验证|网络异常/.test(pageText)) {
         return JSON.stringify({status: 'blocked', jobs: []});
     }
+    // Login wall detection: Liepin may redirect to wow.liepin.com or show a
+    // login prompt on the search page when the session is not established.
+    if (location.hostname.indexOf('wow.liepin.com') >= 0) {
+        return JSON.stringify({status: 'login_required', jobs: []});
+    }
+    if (/请先登录|登录后查看|请登录|立即登录|登录猎聘/.test(pageText) && !/退出登录/.test(pageText)) {
+        return JSON.stringify({status: 'login_required', jobs: []});
+    }
     var anchors = Array.prototype.slice.call(document.querySelectorAll('a[data-nick="job-detail-job-info"]'));
     if (!anchors.length) {
         return JSON.stringify({status: /没有找到|暂无满足|未找到/.test(text) ? 'empty' : 'waiting', jobs: []});
@@ -280,7 +288,9 @@ class LiepinCollector:
                             if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
                                 return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
                         if status == "blocked":
-                            return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘出现验证或限流信号，已停止整个平台任务")
+                            return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘出现验证码或限流信号，已停止整个平台任务。请稍后在浏览器中手动完成验证后重试。")
+                        if status == "login_required":
+                            return PlatformCollectionResult(self.platform, "blocked", "login_required", "猎聘需要登录，请先在浏览器中登录猎聘（www.liepin.com）后重试采集。")
                         if status in {"empty", "waiting"}:
                             return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "猎聘已无更多结果")
                         if status != "ready" or not isinstance(payload.get("jobs"), list):
@@ -319,7 +329,7 @@ class LiepinCollector:
                             finally:
                                 self.browser.close_tab(detail_target)
                             if detail_status == "blocked":
-                                return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘详情页出现验证或限流，已停止整个平台任务")
+                                return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "猎聘详情页出现验证码或限流，已停止整个平台任务。请稍后在浏览器中手动完成验证后重试。")
                             if detail_status == "offline":
                                 hooks.on_parse_failed("猎聘岗位已下线")
                                 continue

--- a/tests/test_liepin_collector.py
+++ b/tests/test_liepin_collector.py
@@ -392,3 +392,55 @@ class LiepinCollectorTests(TestCase):
 
         self.assertEqual(result.status, "completed")
         self.assertEqual(len(collected), 0)
+
+    def test_list_script_detects_login_wall(self):
+        self.assertIn("login_required", JS_EXTRACT_LIST)
+        self.assertIn("wow.liepin.com", JS_EXTRACT_LIST)
+        self.assertIn("请先登录", JS_EXTRACT_LIST)
+
+    def test_login_required_on_search_page_returns_clear_error(self):
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=lambda _target, _script: json.dumps({"status": "login_required", "jobs": []}),
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(browser=browser).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason_code, "login_required")
+        self.assertIn("登录", result.message)
+
+    def test_verification_message_guides_manual_retry(self):
+        browser = LiepinBrowser(
+            new_tab=lambda url, **_kwargs: url,
+            close_tab=lambda _target: True,
+            evaluate=lambda _target, _script: json.dumps({"status": "blocked", "jobs": []}),
+            scroll=lambda *_args, **_kwargs: True,
+            wait_for_load=lambda *_args, **_kwargs: True,
+        )
+        hooks = CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _candidate: True,
+            on_candidate=lambda _candidate: True,
+            on_parse_failed=lambda _reason: None,
+            on_event=lambda **_kwargs: None,
+        )
+        result = LiepinCollector(browser=browser).collect(
+            PlatformCollectionRequest("liepin", ["AI"], ["上海"], {"上海": "020"}, max_pages=1),
+            hooks,
+        )
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason_code, "rate_limit")
+        self.assertIn("验证码", result.message)
+        self.assertIn("手动", result.message)


### PR DESCRIPTION
## Summary

修复猎聘采集器两个实际问题：
1. **未登录时报模糊错误** — 搜索页没有登录墙检测，未登录时报 `selector_changed` 而非清晰的登录提示
2. **验证码错误消息不清晰** — 用户不知道是验证码问题，也不知道如何处理

## 修改

### `JS_EXTRACT_LIST` 添加登录墙检测
```javascript
// 检测 wow.liepin.com 域名（登录墙子域）
if (location.hostname.indexOf('wow.liepin.com') >= 0) {
    return JSON.stringify({status: 'login_required', jobs: []});
}
// 检测登录文本（排除退出登录）
if (/请先登录|登录后查看|请登录|立即登录|登录猎聘/.test(pageText) && !/退出登录/.test(pageText)) {
    return JSON.stringify({status: 'login_required', jobs: []});
}
```

### `collect` 方法处理 `login_required`
- 搜索页 `login_required` → `blocked` + `login_required` + 猎聘需要登录，请先在浏览器中登录猎聘（www.liepin.com）后重试采集。
- 验证码消息改进 → 猎聘出现验证码或限流信号，已停止整个平台任务。请稍后在浏览器中手动完成验证后重试。

## 新增测试（3 个）

| 测试 | 验证目标 |
|------|---------|
| `test_list_script_detects_login_wall` | JS 包含登录墙检测代码 |
| `test_login_required_on_search_page_returns_clear_error` | 搜索页登录墙返回 `blocked` + `login_required` |
| `test_verification_message_guides_manual_retry` | 验证码消息包含验证码和手动 |

## 验证

```
tests/test_liepin_collector.py: 15 passed (原 12 + 新增 3)
```

## 安全约束

- ✅ fail-closed 保持：登录墙和验证码都停止采集（`blocked`）
- ✅ 不自动登录、不绕过验证码
- ✅ 只读采集约束不变