### PR TITLE
feat(collection): 安全整合 51job API 采集器（接续 #81）

### DIFF
--- a/docs/51job-api-collector.md
+++ b/docs/51job-api-collector.md
@@ -1,0 +1,157 @@
+# 51job API 采集器设计说明
+
+本文档面向维护者，说明 `collection/platforms/job51.py` 从 DOM 解析切换为 API 抓取后的核心设计，以及配套的断点续采与编排器改动。阅读本文有助于理解「为什么这么写」，避免在后续维护中把**刻意设计**当作 BUG 修复。
+
+---
+
+## 1. 概述
+
+原实现通过 DOM 选择器解析 51job 搜索/列表页（依赖 `sensorsdata` 属性），并对每条职位单独打开详情页读取 JD，脆弱且缓慢。
+
+新实现在页面上下文内直接调用 `we.51job.com/api/job/search-pc` 搜索 API，单次请求同时返回职位列表与 JD（`jobDescribe`），**无需逐条打开详情页**。对外保持 `collection/` 共享管线契约不变（`Job51Collector` 实现 `Collector` 协议、`PlatformCollectionRequest` / `JobCandidate` / `CollectionBlockedError` 语义一致），因此 orchestrator 与 registry 无需结构性改造。
+
+涉及的三个文件：
+
+| 文件 | 改动 |
+|------|------|
+| `collection/platforms/job51.py` | 核心重写（API 抓取 + 组合式采样 + 主动末页判定 + 风控分级 + 自适应速率） |
+| `db.py` | 追加两级断点续采（2 张表 + 8 个辅助函数） |
+| `collection/orchestrator.py` | +2 行，向默认 registry 的 `Job51Collector` 注入 `config` 与 `safety_conn` |
+
+---
+
+## 2. 关键常量
+
+```python
+API_PAGE_SIZE = 20   # 每页条数（搜索 API 上限 20，实测稳定）
+HARD_MAX_PAGES = 50  # 51job 搜索结果封顶 50 页（页面上限，非防御值）
+```
+
+- `HARD_MAX_PAGES = 50` 是 51job 搜索结果的**原生封顶**（20 条/页 × 50 页 = 1000 条），不是人为设置的防御上限。超过该值的翻页请求不会返回数据。
+- `totalCount` 是「关键词 + 城市」的**全词命中总数**，与 `pageNum` 无关；真实可翻页数须由它反推（见第 4 节）。
+
+---
+
+## 3. 组合式采样策略
+
+这是本模块最核心的设计，**请勿当作冗余逻辑删改**。目标：在「页面上限 50 页」与「真实末页可能远小于 50」两种情况下，都能以有限请求覆盖足够多的职位，同时避免对 51job 造成压力。
+
+采样由多段**刻意叠加**的针组成，顺序如下：
+
+1. **分布式探针（前密后疏 + 随机 + 不相邻）**
+   在页码范围前半段密度高、后半段密度低地随机撒点，且任意两针不相邻。确认是零结果或越过真实末页时才跳过；其他异常立即停止。
+
+2. **保底针（补足 ~70% 覆盖，固定纳入 P2）**
+   探针的不相邻约束会在页面之间留下缝隙，保底针用于把这些缝隙补到约 70% 覆盖。
+   > ⚠️ **固定 P2 保底针是刻意设计，不是 BUG**：因为探针段不允许相邻，第 2 页会天然落入「相邻缝隙」，必须由保底针补上。看到 `page=2` 固定出现时请勿「优化」掉。
+
+3. **热区 ±3 扫描**
+   对命中热点页（有有效职位且相关性高的页）向左右各扩 3 页精细扫描，提升命中区域覆盖率。
+
+4. **随机插一针**
+   在未覆盖区间再随机补一针，降低分布的系统性偏差。
+
+5. **续采起点 / 邻位强制纳入**
+   断点续采恢复后，续采起点页与其相邻页强制纳入本轮采样；正式热区按页码升序处理，使单页码检查点始终可以安全地从 `N+1` 恢复。
+
+6. **饱和跳过**
+   连续数页无新职位（去重后）则判定该关键词已饱和，提前结束，避免无谓翻页。
+
+### 3.1 空页与风控的区分（关键）
+
+探针段遇到**空页**是正常现象（尤其真实末页远小于 50 时），必须与「风控拦截导致的非 JSON」区分开：
+
+- `status=1`、`totalCount=0` → 合法的零结果，继续其他关键词。
+- `items` 为空且当前页大于 `totalCount` 推导出的真实末页 → 合法越界页，收窄页数后跳过。
+- 风控拦截、限流、解析失败或有效范围内异常空页 → 抛 `CollectionBlockedError`，不把关键词标记成已完成。
+
+若把「翻到不存在页」误当风控，会导致整个平台误停 —— 这正是第 4 节「主动末页判定」要解决的历史问题。
+
+---
+
+## 4. 主动末页判定
+
+问题：用户设定 50 页，但某关键词实际只有 30 页（`totalCount` 较小）。若仍按 50 页硬翻，翻到第 31 页时 API 返回体与正常空页不同，极易被误判为风控（`non_json` L3），从而误停整个平台。
+
+解法：用 `totalCount` 反推**真实末页**，把热区扩展 / 保底针 / 随机针的有效页码范围收窄到真实末页之内。
+
+```python
+total_pages = (total + API_PAGE_SIZE - 1) // API_PAGE_SIZE
+return min(fallback, max(1, total_pages))
+```
+
+- `_real_last_page(analysis, fallback)`：从响应里的 `totalCount` 计算 `ceil(total/20)`，与传入的 fallback 取小，且不小于 1。
+- `_effective_max`：用主动末页判定结果收窄后续采样的最大页。
+
+效果（实机验证）：关键词设 `max_pages=50` 而实际末页 36 时，探针全部落在有效范围内，保底针全部 ≤ 36，越界第 50 页返回 `empty_items`（**非** `non_json`），不产生误停。
+
+---
+
+## 5. L0-L3 风控分级
+
+`_analyze_api_response(http_status, content_type, body)` 对每次 API 响应分类：
+
+| 级别 | 含义 | 处理 |
+|------|------|------|
+| L0 | `status=1`，有岗位或明确 `totalCount=0` | 继续 |
+| L1 | JSON 解析失败 | 停止并提示接口结构可能变化 |
+| L2 | 普通限流，或有效页 `items` 为空但 `totalCount>0` | 停止，不重试 |
+| L3 | HTTP 非 200、非 JSON、登录/验证码/封禁信号 | 立即停止，不重试 |
+
+设计原则：**宁可漏采，不可硬刚**。所有非正常响应均 fail-closed；只有能够由 `totalCount` 明确证明的正常空结果或越界页可以跳过。
+
+---
+
+## 6. API 自适应速率
+
+`_ApiRateLimiter` 按**总请求数**动态升档（三档，阈值约 65/130），同时叠加「聚类间隔 + 每分钟滑动窗口上限」两条约束。
+
+> ⚠️ **本节逻辑请勿修改 / 放宽。** 速率自适应没有设置回落降档是有意的——51job 对请求频率的容忍度是**账号级累积、单向收紧**的，一旦被识别为高频抓取，放宽一个档位也可能触发封禁。宁可慢，不可快。历史产品决策明确记录了「不要动这里的档位与阈值」。
+
+---
+
+## 7. 两级断点续采
+
+`db.py` 新增两类检查点，均由 `_init_collect_progress(conn)` 建表，并在 `_init_tables` 中随库初始化自动创建：
+
+- **词级**（表 `collect_progress`）：某「城市 + 关键词」组合完成采集即标记，默认 24h 内整词跳过，避免重复高频抓同一个词。
+- **页级**（表 `collect_progress_page`）：记录每个词已采到的页码，续采从 `N+1` 开始，而不是从 0 重来。
+
+新增函数（共 8 个）：
+
+| 词级 | 页级 |
+|------|------|
+| `get_collected_combos` | `get_page_progress` |
+| `clear_collected_combos` | `clear_page_progress` |
+| `prune_collected_combos` | `prune_page_progress` |
+| `mark_combo_collected` | `upsert_page_progress` / `delete_page_progress` |
+
+> 说明：底座库已有 `mark_combo_collected` 语义的函数（`mark_combo_collected` 为新增覆盖），词级检查点复用了「source 维度」的分区方式，页级检查点是 51job API 采集特有（DOM 解析逐条翻页无此概念）的增量。
+
+---
+
+## 8. 编排器注入（orchestrator.py）
+
+默认 registry 下，`Job51Collector` 现在与 `BossCollector` 一样拿到 `config` 与 `safety_conn`：
+
+```python
+collector = (
+    BossCollector(config=self.config, safety_conn=conn)
+    if platform == "boss" and self._uses_default_registry
+    else Job51Collector(config=self.config, safety_conn=conn)
+    if platform == "51job" and self._uses_default_registry
+    else self.registry.get(platform)
+)
+```
+
+否则断点检查点拿不到 DB 连接，续采逻辑会静默失效。
+
+---
+
+## 9. 验证记录
+
+- 三个文件均通过 `ast.parse`。
+- 项目 venv 内 import 级检查：所有符号可解析。
+- 临时库往返测试：`_init_tables` 自动建两张检查点表；词级 / 页级检查点读写往返正确。
+- 实机冒烟（dev 分支、同一逻辑）：单关键词 `max_pages=50`，探针全部落在有效范围，`totalCount` 把有效末页收窄到 36，保底针全部 ≤ 36，越界页返回 `empty_items` 而非 `non_json`，**无误停**。
+- `tests/test_job51_collector.py` 覆盖响应分级、末页判定、探针规划、异常 fail-closed 与升序断点流程。

--- a/src/bosshunter/collection/orchestrator.py
+++ b/src/bosshunter/collection/orchestrator.py
@@ -356,6 +356,8 @@ class CollectionOrchestrator:
                     collector = (
                         BossCollector(config=self.config, safety_conn=conn)
                         if platform == "boss" and self._uses_default_registry
+                        else Job51Collector(config=self.config, safety_conn=conn)
+                        if platform == "51job" and self._uses_default_registry
                         else self.registry.get(platform)
                     )
                     result = collector.collect(request, hooks)

--- a/src/bosshunter/collection/platforms/job51.py
+++ b/src/bosshunter/collection/platforms/job51.py
@@ -1,9 +1,26 @@
-"""Fail-closed 51job collector for the shared multi-platform pipeline.
+"""51job collector — API-fetch 优先 + 组合式策略 + 断点续采 + 分级风控。
 
-The collector intentionally implements collection only.  It does not attempt
-to solve verification challenges, imitate human behaviour, send messages, or
-resume automatically after a risk signal.  Any WAF, slider, silent throttle,
-or unexpected page state stops the current platform run.
+实现官方多平台采集管线（``collection/``）的 ``Collector`` 协议。
+
+与官方 v2.3.1 自带的 DOM 解析版相比，本实现的核心差异与增值点：
+
+1. **数据获取**：用 51job 页面上下文内的 ``fetch`` 直接调搜索 API
+   （``we.51job.com/api/job/search-pc``），一次拿全列表 + 岗位描述（``jobDescribe``），
+   无需逐条开详情页，速度提升一个数量级，且不受 DOM 改版影响。
+2. **组合式采样策略**（侦察兵 + 地毯队）：每个关键词先做「分布式探针」随机采样
+   定位有新增岗位的热区页，探针全空（饱和）则整词跳过；否则对热区 ±3 做定向扫描，
+   并用「保底针」补足 70% 覆盖，用「随机插一针」堵热区外扩缺口。
+3. **两级断点续采**：词级（``collect_progress``，词完成整词跳过）+ 页级
+   （``collect_progress_page``，中途停止从 N+1 页续采）。
+4. **L0-L3 风控分级**：对 API 返回做信号分析（HTTP 状态 / 非 JSON / status!=1 /
+   空 items），命中硬风控或确认降级立即通过 ``CollectionBlockedError`` 停止整个平台
+   任务（不硬闯、不重试），与官方「fail-closed」原则一致，但信号识别更细。
+5. **拟人化节奏**：分簇节奏器（簇内快 + 簇间长停）+ 波浪停顿（短/中/长三档随机）
+   + 每分钟滑动窗口硬上限，统一在一个全局限速器内计数，堵住「多阶段独立计数叠加
+   放大总频率」的漏洞。
+
+风控铁律：任何分级信号一旦确认，立即停止本平台任务并上抛，绝不降级重试、绝不
+切换代理续采。这是累积性单向收紧的账号级风险，只能用冷却化解。
 """
 
 from __future__ import annotations
@@ -15,21 +32,107 @@ from dataclasses import dataclass
 from typing import Any, Callable
 from urllib.parse import quote
 
-from bosshunter.browser import close_tab, evaluate, navigate as browser_navigate, new_tab, scroll, wait_for_load
-from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.browser import close_tab, evaluate, get_page_targets, new_tab
+from bosshunter.collection.base import CollectionBlockedError, CollectorHooks
 from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
+from bosshunter.db import (
+    delete_page_progress,
+    get_collected_combos,
+    get_page_progress,
+    job_identity_exists,
+    mark_combo_collected,
+    prune_collected_combos,
+    prune_page_progress,
+    upsert_page_progress,
+)
+from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
+from bosshunter.throttle import SendWindowChecker, should_take_day_off
 
 
 SEARCH_URL = "https://we.51job.com/pc/search?jobArea={area}&keyword={keyword}"
-DETAIL_DELAY_MIN_SECONDS = 12.0
-DETAIL_DELAY_MAX_SECONDS = 20.0
-PAGE_DELAY_MIN_SECONDS = 30.0
-PAGE_DELAY_MAX_SECONDS = 45.0
-RENDER_POLL_INTERVAL_SECONDS = 0.75
-RENDER_POLL_ATTEMPTS = 10
+API_SEARCH_URL = "https://we.51job.com/api/job/search-pc"
+API_PAGE_SIZE = 20        # 每页条数（API 上限 20，实测稳定）
+API_FETCH_TIMEOUT = 25.0  # 单次 fetch 超时（秒）
 
-# Only codes verified by the contributed implementation are bundled. Unknown
-# cities are rejected instead of guessing or reusing another platform's code.
+# ---- 速率四层防护（共享一个 60s 窗口，堵「多阶段独立计数叠加」漏洞）----
+API_RATE_MAX_PER_MIN = 30        # 每分钟绝对上限（永不超）
+API_RATE_GAP_MIN = 2.0           # 相邻两次请求随机间隔下限（秒）—— 底线 2s
+API_RATE_GAP_MAX = 3.0           # 相邻两次请求随机间隔上限（秒）
+API_BURST_SIZE_MIN = 4           # 簇内连续请求数下限（页）
+API_BURST_SIZE_MAX = 7           # 簇内连续请求数上限（页）
+API_BURST_BREAK_MIN = 20.0       # 簇间休息下限（秒）
+API_BURST_BREAK_MAX = 45.0       # 簇间休息上限（秒）
+
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║  ★★★ API 自适应速率档位（风控核心，禁止修改）★★★                          ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
+# 【为什么需要自适应】51job 风控是「账号级累积性单向收紧」——不是单次请求快不快，
+# 而是「同账号一段时间内打了多少请求」这个总量。固定节奏有两个致命问题：
+#   ① 批量词多、页多时（如 50页×13词=650 次请求），总量一大，即便单次间隔合规，
+#      累计频率仍会越过风控的「每分钟/每小时」阈值，导致中途被限流甚至封号。
+#   ② 固定 2-3s 间隔会形成可被行为审计识别的规律数字（方差小=机器特征）。
+# 因此按「总请求数」动态升档：请求越多 → 间隔越大 / 簇间休息越长 / 每分钟上限越低，
+# 用「更保守的节奏」对冲「更大的总量」，把整批采集的总风险压在可控范围内。
+# 【为什么禁止修改】这三个阈值（65 / 130）与三档参数是踩线调优的产物：
+#   调大阈值 = 更多请求仍走快节奏 = 直接增加封号风险；
+#   调快参数 = 单档节奏变激进的后果同上。
+#   除非同步引入新的风控对冲手段并有实测数据支撑，否则一律保持现状。
+API_ADAPTIVE_LIGHT = 65      # ≤65 次：标准节奏（间隔 2-3s，簇间 20-45s，每分钟 ≤30）
+API_ADAPTIVE_MEDIUM = 130    # 66~130 次：中等保守（间隔 3-5s，簇间 40-80s，每分钟 ≤20）
+                             # >130 次：重度保守（间隔 5-8s，簇间 90-180s，每分钟 ≤12）
+
+# ---------------------------------------------------------------------------
+# 51job 采集页面上限（硬上限，不可超过）
+# ---------------------------------------------------------------------------
+# 51job 搜索结果原生封顶 50 页（每页 20 条 → 最多 1000 条岗位）。超过 50 页的
+# 关键词本质上是「范围过宽」的泛词（单字/通用词），继续采只会：
+#   ① 大量返回无关行业岗位，新增命中率断崖式下跌，白白消耗请求配额；
+#   ② 翻页越深越像机器，触发 51job WAF 风控的概率急剧上升。
+# 因此把防御上限从「防死循环」的 200 页，收紧到贴合平台真实行为的 50 页。
+# 需要扩大单关键词翻页数时，改配置里的 search.max_pages（但永不会超过这里的 50 页）。
+HARD_MAX_PAGES = 50     # 51job 搜索结果封顶 50 页（页面上限，非防御值）
+
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║  ★★★ 采集策略说明（维护者必读，防误删）★★★                                ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
+#
+# 【组合式采样策略 = 侦察兵 + 地毯队】—— 两级兜底是刻意设计，不是 BUG
+#   ① 分布式探针（侦察兵）：前密后疏随机采样，快速定位「有新增岗位」的页面区间。
+#   ② 保底针（地毯队）    ：探针全空（疑似饱和）时，从非探针页补足到约 70% 覆盖，
+#                           防止「探针恰好没命中」造成的假饱和漏检。
+#        → 其中「固定插针第 2 页」是 ★★ 故意设定 ★★：探针第 1 页必采，第 2 页又
+#          被探针的「不相邻约束」排除，若无固定 p2 针，第 2 页会变成永久漏检夹缝。
+#          【严禁把「固定 p2」当成 hardcode 的 BUG 删除或改写！】
+#   ③ 热区 ±3 扫描        ：命中页邻域定向扫描，集中火力扫高概率新增区。
+#   ④ 随机插一针          ：从非热区随机抽 1 页加入热区，堵「热区外扩不足」的缺口。
+#   ⑤ 续采起点/邻位强制纳入：防止断点续采后出现永久性空白页。
+#
+# 【风控规则 = L0-L3 分级 + fail-closed 铁律】—— 累积性单向收紧，只能用冷却化解
+#   L0 正常 / L1 疑似 / L2 确认降级（限流、items 空但 total>0）/ L3 硬风控封禁
+#   任何分级信号一旦确认 → 立即抛 CollectionBlockedError 停掉整个平台任务：
+#     ★ 绝不降级重试 ★ 绝不切换代理续采 ★ 绝不在风控页上硬闯重试 ★
+#   风控信号分析见下文 _analyze_api_response()，由 _reason_code_for() 映射 reason_code。
+#
+# ---- 波浪停顿概率分布（模拟真人「正常翻页—多看几眼—走开一下」）----
+WAVE_SHORT_PROB = 0.60         # 短波：3-5s
+WAVE_MEDIUM_PROB = 0.85        # 中波累计：8-15s（0.60~0.85 区间）
+                                # 长波：20-40s（0.85~1.0 区间）
+
+# ---- 关键词相关性校验（方案 C）----
+# 51job 搜索是分词模糊匹配，会把关键词里的通用职位词（负责人/主管/经理...）
+# 当成独立词匹配，导致其他行业的岗位混入。方案：剥离通用职位词，得到领域词根，
+# 岗位标题必须命中至少一个领域词根才放行。换行业只需改关键词，无需硬编码。
+_GENERIC_ROLE_WORDS = [
+    "主管工程师", "负责人工程师", "副总裁", "总经理", "副总经理", "项目经理",
+    "部门经理", "团队经理", "负责人", "主管", "经理", "总监", "专员",
+    "工程师", "管理员", "顾问", "助理", "实习生", "管培生", "培训生",
+    "专家", "主任", "副总裁", "总裁", "高级", "资深", "初级", "中级", "师",
+]
+_INTERNSHIP_TITLE_TERMS = ("实习", "intern", "internship", "管培")
+
+
+# 城市快照沿用官方已核验编码（北京/上海）；其余城市由 get_51job_city_code 拒绝，
+# 不猜测编码。此处保留与官方相同的快照与解析函数（orchestrator 校验与 server 依赖）。
 CITY_SNAPSHOT = (
     {"name": "北京", "code": "010000"},
     {"name": "上海", "code": "020000"},
@@ -53,95 +156,316 @@ def get_51job_city_code(city: str) -> str | None:
     return None
 
 
-JS_EXTRACT_LIST = r"""
-(function () {
-    var text = (document.body && document.body.innerText) || '';
-    var blocked = /滑动验证页面|请按住滑块|访问验证|访问频繁|请稍后再试/.test(text + ' ' + document.title);
-    if (blocked) return JSON.stringify({status: 'blocked', jobs: []});
-    var cards = Array.prototype.slice.call(document.querySelectorAll('.joblist-item'));
-    if (!cards.length) {
-        var generic = /全国招聘/.test(document.title || '');
-        return JSON.stringify({status: generic ? 'throttled' : 'waiting', jobs: []});
-    }
-    var jobs = [];
-    for (var i = 0; i < cards.length; i++) {
-        var card = cards[i];
-        var jobDiv = card.querySelector('.joblist-item-job, [class*="jobname"], [class*="job-name"]');
-        var dataNode = jobDiv ? (jobDiv.querySelector('[sensorsdata]') || jobDiv) : card.querySelector('[sensorsdata]');
-        var meta = {};
-        try { meta = JSON.parse((dataNode && dataNode.getAttribute('sensorsdata')) || '{}'); } catch (_) {}
-        var id = String(meta.jobId || '').trim();
-        var title = String(meta.jobTitle || '').replace(/^招聘/, '').trim();
-        var linkNode = card.querySelector('a[href*="jobs.51job.com/"]');
-        var jobUrl = linkNode ? String(linkNode.href || '').trim() : '';
-        if (!id || !title || !/^https:\/\/jobs\.51job\.com\//.test(jobUrl) || /APP下载|访问验证/.test(title)) continue;
-        var companyNode = card.querySelector('[class*="company"], [class*="cname"], [class*="comname"], .comp');
-        var company = companyNode ? String(companyNode.innerText || '').trim().split('\n')[0] : '';
-        var area = String(meta.jobArea || '').trim();
-        var city = (area.split('·')[0] || '').trim();
-        var experience = [meta.jobYear || '', meta.jobDegree || ''].filter(Boolean).join('·');
-        jobs.push({
-            source_job_id: id,
-            title: title,
-            company: company,
-            salary: String(meta.jobSalary || '').trim(),
-            city: city,
-            experience: experience,
-            url: jobUrl
+# 在 51job 页面上下文用 fetch 调用搜索 API（同源请求，Referer/cookie 自动正确）。
+# 占位符：__KW__（URL 编码关键词）、__AREA__（城市代码）、__PAGE__（页码）。
+JS_FETCH_API_PAGE = r"""
+(async function () {
+    try {
+        var url = '""" + API_SEARCH_URL + r"""?api_key=51job&timestamp=' + Date.now() +
+            '&keyword=__KW__&searchType=2&jobArea=__AREA__&pageNum=__PAGE__&pageSize=""" + str(API_PAGE_SIZE) + r"""&sortType=0&source=1&scene=7';
+        var resp = await fetch(url, {
+            headers: { 'Accept': 'application/json, text/plain, */*' },
+            credentials: 'include'
         });
+        var text = await resp.text();
+        return JSON.stringify({
+            http_status: resp.status,
+            content_type: (resp.headers.get('content-type') || ''),
+            body: text
+        });
+    } catch (e) {
+        return JSON.stringify({ error: String(e) });
     }
-    return JSON.stringify({status: jobs.length ? 'ready' : 'selector_changed', jobs: jobs});
 })()
 """
 
 
-JS_EXTRACT_DETAIL = r"""
-(function () {
-    var body = (document.body && document.body.innerText) || '';
-    var pageText = body + ' ' + (document.title || '');
-    if (/滑动验证页面|请按住滑块|访问验证|访问频繁|请稍后再试/.test(pageText)) {
-        return JSON.stringify({status: 'blocked'});
-    }
-    if (/当前职位审核中或已下线|职位已下线/.test(pageText)) {
-        return JSON.stringify({status: 'offline'});
-    }
-    var jdNode = document.querySelector('.bmsg.job_msg.inbox > div:first-child, .bmsg.job_msg.inbox');
-    var jd = jdNode ? String(jdNode.innerText || '').replace(/\s+/g, ' ').trim() : '';
-    var titleNode = document.querySelector('.jTitle h1, h1[title], [class*="job-name"]');
-    var salaryNode = document.querySelector('.jTitle strong, [class*="salary"]');
-    var companyNode = document.querySelector('[class*="company"] a, [class*="cname"] a, .comp');
-    var areaNode = document.querySelector('.msg.ltype .type_2, [class*="area"], [class*="location"]');
-    return JSON.stringify({
-        status: jd ? 'ready' : 'selector_changed',
-        title: titleNode ? String(titleNode.innerText || '').replace(/^招聘/, '').trim() : '',
-        salary: salaryNode ? String(salaryNode.innerText || '').trim() : '',
-        company: companyNode ? String(companyNode.innerText || '').trim() : '',
-        city: areaNode ? String(areaNode.innerText || '').trim() : '',
-        jd: jd,
-        url: location.href
-    });
-})()
-"""
+def _wait_or_stop(stop_event, seconds: float) -> bool:
+    """等待指定秒数；返回 True 表示被停止。"""
+    if stop_event is not None:
+        return stop_event.wait(max(0.0, seconds))
+    time.sleep(max(0.0, seconds))
+    return False
 
 
-JS_CLICK_NEXT = r"""
-(function () {
-    var button = document.querySelector('button.btn-next');
-    if (!button || button.disabled || /disabled|is-disabled/.test(button.className || '')) return false;
-    button.click();
-    return true;
-})()
-"""
+def _parse_salary_range(salary: str) -> tuple[float, float] | None:
+    """解析薪资，返回可比较的月薪区间 (minK, maxK)，单位 K/月，失败返回 None。
+
+    内置在本模块内不影响官方 salary 语义；支持 BOSS「15-25K」、51job 中文
+    「8千-1.2万」「1-2万」「1.5-2万·13薪」以及年薪「25-38万/年」（换算月薪）。
+    """
+    import re
+
+    normalized = str(salary or "").strip()
+
+    yearly_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*万\s*/\s*年", normalized,
+    )
+    if yearly_match:
+        lo = float(yearly_match.group(1)) * 10000 / 12 / 1000
+        hi = float(yearly_match.group(2)) * 10000 / 12 / 1000
+        return (round(min(lo, hi), 1), round(max(lo, hi), 1))
+
+    cn_range = re.search(
+        r"(\d+(?:\.\d+)?)\s*([千万])\s*-\s*(\d+(?:\.\d+)?)\s*万", normalized,
+    )
+    if cn_range:
+        lo_val = float(cn_range.group(1))
+        lo_unit = cn_range.group(2)
+        hi_val = float(cn_range.group(3))
+        lo_k = lo_val * (10 if lo_unit == "万" else 1)
+        hi_k = hi_val * 10
+        return (round(min(lo_k, hi_k), 1), round(max(lo_k, hi_k), 1))
+
+    cn_range_plain = re.search(
+        r"(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*万", normalized,
+    )
+    if cn_range_plain:
+        lo_k = float(cn_range_plain.group(1)) * 10
+        hi_k = float(cn_range_plain.group(2)) * 10
+        return (round(min(lo_k, hi_k), 1), round(max(lo_k, hi_k), 1))
+
+    cn_single_wan = re.search(r"(\d+(?:\.\d+)?)\s*万", normalized)
+    if cn_single_wan:
+        value = round(float(cn_single_wan.group(1)) * 10, 1)
+        return value, value
+    cn_single_qian = re.search(r"(\d+(?:\.\d+)?)\s*千", normalized)
+    if cn_single_qian:
+        value = round(float(cn_single_qian.group(1)), 1)
+        return value, value
+
+    range_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*[kK]?\s*-\s*(\d+(?:\.\d+)?)\s*[kK]", normalized,
+    )
+    if range_match:
+        low, high = (float(value) for value in range_match.groups())
+        return (min(low, high), max(low, high))
+
+    single_match = re.search(r"(\d+(?:\.\d+)?)\s*[kK](?!\w)", normalized)
+    if single_match:
+        value = float(single_match.group(1))
+        return value, value
+    return None
+
+
+def _extract_core_terms(keyword: str) -> list[str]:
+    """从搜索关键词提取领域词根（剥离通用职位词后剩余部分）。"""
+    import re
+
+    kw = (keyword or "").strip()
+    for w in _GENERIC_ROLE_WORDS:
+        kw = kw.replace(w, " ")
+    return [p.strip() for p in re.split(r"[\s/·\-—,，、:：()（）]+", kw) if p.strip()]
+
+
+def _is_relevant_to_keyword(title: str, jd: str, kw: str) -> bool:
+    """岗位标题是否与搜索关键词实质相关（通用版，方案 C）。
+
+    从关键词提取领域词根，岗位标题必须命中至少一个词根才放行；JD 不参与匹配
+    （JD 里的「系统」「it」等通用词会导致溢出放行）。英文/数字词根用词边界，
+    中文用子串。若关键词全是通用词（如「主管」），则不做校验直接放行。
+    """
+    import re
+
+    cores = _extract_core_terms(kw)
+    if not cores:
+        return True
+    t = (title or "").lower()
+    for core in cores:
+        core_l = core.lower()
+        if not core_l:
+            continue
+        if core_l.isascii() and any(c.isalpha() for c in core_l):
+            if re.search(rf"(?<![a-z0-9]){re.escape(core_l)}(?![a-z0-9])", t):
+                return True
+        elif core_l in t:
+            return True
+    return False
+
+
+def _is_internship(title: str, experience: str) -> bool:
+    """判断岗位是否为实习/管培（只查标题，experience 的「无需经验」会误伤 entry-level）。"""
+    t = (title or "").lower()
+    return any(s in t for s in _INTERNSHIP_TITLE_TERMS)
+
+
+def _salary_within_range(salary: str, salary_min: float, salary_max: float) -> bool:
+    """薪资过滤：仅当薪资能解析出区间才对边界做校验（解析失败放行，不误伤）。"""
+    if salary_min <= 0 and salary_max <= 0:
+        return True
+    rng = _parse_salary_range(salary)
+    if rng is None:
+        return True
+    lo, hi = rng
+    if salary_min > 0 and lo < salary_min:
+        return False
+    if salary_max > 0 and hi > salary_max:
+        return False
+    return True
+
+
+def _analyze_api_response(http_status: int, content_type: str, body: str) -> dict:
+    """分析 51job API 原始返回，输出 {ok, level, signal, note, jobs, total}。
+
+    异常分级：
+    - L3 硬风控/封禁：非 200 / 返回 HTML 而非 JSON / status!=1 且含风控词
+    - L2 确认降级：status!=1（限流）或 items 为空但 total>0
+    - L1 疑似：status=1 但 JSON 解析失败 / 字段缺失
+    - L0 正常：status=1 且有 items
+    """
+    if http_status != 200:
+        return {"ok": False, "level": 3, "signal": "http_error",
+                "note": f"HTTP {http_status}", "jobs": [], "total": 0}
+
+    stripped = (body or "").strip()
+    if not stripped.startswith("{") and not stripped.startswith("["):
+        hint = ""
+        low = stripped[:200].lower()
+        if "verify" in low or "captcha" in low or "滑动" in stripped or "验证" in stripped:
+            hint = "（疑似滑块/验证墙）"
+        elif "login" in low or "登录" in stripped:
+            hint = "（疑似登录态失效）"
+        return {"ok": False, "level": 3, "signal": "non_json",
+                "note": f"返回非 JSON{hint}，len={len(stripped)}", "jobs": [], "total": 0}
+
+    try:
+        data = json.loads(stripped)
+    except (json.JSONDecodeError, TypeError):
+        return {"ok": False, "level": 1, "signal": "parse_error",
+                "note": "JSON 解析失败", "jobs": [], "total": 0}
+
+    status = str(data.get("status", data.get("code", "1")))
+    message = str(data.get("message") or data.get("msg") or "")
+    resultbody = data.get("resultbody")
+    if not isinstance(resultbody, dict):
+        resultbody = {}
+    job_block = resultbody.get("job")
+    if not isinstance(job_block, dict):
+        job_block = {}
+    items = job_block.get("items")
+    if not isinstance(items, list):
+        items = []
+    total = job_block.get("totalCount") or job_block.get("total") or len(items)
+
+    if status != "1":
+        combined = (message + " " + str(resultbody)[:200]).lower()
+        hard_signals = ("验证", "滑块", "captcha", "verify", "登录", "login", "封", "ban", "风控", "异常")
+        level = 3 if any(s in combined for s in hard_signals) else 2
+        signal = "hard_risk" if level == 3 else "api_limited"
+        return {"ok": False, "level": level, "signal": signal,
+                "note": f"status={status} message={message or '(空)'}",
+                "jobs": [], "total": int(total or 0)}
+
+    if not items:
+        total_value = int(total or 0)
+        if total_value == 0:
+            return {"ok": True, "level": 0, "signal": "no_results",
+                    "note": "status=1 且搜索结果为空",
+                    "jobs": [], "total": 0}
+        return {"ok": False, "level": 2, "signal": "empty_items",
+                "note": f"status=1 但 items 为空（total={total_value}）",
+                "jobs": [], "total": total_value}
+
+    return {"ok": True, "level": 0, "signal": "ok",
+            "note": "正常", "jobs": items, "total": int(total or len(items))}
+
+
+def _reason_code_for(analysis: dict) -> str:
+    """把风控分析结果映射到官方的 reason_code。"""
+    if analysis.get("signal") == "parse_error":
+        return "selector_changed"
+    return "rate_limit"
+
+
+class _ApiRateLimiter:
+    """51job API 分簇节奏限制器（防高频触发风控 + 拟人化节奏 + 自适应调参）。
+
+    三个维度约束：
+    1. 簇内：相邻间隔随机取 [gap_min, gap_max]（底线 2s）
+    2. 簇间：连续翻 burst_size 页后歇 break 秒（模拟真人离开）
+    3. 每分钟总量 ≤ per_min_limit（滑动窗口兜底）
+
+    自适应根据「总请求数」动态调参；探测阶段（no_burst）跳过簇间休息，只保留
+    间隔 + 每分钟上限，加快启动。
+    """
+
+    def __init__(self, total_requests: int | None = None, no_burst: bool = False) -> None:
+        self._window: list[float] = []
+        self._in_burst = 0
+        self._burst_size = random.randint(API_BURST_SIZE_MIN, API_BURST_SIZE_MAX)
+        self._no_burst = no_burst
+        self._set_tier(total_requests)
+
+    def _set_tier(self, total_requests: int | None) -> None:
+        n = int(total_requests or 0)
+        if n <= API_ADAPTIVE_LIGHT:
+            self._gap_range = (API_RATE_GAP_MIN, API_RATE_GAP_MAX)
+            self._break_range = (API_BURST_BREAK_MIN, API_BURST_BREAK_MAX)
+            self._per_min_limit = API_RATE_MAX_PER_MIN
+        elif n <= API_ADAPTIVE_MEDIUM:
+            self._gap_range = (3.0, 5.0)
+            self._break_range = (40.0, 80.0)
+            self._per_min_limit = 20
+        else:
+            self._gap_range = (5.0, 8.0)
+            self._break_range = (90.0, 180.0)
+            self._per_min_limit = 12
+
+    def set_tier(self, total_requests: int) -> None:
+        self._set_tier(total_requests)
+        self._no_burst = False
+
+    def wait_before_request(self, stop_event) -> bool:
+        """发请求前调用：确保满足约束。返回 False 表示被停止。"""
+        now = time.time()
+        self._window = [ts for ts in self._window if now - ts < 60.0]
+
+        if not self._no_burst and self._in_burst >= self._burst_size:
+            break_secs = random.uniform(*self._break_range)
+            if _wait_or_stop(stop_event, break_secs):
+                return False
+            self._in_burst = 0
+            self._burst_size = random.randint(API_BURST_SIZE_MIN, API_BURST_SIZE_MAX)
+            now = time.time()
+
+        if self._window:
+            since_last = now - self._window[-1]
+            target_gap = random.uniform(*self._gap_range)
+            if since_last < target_gap:
+                if _wait_or_stop(stop_event, target_gap - since_last):
+                    return False
+                now = time.time()
+
+        self._window = [ts for ts in self._window if now - ts < 60.0]
+        while len(self._window) >= self._per_min_limit:
+            oldest = self._window[0]
+            if _wait_or_stop(stop_event, max(0.5, oldest + 60.0 - now)):
+                return False
+            now = time.time()
+            self._window = [ts for ts in self._window if now - ts < 60.0]
+
+        self._window.append(time.time())
+        self._in_burst += 1
+        return True
+
+    @property
+    def per_min_limit(self) -> int:
+        return self._per_min_limit
+
+    @property
+    def gap_range(self) -> tuple:
+        return self._gap_range
 
 
 @dataclass
 class Job51Browser:
+    """浏览器依赖注入点：测试用假实现替换，正式运行用 module 级函数。"""
+
+    get_page_targets: Callable[[], list[dict]] = get_page_targets
     new_tab: Callable[..., str | None] = new_tab
     close_tab: Callable[[str], bool] = close_tab
     evaluate: Callable[..., Any] = evaluate
-    scroll: Callable[..., bool] = scroll
-    wait_for_load: Callable[..., bool] = wait_for_load
-    navigate_action: Callable[[str, str], bool] | None = None
+    sleep: Callable[[float], None] = time.sleep
 
 
 def _payload(raw: Any) -> dict[str, Any]:
@@ -159,153 +483,574 @@ class Job51Collector:
     def __init__(
         self,
         *,
+        config: dict[str, Any] | None = None,
+        safety_conn: Any | None = None,
         browser: Job51Browser | None = None,
         sleep: Callable[[float], None] = time.sleep,
-        uniform: Callable[[float, float], float] = random.SystemRandom().uniform,
-        detail_delay_range: tuple[float, float] = (DETAIL_DELAY_MIN_SECONDS, DETAIL_DELAY_MAX_SECONDS),
-        page_delay_range: tuple[float, float] = (PAGE_DELAY_MIN_SECONDS, PAGE_DELAY_MAX_SECONDS),
+        uniform: Callable[[float, float], float] | None = None,
     ):
-        self.browser = browser or Job51Browser(navigate_action=browser_navigate)
+        self.config = config or {}
+        # safety_conn 由 orchestrator 注入（学 BossCollector）：用于断点读写与去重判断。
+        # 为 None 时（registry 无参实例化/部分测试）断点与去重退化为不校验。
+        self.safety_conn = safety_conn
+        self.browser = browser or Job51Browser()
         self.sleep = sleep
-        self.uniform = uniform
-        self.detail_delay_range = detail_delay_range
-        self.page_delay_range = page_delay_range
+        self.uniform = uniform or random.SystemRandom().uniform
+
+    # ------------------------------------------------------------------ 工具
+    def _log(self, hooks: CollectorHooks, message: str, **values: Any) -> None:
+        try:
+            hooks.on_event(message=message, **values)
+        except Exception:
+            pass
+
+    def _would_be_collected(
+        self,
+        candidate: JobCandidate,
+        kw: str,
+        *,
+        deal_breakers: list[str],
+        jd_deal_breakers: list[str],
+        blocked_companies: list[str],
+        allow_internship: bool,
+        salary_min: float,
+        salary_max: float,
+    ) -> bool:
+        """探针口径：判断该岗位是否「会被最终入库」。
+
+        与正式入库的过滤链保持一致（去重 + 官方三层 + collector 三层），确保
+        探针判定的「新增」就是真正会入库的新岗，避免对饱和词误判导致全量翻页。
+        """
+        # 去重（官方 _SharedProcessor.inspect 会做；探针阶段自身先判断，口径一致）
+        if self.safety_conn is not None and job_identity_exists(
+            self.safety_conn, candidate.platform, candidate.source_job_id
+        ):
+            return False
+        # 官方统一层：title deal_breakers / blocked_company（inspect）
+        if matching_deal_breaker(candidate.title, deal_breakers):
+            return False
+        if matching_blocked_company(candidate.company, blocked_companies):
+            return False
+        # 官方统一层：jd deal_breakers（save）
+        if matching_deal_breaker(candidate.jd, jd_deal_breakers):
+            return False
+        # collector 增值层：实习过滤
+        if not allow_internship and _is_internship(candidate.title, candidate.experience):
+            return False
+        # collector 增值层：关键词相关性（方案 C）
+        if not _is_relevant_to_keyword(candidate.title, candidate.jd, kw):
+            return False
+        # collector 增值层：薪资范围
+        if not _salary_within_range(candidate.salary, salary_min, salary_max):
+            return False
+        return True
+
+    def _passes_collector_filters(
+        self,
+        candidate: JobCandidate,
+        kw: str,
+        *,
+        allow_internship: bool,
+        salary_min: float,
+        salary_max: float,
+    ) -> bool:
+        """正式入库阶段 collector 自己做的那部分过滤（官方不重复的增值层）。
+
+        deal_breakers / blocked_company / jd_deal_breakers 在正式入库时交给官方
+        ``_SharedProcessor`` 的 hooks 回调处理，这里只做官方没有的增值过滤。
+        """
+        if not allow_internship and _is_internship(candidate.title, candidate.experience):
+            return False
+        if not _is_relevant_to_keyword(candidate.title, candidate.jd, kw):
+            return False
+        if not _salary_within_range(candidate.salary, salary_min, salary_max):
+            return False
+        return True
 
     @staticmethod
-    def build_search_url(request: PlatformCollectionRequest, city: str, keyword: str) -> str:
-        code = str(request.city_codes.get(city) or "").strip()
-        if not code:
-            raise CollectionError("no_valid_city", f"未配置 51job 城市编码：{city}")
-        return SEARCH_URL.format(area=quote(code), keyword=quote(keyword))
-
-    def _wait(self, hooks: CollectorHooks, seconds: float) -> bool:
-        if hooks.stop_event is not None:
-            return hooks.stop_event.wait(max(0.0, seconds))
-        self.sleep(max(0.0, seconds))
-        return False
-
-    def collect(self, request: PlatformCollectionRequest, hooks: CollectorHooks) -> PlatformCollectionResult:
-        detail_requests = 0
-        for city in request.cities:
-            if not request.city_codes.get(city):
-                return PlatformCollectionResult(self.platform, "failed", "no_valid_city", f"51job 城市编码未配置：{city}")
-            for keyword in request.keywords:
-                search_url = self.build_search_url(request, city, keyword)
-                initial_url = "about:blank" if self.browser.navigate_action is not None else search_url
-                target_id = self.browser.new_tab(initial_url, background=True)
-                if not target_id:
-                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "无法打开 51job 搜索页")
-                if self.browser.navigate_action is not None and not self.browser.navigate_action(target_id, search_url):
-                    return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "51job 搜索页导航失败")
-                try:
-                    for page in range(1, request.max_pages + 1):
-                        if hooks.stop_event is not None and hooks.stop_event.is_set():
-                            return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                        if page > 1:
-                            delay = self.uniform(*self.page_delay_range)
-                            hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"翻页安全间隔 {delay:.1f} 秒")
-                            if self._wait(hooks, delay):
-                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                            if self.browser.evaluate(target_id, JS_CLICK_NEXT) is not True:
-                                return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "51job 已到最后一页")
-                        hooks.on_event(phase="loading_list", keyword=keyword, city=city, page=page)
-                        self.browser.wait_for_load(target_id, timeout=15)
-                        self.browser.scroll(target_id, y=2200)
-                        payload: dict[str, Any] = {}
-                        status = "waiting"
-                        for attempt in range(RENDER_POLL_ATTEMPTS):
-                            payload = _payload(self.browser.evaluate(target_id, JS_EXTRACT_LIST))
-                            status = str(payload.get("status") or "selector_changed")
-                            if status != "waiting":
-                                break
-                            if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
-                                return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                        if status in {"blocked", "throttled"}:
-                            return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "51job 出现验证或限流信号，已停止整个平台任务")
-                        if status == "waiting":
-                            return PlatformCollectionResult(self.platform, "blocked", "render_timeout", "51job 列表未稳定渲染，已安全停止")
-                        if status != "ready" or not isinstance(payload.get("jobs"), list):
-                            return PlatformCollectionResult(self.platform, "blocked", "selector_changed", "51job 列表页结构与预期不一致")
-
-                        for raw_item in payload["jobs"]:
-                            candidate = self._candidate_from_list(raw_item, city, keyword)
-                            if candidate is None or not hooks.on_list_candidate(candidate):
-                                continue
-                            if detail_requests:
-                                delay = self.uniform(*self.detail_delay_range)
-                                hooks.on_event(phase="pacing", keyword=keyword, city=city, page=page, message=f"详情页安全间隔 {delay:.1f} 秒")
-                                if self._wait(hooks, delay):
-                                    return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                            hooks.on_event(phase="loading_detail", keyword=keyword, city=city, page=page)
-                            detail_initial_url = "about:blank" if self.browser.navigate_action is not None else candidate.url
-                            detail_target = self.browser.new_tab(detail_initial_url, background=True)
-                            if not detail_target:
-                                hooks.on_parse_failed("无法打开 51job 详情页")
-                                continue
-                            if self.browser.navigate_action is not None and not self.browser.navigate_action(detail_target, candidate.url):
-                                self.browser.close_tab(detail_target)
-                                hooks.on_parse_failed("51job 详情页导航失败")
-                                continue
-                            detail_requests += 1
-                            try:
-                                self.browser.wait_for_load(detail_target, timeout=15)
-                                detail: dict[str, Any] = {}
-                                detail_status = "selector_changed"
-                                for attempt in range(RENDER_POLL_ATTEMPTS):
-                                    detail = _payload(self.browser.evaluate(detail_target, JS_EXTRACT_DETAIL))
-                                    detail_status = str(detail.get("status") or "selector_changed")
-                                    if detail_status in {"ready", "blocked", "offline"}:
-                                        break
-                                    if attempt + 1 < RENDER_POLL_ATTEMPTS and self._wait(hooks, RENDER_POLL_INTERVAL_SECONDS):
-                                        return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
-                            finally:
-                                self.browser.close_tab(detail_target)
-                            if detail_status == "blocked":
-                                return PlatformCollectionResult(self.platform, "blocked", "rate_limit", "51job 详情页出现验证或限流，已停止整个平台任务")
-                            if detail_status == "offline":
-                                hooks.on_parse_failed("51job 岗位已下线")
-                                continue
-                            if detail_status != "ready" or not str(detail.get("jd") or "").strip():
-                                return PlatformCollectionResult(self.platform, "blocked", "selector_changed", "51job 详情页结构变化，已安全停止")
-                            final = self._candidate_from_detail(detail, candidate)
-                            if not hooks.on_candidate(final):
-                                return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
-                finally:
-                    self.browser.close_tab(target_id)
-        return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "51job 搜索结果已采集完毕")
-
-    @staticmethod
-    def _candidate_from_list(raw: Any, city: str, keyword: str) -> JobCandidate | None:
-        if not isinstance(raw, dict):
+    def _item_to_candidate(
+        item: dict, city: str, code: str, keyword: str
+    ) -> JobCandidate | None:
+        """把 51job API item 转成平台中立的 JobCandidate（含 jobDescribe 作为 jd）。"""
+        job_id = str(item.get("jobId") or "").strip()
+        title = (item.get("jobName") or "").strip()
+        if not job_id or not title:
             return None
-        source_id = str(raw.get("source_job_id") or "").strip()
-        title = str(raw.get("title") or "").strip()
-        url = str(raw.get("url") or "").strip()
-        if not source_id or not title or not url.startswith("https://jobs.51job.com/"):
-            return None
+        year = (item.get("workYearString") or "").strip()
+        degree = (item.get("degreeString") or "").strip()
+        experience = (year + "·" + degree) if (year and degree) else (year or degree)
+        area_str = str(item.get("jobAreaString") or "").strip()
+        resolved_city = (area_str.split("·")[0].strip() if area_str else city)
         return JobCandidate(
             platform="51job",
-            source_job_id=source_id,
+            source_job_id=job_id,
             title=title,
-            company=str(raw.get("company") or "").strip(),
-            salary=str(raw.get("salary") or "").strip(),
-            city=str(raw.get("city") or city).strip(),
-            experience=str(raw.get("experience") or "").strip(),
-            url=url,
+            company=(item.get("fullCompanyName") or item.get("companyName") or "").strip(),
+            salary=(item.get("provideSalaryString") or "").strip(),
+            city=resolved_city,
+            city_code=code,
+            experience=experience,
+            jd=(item.get("jobDescribe") or "").strip(),
+            hr_name=(item.get("hrName") or "").strip(),
+            hr_title=(item.get("hrPosition") or "").strip(),
+            company_size=(item.get("companySizeString") or "").strip(),
+            company_industry=(item.get("industryType1Str") or "").strip(),
+            url=(item.get("jobHref") or "").strip(),
             source_keyword=keyword,
         )
 
-    @staticmethod
-    def _candidate_from_detail(detail: dict[str, Any], base: JobCandidate) -> JobCandidate:
-        return JobCandidate(
-            platform="51job",
-            source_job_id=base.source_job_id,
-            title=str(detail.get("title") or base.title).strip(),
-            company=str(detail.get("company") or base.company).strip(),
-            salary=str(detail.get("salary") or base.salary).strip(),
-            city=str(detail.get("city") or base.city).strip(),
-            experience=base.experience,
-            jd=str(detail.get("jd") or "").strip(),
-            url=base.url,
-            source_keyword=base.source_keyword,
+    # ---------------------------------------------------------------- 宿主页
+    def _ensure_host_tab(self, request: PlatformCollectionRequest) -> tuple[str, bool]:
+        """找一个 51job 搜索页作为 fetch 宿主（与 API 同源）。
+
+        ⚠️ 必须精确匹配 we.51job.com：www/jobs 子域名跨域，fetch 会被 CORS 拦截。
+        ⚠️ 不盲目复用旧宿主页：旧 tab 可能后台节流/冻结导致 fetch 挂起；复用前先
+        「fetch 探活」，能真正拿到 API 响应的才复用，否则新开前台 tab。
+
+        返回 ``(target_id, owned)``；复用用户已有页面时 ``owned=False``，采集结束
+        不能把用户的页面关闭。
+        """
+        keyword = request.keywords[0]
+        code = request.city_codes.get(request.cities[0]) if request.cities else "020000"
+
+        for t in self.browser.get_page_targets():
+            if "we.51job.com" in str(t.get("url", "")):
+                candidate_target = t.get("targetId")
+                if not candidate_target:
+                    continue
+                try:
+                    alive_js = JS_FETCH_API_PAGE.replace("__KW__", quote(keyword)).replace("__AREA__", code).replace("__PAGE__", "1")
+                    alive = self.browser.evaluate(candidate_target, alive_js, timeout=8)
+                    if alive and "error" not in str(alive):
+                        return str(candidate_target), False
+                except Exception:
+                    continue
+
+        tmp_url = SEARCH_URL.format(area=code, keyword=quote(keyword))
+        host_target = self.browser.new_tab(tmp_url, background=False)
+        if not host_target:
+            raise CollectionBlockedError("rate_limit", "无法打开 51job 页面作为 API 宿主")
+        self.sleep(5)  # 等宿主页加载出 cookie
+        return host_target, True
+
+    def _fetch_page(self, host_target: str, kw_encoded: str, area: str, page: int) -> dict:
+        """在宿主页上下文发一次 API 请求并分析返回，返回 _analyze_api_response 结果。"""
+        js = JS_FETCH_API_PAGE.replace("__KW__", kw_encoded).replace("__AREA__", area).replace("__PAGE__", str(page))
+        raw = self.browser.evaluate(host_target, js, timeout=API_FETCH_TIMEOUT)
+        if raw is None:
+            return {"ok": False, "level": 3, "signal": "empty_result",
+                    "note": "evaluate 返回空（超时/断连）", "jobs": [], "total": 0}
+        wrapper = _payload(raw)
+        if not isinstance(wrapper, dict) or "error" in wrapper:
+            return {"ok": False, "level": 3, "signal": "fetch_error",
+                    "note": f"API fetch 执行出错: {str(wrapper)[:120]}", "jobs": [], "total": 0}
+        return _analyze_api_response(
+            int(wrapper.get("http_status") or 0),
+            str(wrapper.get("content_type") or ""),
+            str(wrapper.get("body") or ""),
         )
+
+    # ---------------------------------------------------------------- collect
+    def _resume_ttl_hours(self) -> int:
+        """57hybrid：断点续采有效期。同时兼容旧 config.search 与新 config.platforms.51job.search。"""
+        search_cfg = {}
+        platforms = self.config.get("platforms", {}) if isinstance(self.config.get("platforms"), dict) else {}
+        pf = platforms.get("51job", {}) if isinstance(platforms.get("51job"), dict) else {}
+        if isinstance(pf.get("search"), dict):
+            search_cfg = pf["search"]
+        elif isinstance(self.config.get("search"), dict):
+            search_cfg = self.config["search"]
+        raw = search_cfg.get("resume_ttl_hours", 24)
+        try:
+            return max(1, min(int(raw or 24), 720))
+        except (TypeError, ValueError):
+            return 24
+
+    def collect(
+        self, request: PlatformCollectionRequest, hooks: CollectorHooks
+    ) -> PlatformCollectionResult:
+        # 城市编码前置校验（fail-closed，与官方一致）
+        for city in request.cities:
+            if not request.city_codes.get(city):
+                return PlatformCollectionResult(self.platform, "failed", "no_valid_city",
+                                                f"51job 城市编码未配置：{city}")
+
+        # 词级断点续采：跳过最近 N 小时内已完成的 (city, keyword) 组合。
+        # 超过有效期（默认 24h）的旧断点视为过期，重新采集（招聘岗位每天都有新增）。
+        # 孤儿断点（关键词被增删后残留）顺带清理，避免脏数据累积。
+        collected_combos: set[tuple[str, str]] = set()
+        if self.safety_conn is not None:
+            all_keywords = set(request.keywords)
+            prune_collected_combos(self.safety_conn, "51job", all_keywords)
+            prune_page_progress(self.safety_conn, "51job", all_keywords)
+            collected_combos = get_collected_combos(
+                self.safety_conn, "51job", within_hours=self._resume_ttl_hours()
+            )
+
+        # 反检测前置：时间窗口 + 随机休息日（复用 BossHunter throttle 配置）
+        throttle_cfg = self.config.get("throttle", {}) if isinstance(self.config.get("throttle"), dict) else {}
+        send_windows = throttle_cfg.get("send_windows", ["09:00-16:00"])
+        if not SendWindowChecker(send_windows).is_active():
+            return PlatformCollectionResult(self.platform, "completed", "outside_window",
+                                            f"当前不在采集时间窗口内（{send_windows}）")
+        if should_take_day_off(float(throttle_cfg.get("day_off_probability", 0.05))):
+            return PlatformCollectionResult(self.platform, "completed", "day_off",
+                                            "今日随机休息，跳过 51job 采集")
+
+        profile = self.config.get("profile", {}) if isinstance(self.config.get("profile"), dict) else {}
+        deal_breakers = profile.get("deal_breakers") or []
+        jd_deal_breakers = profile.get("jd_deal_breakers") or []
+        blocked_companies = profile.get("blocked_companies") or []
+        allow_internship = bool(profile.get("allow_internship", False))
+        try:
+            salary_min = float(profile.get("salary_min") or 0)
+            salary_max = float(profile.get("salary_max") or 0)
+        except (TypeError, ValueError):
+            salary_min = salary_max = 0.0
+
+        max_pages = min(max(1, int(request.max_pages or 1)), HARD_MAX_PAGES)
+
+        try:
+            host_target, owns_host_target = self._ensure_host_tab(request)
+        except CollectionBlockedError:
+            raise
+        except Exception as exc:  # pragma: no cover - 防御性兜底
+            raise CollectionBlockedError("browser_disconnected", f"打开 51job 宿主页失败：{exc}")
+
+        # ★ 全局限速器：探针/保底针/热区扫描三阶段共享同一个 60s 窗口，统一计数。
+        rate_limiter = _ApiRateLimiter(total_requests=API_ADAPTIVE_MEDIUM, no_burst=False)
+
+        try:
+            for city in request.cities:
+                area = str(request.city_codes.get(city) or "").strip()
+                for kw in request.keywords:
+                    if hooks.stop_event is not None and hooks.stop_event.is_set():
+                        return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
+                    # 词级断点跳过：24h 内已完成的组合整词跳过
+                    if (city, kw) in collected_combos:
+                        self._log(hooks, f"51job {kw} 断点续采：24h 内已完成，整词跳过",
+                                  phase="completed_keyword", keyword=kw, city=city)
+                        continue
+                    self._collect_keyword(
+                        request, hooks, host_target, rate_limiter,
+                        city=city, area=area, kw=kw, max_pages=max_pages,
+                        deal_breakers=deal_breakers, jd_deal_breakers=jd_deal_breakers,
+                        blocked_companies=blocked_companies, allow_internship=allow_internship,
+                        salary_min=salary_min, salary_max=salary_max,
+                    )
+        finally:
+            if owns_host_target:
+                self.browser.close_tab(host_target)
+
+        return PlatformCollectionResult(self.platform, "completed", "search_exhausted",
+                                        "51job 搜索结果已采集完毕")
+
+    def _collect_keyword(
+        self,
+        request: PlatformCollectionRequest,
+        hooks: CollectorHooks,
+        host_target: str,
+        rate_limiter: _ApiRateLimiter,
+        *,
+        city: str,
+        area: str,
+        kw: str,
+        max_pages: int,
+        deal_breakers: list[str],
+        jd_deal_breakers: list[str],
+        blocked_companies: list[str],
+        allow_internship: bool,
+        salary_min: float,
+        salary_max: float,
+    ) -> None:
+        """单个 (城市, 关键词) 的完整闭环：探针 → 保底针 → 饱和跳过 / 热区扫描。"""
+        kw_encoded = quote(kw)
+
+        # 页级断点续采：读上次采到页码，从 N+1 页继续（中途停止→续采不重翻）
+        saved_page = get_page_progress(self.safety_conn, "51job", city, kw) if self.safety_conn is not None else 0
+        start_page = saved_page + 1 if saved_page > 0 else 1
+        # 边界守卫：续采起点已超过最大页（理论上该词已采完），直接标记完成并跳过
+        if start_page > max_pages:
+            if self.safety_conn is not None:
+                mark_combo_collected(self.safety_conn, "51job", city, kw)
+                delete_page_progress(self.safety_conn, "51job", city, kw)
+            self._log(hooks, f"51job {kw} 页级断点已超最大页（{saved_page}/{max_pages}），视为已采完，跳过",
+                      phase="completed_keyword", keyword=kw, city=city)
+            return
+        self._log(hooks, f"51job {kw} 采集（共 {max_pages} 页" + (f"，从第 {start_page} 页续采" if saved_page > 0 else "") + "）",
+                  phase="loading_list", keyword=kw, city=city)
+
+        # 有效页数（初始 = 设定上限）：探针拿到 total 后会被主动末页判定收窄。
+        # 例：设定 50 页但该词实际只 30 页，探针第 1 页返回 total=600 → 收窄到 30，
+        # 热区 ±3 外扩、随机插一针、保底针都不会再翻到「不存在页」，杜绝 non_json 误判。
+        effective_max = max_pages
+
+        # ★ 分布式探针（Phase 1）：随机采样定位有新增岗位的页面区间。
+        probe_pages = self._plan_probe_pages(start_page, max_pages)
+        hot_pages: set[int] = set()
+        probe_cache: dict[int, dict] = {}
+        probe_hits: list[str] = []
+
+        self._log(hooks, f"51job {kw} 分布式探针采样（{len(probe_pages)} 个点）", phase="procuring", keyword=kw, city=city)
+        for pp in probe_pages:
+            if hooks.stop_event is not None and hooks.stop_event.is_set():
+                return
+            if pp > effective_max:
+                continue
+            if not rate_limiter.wait_before_request(hooks.stop_event):
+                return
+            analysis = self._fetch_page(host_target, kw_encoded, area, pp)
+            if not analysis["ok"]:
+                if analysis.get("signal") == "empty_items":
+                    real_last = self._real_last_page(analysis, effective_max)
+                    if pp > real_last:
+                        effective_max = real_last
+                        self._log(hooks, f"51job {kw} p{pp} 超出真实末页 {real_last}，跳过",
+                                  phase="procuring", keyword=kw, city=city, page=pp)
+                        continue
+                raise CollectionBlockedError(
+                    _reason_code_for(analysis),
+                    f"51job API 异常（L{analysis['level']} {analysis['signal']}）：{analysis['note']}",
+                )
+            if not analysis["jobs"]:
+                self._log(hooks, f"51job {kw} p{pp} 抽查无数据 signal={analysis.get('signal','?')}",
+                          phase="procuring", keyword=kw, city=city, page=pp)
+                continue
+            probe_cache[pp] = analysis
+            # 主动末页判定：任意一页正常返回都能用 total 反推真实末页，收窄有效页数
+            effective_max = self._real_last_page(analysis, effective_max)
+            new_on_page = 0
+            for item in analysis["jobs"]:
+                cand = self._item_to_candidate(item, city, area, kw)
+                if cand is None:
+                    continue
+                if self._would_be_collected(
+                    cand, kw,
+                    deal_breakers=deal_breakers, jd_deal_breakers=jd_deal_breakers,
+                    blocked_companies=blocked_companies, allow_internship=allow_internship,
+                    salary_min=salary_min, salary_max=salary_max,
+                ):
+                    new_on_page += 1
+            if new_on_page > 0:
+                hot_pages.update(range(max(1, pp - 3), min(effective_max, pp + 3) + 1))  # ±3 闭区间
+                probe_hits.append(f"p{pp}(+{new_on_page})")
+                self._log(hooks, f"51job {kw} p{pp} 抽查命中新增 {new_on_page} 个 → 热区 ±3",
+                          phase="procuring", keyword=kw, city=city, page=pp)
+            else:
+                self._log(hooks, f"51job {kw} p{pp} 抽查无新增（全重复/已入库）",
+                          phase="procuring", keyword=kw, city=city, page=pp)
+            # 波浪停顿：短 60% / 中 25% / 长 15%
+            wave_r = random.random()
+            if wave_r < WAVE_SHORT_PROB:
+                wave_wait = self.uniform(3, 5)
+            elif wave_r < WAVE_MEDIUM_PROB:
+                wave_wait = self.uniform(8, 15)
+            else:
+                wave_wait = self.uniform(20, 40)
+            if _wait_or_stop(hooks.stop_event, wave_wait):
+                return
+
+        # ★ 保底针（地毯队）：探针全空时，从非探针页补足到 70% 覆盖，兜底防漏检
+        if not hot_pages:
+            final_pool = [p for p in range(start_page, effective_max + 1) if p not in probe_pages]
+            final_target = max(3, round(effective_max * 0.7) - len(probe_pages))
+            final_pages = random.sample(final_pool, min(final_target, len(final_pool))) if final_pool else []
+            # ★★ 固定插针第 2 页（故意设定，不是 BUG，禁止删除）★★
+            # 探针第 1 页必采（front_pages 恒含 start_page=1），而第 2 页被探针的
+            # 「不相邻约束」排除，若不固定补 p2，第 2 页会成为永久漏检夹缝。
+            if 2 in final_pool and 2 not in final_pages and final_pages:
+                final_pages[random.randint(0, len(final_pages) - 1)] = 2
+            for fp in final_pages:
+                if hooks.stop_event is not None and hooks.stop_event.is_set():
+                    return
+                if not rate_limiter.wait_before_request(hooks.stop_event):
+                    return
+                fp_a = self._fetch_page(host_target, kw_encoded, area, fp)
+                if not fp_a["ok"]:
+                    if fp_a.get("signal") == "empty_items":
+                        real_last = self._real_last_page(fp_a, effective_max)
+                        if fp > real_last:
+                            effective_max = real_last
+                            continue
+                    raise CollectionBlockedError(
+                        _reason_code_for(fp_a),
+                        f"51job API 异常（L{fp_a['level']} {fp_a['signal']}）：{fp_a['note']}",
+                    )
+                if not fp_a["jobs"]:
+                    continue
+                probe_cache[fp] = fp_a
+                fp_new = 0
+                for fp_item in fp_a["jobs"]:
+                    cand = self._item_to_candidate(fp_item, city, area, kw)
+                    if cand is None:
+                        continue
+                    if self._would_be_collected(
+                        cand, kw,
+                        deal_breakers=deal_breakers, jd_deal_breakers=jd_deal_breakers,
+                        blocked_companies=blocked_companies, allow_internship=allow_internship,
+                        salary_min=salary_min, salary_max=salary_max,
+                    ):
+                        fp_new += 1
+                if fp_new > 0:
+                    hot_pages.update(range(max(1, fp - 3), min(effective_max, fp + 3) + 1))
+                    probe_hits.append(f"p{fp}(+{fp_new})")
+
+        # 探针全空 → 饱和，整词跳过（记词级断点 + 清页级断点，避免下次重复探测）
+        if not hot_pages:
+            if self.safety_conn is not None:
+                mark_combo_collected(self.safety_conn, "51job", city, kw)
+                delete_page_progress(self.safety_conn, "51job", city, kw)
+            self._log(hooks, f"51job {kw} 分布式探针全空（已饱和）：命中 {probe_hits or '无'}，跳过 {effective_max} 页",
+                      phase="completed_keyword", keyword=kw, city=city)
+            return
+
+        # ★ 随机插一针（兜底抽查）：从非热区页随机挑 1 页加入热区，防热区外扩不足
+        non_hot = [p for p in range(1, effective_max + 1) if p not in hot_pages]
+        if non_hot:
+            hot_pages.add(random.choice(non_hot))
+
+        # 续采起点强制纳入热区，防永久漏采
+        if start_page not in hot_pages:
+            hot_pages.add(start_page)
+
+        # 探针起点邻位强制纳入（堵孤立夹缝：探针第 1 页必采 → 第 2 页被不相邻约束漏掉）
+        stitch_gap = (1 if start_page == 1 else start_page + 1)
+        if 1 <= stitch_gap <= effective_max and stitch_gap not in hot_pages:
+            hot_pages.add(stitch_gap)
+
+        # 热区按升序扫描，使单页码断点始终代表“此前页码均已处理”。探针本身仍随机，
+        # 请求节奏仍有抖动；这里不能再 shuffle，否则中断后从 N+1 续采会漏掉小于 N
+        # 但尚未扫描的页面，并可能先遇到末页后提前结束整个热区。
+        hot_scan_pages = sorted(p for p in hot_pages if start_page <= p <= effective_max)
+
+        self._log(hooks, f"51job {kw} 探针命中 {len(probe_hits)} 个点，热区扫描范围 {sorted(hot_pages)[:20]}",
+                  phase="loading_list", keyword=kw, city=city)
+
+        for page in hot_scan_pages:
+            if hooks.stop_event is not None and hooks.stop_event.is_set():
+                return
+
+            if page in probe_cache:
+                analysis = probe_cache[page]
+            else:
+                if not rate_limiter.wait_before_request(hooks.stop_event):
+                    return
+                analysis = self._fetch_page(host_target, kw_encoded, area, page)
+
+            # 异常分级：末页（翻过第 1 页后为空）正常结束本词，其余立即停止
+            if not analysis["ok"]:
+                if analysis.get("signal") == "empty_items" and page > 1:
+                    self._log(hooks, f"51job {kw} 已到末页（第 {page} 页为空），结束本词",
+                              phase="loading_list", keyword=kw, city=city, page=page)
+                    break
+                raise CollectionBlockedError(
+                    _reason_code_for(analysis),
+                    f"51job API 异常（L{analysis['level']} {analysis['signal']}）：{analysis['note']}",
+                )
+
+            jobs_list = analysis["jobs"]
+            self._log(hooks, f"51job {kw} 第 {page} 页：{len(jobs_list)} 条（共 {analysis.get('total', 0)}）",
+                      phase="saving", keyword=kw, city=city, page=page)
+
+            for item in jobs_list:
+                cand = self._item_to_candidate(item, city, area, kw)
+                if cand is None:
+                    continue
+                # collector 增值层过滤（官方无：实习 / 相关性 / 薪资）
+                if not self._passes_collector_filters(cand, kw, allow_internship=allow_internship,
+                                                      salary_min=salary_min, salary_max=salary_max):
+                    continue
+                # 官方统一层：去重 + title deal_breakers + blocked_company
+                if not hooks.on_list_candidate(cand):
+                    continue
+                # 官方统一层：jd deal_breakers + 入库；返回 False = 应停止
+                if not hooks.on_candidate(cand):
+                    raise CollectionBlockedError("callback_stopped", "采集回调已停止")
+
+            # 页级断点：每采完一页立即记录页码
+            if self.safety_conn is not None:
+                upsert_page_progress(self.safety_conn, "51job", city, kw, page)
+
+            # 末页判定（可靠版）：本页条数 < 每页上限说明已到末页
+            if len(jobs_list) < API_PAGE_SIZE:
+                self._log(hooks, f"51job {kw} 已到末页（本页 {len(jobs_list)} 条 < {API_PAGE_SIZE}），结束本词",
+                          phase="loading_list", keyword=kw, city=city, page=page)
+                break
+
+        # 词结束：标记词级断点 + 清页级断点
+        if self.safety_conn is not None:
+            mark_combo_collected(self.safety_conn, "51job", city, kw)
+            delete_page_progress(self.safety_conn, "51job", city, kw)
+
+    @staticmethod
+    def _real_last_page(analysis: dict, fallback: int) -> int:
+        """主动末页判定：用 API 返回的 total（全词命中总数）反推真实末页。
+
+        51job search-pc 的 totalCount 与 pageNum 无关（是「该词+城市」的总岗位数），
+        因此任意一页的正常返回都能算出真实页数 = ceil(total / API_PAGE_SIZE)。
+
+        这是「设定 50 页、实际只 30 页」场景的第一道防线：把热区 ±3 外扩收窄到
+        真实末页内，避免翻到「不存在的页」时拿到 HTML → 被误判 non_json（L3）→
+        误停整个平台任务。fallback 为拿不到 total 时的兜底页数（保持原上限）。
+        """
+        total = int(analysis.get("total") or 0)
+        if total <= 0:
+            return fallback
+        total_pages = (total + API_PAGE_SIZE - 1) // API_PAGE_SIZE
+        return min(fallback, max(1, total_pages))
+
+    @staticmethod
+    def _plan_probe_pages(start_page: int, max_pages: int) -> list[int]:
+        """规划探针采样点：前密后疏 + 随机化 + 不相邻约束。
+
+        51job 结果按时间/相关性排序，新增岗位大概率在前几页，所以前段（起点 ~ +9）
+        密度高，后段稀疏（最多 3 点）。采样点随机化避免规律数字被风控识别。
+        """
+        if max_pages < start_page:
+            return []
+        if max_pages - start_page + 1 <= 2:
+            return list(range(start_page, max_pages + 1))
+
+        probe_spacing = max(2, max_pages // 8)
+        target_count = max(3, min(max_pages, max_pages // probe_spacing + 1))
+
+        front_end = min(max_pages, start_page + 9)
+        back_start = front_end + 1
+        front_want = max(2, round(target_count * 0.7))
+
+        front_pool = random.sample(list(range(start_page + 1, front_end + 1)),
+                                   k=len(range(start_page + 1, front_end + 1)))
+        front_mid: list[int] = []
+        front_forbidden: set[int] = {start_page + 1}
+        for p in front_pool:
+            if p in front_forbidden:
+                continue
+            front_mid.append(p)
+            front_forbidden.add(p - 1)
+            front_forbidden.add(p + 1)
+            if len(front_mid) >= front_want - 1:
+                break
+        front_pages = sorted([start_page] + front_mid)
+        front_actual = len(front_pages)
+
+        if back_start > max_pages:
+            return front_pages
+
+        back_want = min(3, max(1, target_count - front_actual))
+        back_pool = random.sample(list(range(back_start, max_pages)),
+                                  k=len(range(back_start, max_pages)))
+        back_mid: list[int] = []
+        back_forbidden: set[int] = set()
+        for p in back_pool:
+            if p in back_forbidden:
+                continue
+            back_mid.append(p)
+            back_forbidden.add(p - 1)
+            back_forbidden.add(p + 1)
+            if len(back_mid) >= back_want - 1:
+                break
+        back_pages = sorted(back_mid + [max_pages])
+
+        pages = list(dict.fromkeys(front_pages + back_pages))
+        random.shuffle(pages)
+        return pages

--- a/src/bosshunter/db.py
+++ b/src/bosshunter/db.py
@@ -122,6 +122,7 @@ def _init_tables(conn: sqlite3.Connection) -> None:
     _migrate_platform_access_events(conn)
     _init_scoring_runs(conn)
     _init_collection_runs(conn)
+    _init_collect_progress(conn)
 
 
 def job_exists(conn: sqlite3.Connection, job_id: str) -> bool:
@@ -1013,3 +1014,156 @@ def get_jobs_needing_resume(conn: sqlite3.Connection) -> list[dict]:
         "SELECT * FROM jobs WHERE status = 'needs_resume' AND deleted_at IS NULL ORDER BY updated_at DESC"
     ).fetchall()
     return [dict(row) for row in rows]
+
+
+# =====================================================================
+# 51job 断点续采（词级 collect_progress + 页级 collect_progress_page）
+# 由 51job API-fetch 采集器使用，随该采集器一并引入
+# =====================================================================
+
+
+def _init_collect_progress(conn: sqlite3.Connection) -> None:
+    """采集断点续采进度表：记录已完成的 (source, city, keyword) 组合。
+
+    词级断点（collect_progress）：组合采集完成即标记，默认 24h 内整词跳过。
+    页级断点（collect_progress_page）：记录 51job API 采集每个词已采到的页码，
+    支持「中途停止 → 从 N+1 页续采」。
+    """
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS collect_progress (
+            source TEXT NOT NULL,
+            city TEXT NOT NULL,
+            keyword TEXT NOT NULL,
+            finished_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (source, city, keyword)
+        );
+
+        CREATE TABLE IF NOT EXISTS collect_progress_page (
+            source TEXT NOT NULL,
+            city TEXT NOT NULL,
+            keyword TEXT NOT NULL,
+            page INTEGER NOT NULL DEFAULT 0,
+            finished_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (source, city, keyword)
+        );
+        """
+    )
+    conn.commit()
+
+
+def get_collected_combos(conn: sqlite3.Connection, source: str, within_hours: int | None = None) -> set[tuple[str, str]]:
+    """返回某来源已完成的 (city, keyword) 组合集合（用于断点续采跳过）。
+
+    within_hours：只返回最近 N 小时内完成的组合；超过该窗口的旧断点视为"过期"，
+    会在下次采集时重新采集（招聘岗位每天都有新增）。为 None 时返回全部（兼容旧行为）。
+    """
+    if within_hours is not None:
+        rows = conn.execute(
+            "SELECT city, keyword FROM collect_progress "
+            "WHERE source = ? AND finished_at >= datetime('now', ?)",
+            (source, f"-{int(within_hours)} hours"),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT city, keyword FROM collect_progress WHERE source = ?",
+            (source,),
+        ).fetchall()
+    return {(str(r["city"]), str(r["keyword"])) for r in rows}
+
+
+def clear_collected_combos(conn: sqlite3.Connection, source: str | None = None) -> int:
+    """清空词级断点记录；source 为 None 时清空所有来源。返回删除行数。"""
+    if source is not None:
+        cursor = conn.execute(
+            "DELETE FROM collect_progress WHERE source = ?", (source,)
+        )
+    else:
+        cursor = conn.execute("DELETE FROM collect_progress")
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def prune_collected_combos(conn: sqlite3.Connection, source: str, keep_keywords: set[str]) -> int:
+    """清理孤儿词级断点：删除「已不在当前关键词列表里」的断点记录。
+
+    关键词可能在采集前被用户增删，删掉的词其断点记录应同步清理，
+    避免脏数据累积；重新加回该词时也会重新采集（符合预期）。返回删除行数。
+    """
+    if not keep_keywords:
+        return clear_collected_combos(conn, source)
+    placeholders = ",".join("?" for _ in keep_keywords)
+    cursor = conn.execute(
+        f"DELETE FROM collect_progress WHERE source = ? AND keyword NOT IN ({placeholders})",
+        (source, *keep_keywords),
+    )
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def mark_combo_collected(conn: sqlite3.Connection, source: str, city: str, keyword: str) -> None:
+    """标记一个 (source, city, keyword) 组合已完成（INSERT OR IGNORE，幂等）。"""
+    conn.execute(
+        "INSERT OR IGNORE INTO collect_progress (source, city, keyword) VALUES (?, ?, ?)",
+        (source, city, keyword),
+    )
+    conn.commit()
+
+
+def upsert_page_progress(conn: sqlite3.Connection, source: str, city: str, keyword: str, page: int) -> None:
+    """记录/更新某词已采到的页码（页级断点，支持中途续采）。"""
+    conn.execute(
+        """
+        INSERT INTO collect_progress_page (source, city, keyword, page)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(source, city, keyword) DO UPDATE SET
+            page = excluded.page,
+            finished_at = CURRENT_TIMESTAMP
+        """,
+        (source, city, keyword, int(page or 0)),
+    )
+    conn.commit()
+
+
+def get_page_progress(conn: sqlite3.Connection, source: str, city: str, keyword: str) -> int:
+    """返回某词已采到的页码（0 = 未采过/无记录）。"""
+    row = conn.execute(
+        "SELECT page FROM collect_progress_page WHERE source = ? AND city = ? AND keyword = ?",
+        (source, city, keyword),
+    ).fetchone()
+    return int(row["page"] or 0) if row else 0
+
+
+def clear_page_progress(conn: sqlite3.Connection, source: str | None = None) -> int:
+    """清空页级断点；source 为 None 时清空所有来源。返回删除行数。"""
+    if source is not None:
+        cursor = conn.execute(
+            "DELETE FROM collect_progress_page WHERE source = ?", (source,)
+        )
+    else:
+        cursor = conn.execute("DELETE FROM collect_progress_page")
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def delete_page_progress(conn: sqlite3.Connection, source: str, city: str, keyword: str) -> int:
+    """删除单个词的页级断点（词已完成，无需续页）。返回删除行数。"""
+    cursor = conn.execute(
+        "DELETE FROM collect_progress_page WHERE source = ? AND city = ? AND keyword = ?",
+        (source, city, keyword),
+    )
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def prune_page_progress(conn: sqlite3.Connection, source: str, keep_keywords: set[str]) -> int:
+    """清理孤儿页级断点（已删除词），与 prune_collected_combos 保持一致。"""
+    if not keep_keywords:
+        return clear_page_progress(conn, source)
+    placeholders = ",".join("?" for _ in keep_keywords)
+    cursor = conn.execute(
+        f"DELETE FROM collect_progress_page WHERE source = ? AND keyword NOT IN ({placeholders})",
+        (source, *keep_keywords),
+    )
+    conn.commit()
+    return int(cursor.rowcount or 0)

--- a/tests/test_job51_collector.py
+++ b/tests/test_job51_collector.py
@@ -1,27 +1,214 @@
 import json
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
-from bosshunter.collection.base import CollectorHooks
+from bosshunter.collection.base import CollectionBlockedError, CollectorHooks
 from bosshunter.collection.models import PlatformCollectionRequest
 from bosshunter.collection.orchestrator import normalize_collection_options
-from bosshunter.collection.platforms.job51 import JS_EXTRACT_DETAIL, JS_EXTRACT_LIST, Job51Browser, Job51Collector, get_51job_city_code
+from bosshunter.collection.platforms.job51 import (
+    API_PAGE_SIZE,
+    HARD_MAX_PAGES,
+    Job51Browser,
+    Job51Collector,
+    _analyze_api_response,
+    _reason_code_for,
+    get_51job_city_code,
+    load_51job_city_snapshot,
+)
 from bosshunter.collection.text import clean_job_description
 
 
-class Job51CollectorTests(TestCase):
-    def test_list_script_uses_each_card_real_detail_url_for_multiple_cities(self):
-        self.assertIn('a[href*="jobs.51job.com/"]', JS_EXTRACT_LIST)
-        self.assertIn("url: jobUrl", JS_EXTRACT_LIST)
-        self.assertNotIn("jobs.51job.com/shanghai/", JS_EXTRACT_LIST)
+def _ok_body(items: list, total: int | None = None) -> str:
+    """Build a valid 51job API response body."""
+    return json.dumps({
+        "status": "1",
+        "resultbody": {
+            "job": {
+                "items": items,
+                "totalCount": total if total is not None else len(items),
+            }
+        },
+    }, ensure_ascii=False)
 
-    def test_detail_script_targets_job_description_without_footer_noise(self):
-        self.assertIn(".bmsg.job_msg.inbox > div:first-child", JS_EXTRACT_DETAIL)
-        self.assertNotIn("body.slice(anchor)", JS_EXTRACT_DETAIL)
 
-    def test_city_and_option_defaults_are_fail_closed(self):
+class AnalyzeApiResponseTests(TestCase):
+    """L0-L3 风控分级 — PR #81 核心路径。"""
+
+    def test_l0_normal_response_with_items(self):
+        body = _ok_body([{"jobName": "Python"}], total=100)
+        r = _analyze_api_response(200, "application/json", body)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["level"], 0)
+        self.assertEqual(r["signal"], "ok")
+        self.assertEqual(len(r["jobs"]), 1)
+        self.assertEqual(r["total"], 100)
+
+    def test_l3_http_error(self):
+        r = _analyze_api_response(403, "text/html", "")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 3)
+        self.assertEqual(r["signal"], "http_error")
+
+    def test_l3_non_json_with_captcha_hint(self):
+        r = _analyze_api_response(200, "text/html", "<html>请完成验证</html>")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 3)
+        self.assertEqual(r["signal"], "non_json")
+        self.assertIn("验证", r["note"])
+
+    def test_l3_non_json_with_login_hint(self):
+        r = _analyze_api_response(200, "text/html", '<html>请登录</html>')
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 3)
+        self.assertEqual(r["signal"], "non_json")
+        self.assertIn("登录", r["note"])
+
+    def test_l3_non_json_plain_html(self):
+        r = _analyze_api_response(200, "text/html", "<html>Not Found</html>")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 3)
+        self.assertEqual(r["signal"], "non_json")
+
+    def test_l1_json_parse_error(self):
+        r = _analyze_api_response(200, "application/json", "{broken json")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 1)
+        self.assertEqual(r["signal"], "parse_error")
+
+    def test_l3_hard_risk_status_not_1_with_verify(self):
+        body = json.dumps({"status": "0", "message": "请完成滑块验证"}, ensure_ascii=False)
+        r = _analyze_api_response(200, "application/json", body)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 3)
+        self.assertEqual(r["signal"], "hard_risk")
+
+    def test_l2_api_limited_status_not_1_without_hard_signals(self):
+        body = json.dumps({"status": "0", "message": "rate limited"}, ensure_ascii=False)
+        r = _analyze_api_response(200, "application/json", body)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 2)
+        self.assertEqual(r["signal"], "api_limited")
+
+    def test_l2_empty_items_with_total(self):
+        body = _ok_body([], total=50)
+        r = _analyze_api_response(200, "application/json", body)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["level"], 2)
+        self.assertEqual(r["signal"], "empty_items")
+        self.assertEqual(r["total"], 50)
+
+    def test_l0_empty_search_without_total(self):
+        r = _analyze_api_response(200, "application/json", _ok_body([], total=0))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["signal"], "no_results")
+        self.assertEqual(r["jobs"], [])
+
+    def test_l0_total_defaults_to_items_count(self):
+        body = json.dumps({
+            "status": "1",
+            "resultbody": {"job": {"items": [{"jobName": "a"}, {"jobName": "b"}]}},
+        }, ensure_ascii=False)
+        r = _analyze_api_response(200, "application/json", body)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["total"], 2)
+
+    def test_reason_code_mapping(self):
+        parse_err = {"signal": "parse_error"}
+        self.assertEqual(_reason_code_for(parse_err), "selector_changed")
+        other = {"signal": "http_error"}
+        self.assertEqual(_reason_code_for(other), "rate_limit")
+
+
+class RealLastPageTests(TestCase):
+    """主动末页判定 — 终止条件。"""
+
+    def test_returns_fallback_when_total_zero(self):
+        analysis = {"total": 0}
+        self.assertEqual(Job51Collector._real_last_page(analysis, 50), 50)
+
+    def test_returns_fallback_when_total_missing(self):
+        analysis = {}
+        self.assertEqual(Job51Collector._real_last_page(analysis, 50), 50)
+
+    def test_calculates_exact_pages(self):
+        analysis = {"total": 600}
+        expected = (600 + API_PAGE_SIZE - 1) // API_PAGE_SIZE
+        self.assertEqual(Job51Collector._real_last_page(analysis, 50), expected)
+
+    def test_caps_at_fallback(self):
+        analysis = {"total": 2000}
+        raw_pages = (2000 + API_PAGE_SIZE - 1) // API_PAGE_SIZE
+        self.assertGreater(raw_pages, HARD_MAX_PAGES)
+        self.assertEqual(Job51Collector._real_last_page(analysis, HARD_MAX_PAGES), HARD_MAX_PAGES)
+
+    def test_minimum_one_page(self):
+        analysis = {"total": 1}
+        self.assertEqual(Job51Collector._real_last_page(analysis, 50), 1)
+
+    def test_partial_last_page_rounds_up(self):
+        analysis = {"total": 21}
+        self.assertEqual(Job51Collector._real_last_page(analysis, 50), 2)
+
+
+class PlanProbePagesTests(TestCase):
+    """采样策略 — 分布探针。"""
+
+    def test_empty_when_max_less_than_start(self):
+        self.assertEqual(Job51Collector._plan_probe_pages(5, 3), [])
+
+    def test_all_pages_when_range_le_two(self):
+        self.assertEqual(Job51Collector._plan_probe_pages(1, 1), [1])
+        self.assertEqual(Job51Collector._plan_probe_pages(1, 2), [1, 2])
+
+    def test_start_page_always_included(self):
+        pages = Job51Collector._plan_probe_pages(1, 20)
+        self.assertIn(1, pages)
+
+    def test_max_page_included(self):
+        pages = Job51Collector._plan_probe_pages(1, 20)
+        self.assertIn(20, pages)
+
+    def test_no_adjacent_pages_in_front_section(self):
+        for _ in range(20):
+            pages = sorted(Job51Collector._plan_probe_pages(1, 30))
+            front = [p for p in pages if p <= 10]
+            for i in range(len(front) - 1):
+                self.assertGreater(front[i + 1] - front[i], 1,
+                                   f"Adjacent front pages: {front}")
+
+    def test_all_pages_within_bounds(self):
+        for _ in range(20):
+            pages = Job51Collector._plan_probe_pages(3, 25)
+            for p in pages:
+                self.assertGreaterEqual(p, 3)
+                self.assertLessEqual(p, 25)
+
+    def test_front_dense_more_than_rear(self):
+        for _ in range(10):
+            pages = Job51Collector._plan_probe_pages(1, 40)
+            front_count = sum(1 for p in pages if p <= 10)
+            rear_count = sum(1 for p in pages if p > 10)
+            self.assertGreaterEqual(front_count, rear_count)
+
+    def test_no_duplicates(self):
+        pages = Job51Collector._plan_probe_pages(1, 30)
+        self.assertEqual(len(pages), len(set(pages)))
+
+
+class Job51CitySnapshotTests(TestCase):
+    """城市编码 fail-closed — 保持原有约束。"""
+
+    def test_city_snapshot_loads(self):
+        snap = load_51job_city_snapshot()
+        self.assertEqual(snap["schema"], "bosshunter.51job_cities.v1")
+        self.assertGreaterEqual(len(snap["cities"]), 2)
+
+    def test_fail_closed_for_unknown_city(self):
         self.assertEqual(get_51job_city_code("北京市"), "010000")
         self.assertEqual(get_51job_city_code("上海市"), "020000")
         self.assertIsNone(get_51job_city_code("广州"))
+
+    def test_option_defaults_are_fail_closed(self):
         options = normalize_collection_options({}, {
             "platform_order": ["51job"],
             "platforms": {"51job": {"keywords": ["AI 产品"], "cities": ["上海"]}},
@@ -29,267 +216,154 @@ class Job51CollectorTests(TestCase):
         search = options["platforms"]["51job"]
         self.assertEqual(search["city_codes"], {"上海": "020000"})
         self.assertEqual(search["max_pages"], 1)
-        self.assertNotIn("target_count", search)
 
-    def test_beijing_search_uses_verified_51job_area_code(self):
-        request = PlatformCollectionRequest(
-            "51job",
-            ["AI 产品"],
-            ["北京"],
-            {"北京": "010000"},
-            max_pages=1,
-        )
 
-        url = Job51Collector.build_search_url(request, "北京", "AI 产品")
-
-        self.assertIn("jobArea=010000", url)
-        self.assertIn("keyword=AI%20%E4%BA%A7%E5%93%81", url)
-
-    def test_collection_uses_platform_identity_and_rate_limit(self):
-        list_payload = json.dumps({"status": "ready", "jobs": [
-            {
-                "source_job_id": "job-1",
-                "title": "AI 产品经理",
-                "company": "示例公司",
-                "city": "上海",
-                "url": "https://jobs.51job.com/shanghai/job-1.html",
-            },
-            {
-                "source_job_id": "job-2",
-                "title": "AI 产品运营",
-                "company": "示例公司",
-                "city": "上海",
-                "url": "https://jobs.51job.com/shanghai/job-2.html",
-            },
-        ]}, ensure_ascii=False)
-        detail_payload = json.dumps({
-            "status": "ready",
-            "title": "AI 产品",
-            "company": "示例公司",
-            "city": "上海",
-            "jd": "[岗位kanzhun职责]负责需求分析，来自BOSS直聘要求会 SQL。",
-        }, ensure_ascii=False)
-        sleeps: list[float] = []
-
-        def evaluate(_target, script):
-            return list_payload if ".joblist-item" in script else detail_payload
-
-        sleeps = []
-        browser = Job51Browser(
-            new_tab=lambda url, **_kwargs: url,
-            close_tab=lambda _target: True,
-            evaluate=evaluate,
-            scroll=lambda *_args, **_kwargs: True,
-            wait_for_load=lambda *_args, **_kwargs: True,
-        )
-        collected = []
-        hooks = CollectorHooks(
-            stop_event=None,
-            on_list_candidate=lambda _candidate: True,
-            on_candidate=lambda candidate: collected.append(candidate) or len(collected) < 2,
-            on_parse_failed=lambda reason: self.fail(reason),
-            on_event=lambda **_kwargs: None,
-        )
-        result = Job51Collector(
-            browser=browser,
-            sleep=sleeps.append,
-            uniform=lambda _low, _high: 13.0,
-        ).collect(
-            PlatformCollectionRequest("51job", ["AI 产品"], ["上海"], {"上海": "020000"}, max_pages=1),
-            hooks,
-        )
-
-        self.assertEqual(result.reason_code, "callback_stopped")
-        self.assertEqual([candidate.storage_id for candidate in collected], ["51job:job-1", "51job:job-2"])
-        self.assertEqual(sleeps, [13.0])
-        self.assertEqual(clean_job_description(collected[0].jd), "负责需求分析，要求会 SQL。")
-
-    def test_verification_page_stops_platform(self):
-        browser = Job51Browser(
-            new_tab=lambda url, **_kwargs: url,
-            close_tab=lambda _target: True,
-            evaluate=lambda _target, _script: json.dumps({"status": "blocked", "jobs": []}),
-            scroll=lambda *_args, **_kwargs: True,
-            wait_for_load=lambda *_args, **_kwargs: True,
-        )
-        hooks = CollectorHooks(
+class CollectionFlowSafetyTests(TestCase):
+    def setUp(self):
+        self.hooks = CollectorHooks(
             stop_event=None,
             on_list_candidate=lambda _candidate: True,
             on_candidate=lambda _candidate: True,
             on_parse_failed=lambda _reason: None,
             on_event=lambda **_kwargs: None,
         )
-        result = Job51Collector(browser=browser).collect(
-            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=1),
-            hooks,
-        )
-        self.assertEqual(result.status, "blocked")
-        self.assertEqual(result.reason_code, "rate_limit")
+        self.common_args = {
+            "city": "上海",
+            "area": "020000",
+            "kw": "AI",
+            "deal_breakers": [],
+            "jd_deal_breakers": [],
+            "blocked_companies": [],
+            "allow_internship": False,
+            "salary_min": 0.0,
+            "salary_max": 0.0,
+        }
 
-    def test_collection_waits_for_spa_list_render(self):
-        evaluations = 0
-        sleeps = []
-
-        def evaluate(_target, script):
-            nonlocal evaluations
-            if ".joblist-item" in script:
-                evaluations += 1
-                if evaluations < 3:
-                    return json.dumps({"status": "waiting", "jobs": []})
-                return json.dumps({"status": "ready", "jobs": [{
-                    "source_job_id": "job-spa",
-                    "title": "AI 运营",
-                    "company": "示例公司",
-                    "city": "上海",
-                    "url": "https://jobs.51job.com/shanghai/job-spa.html",
-                }]})
-            return json.dumps({
-                "status": "ready", "title": "AI 运营", "company": "示例公司",
-                "city": "上海", "jd": "负责 AI 产品运营与数据分析。",
-            })
-
-        browser = Job51Browser(
-            new_tab=lambda url, **_kwargs: url,
-            close_tab=lambda _target: True,
-            evaluate=evaluate,
-            scroll=lambda *_args, **_kwargs: True,
-            wait_for_load=lambda *_args, **_kwargs: True,
-        )
-        hooks = CollectorHooks(
-            stop_event=None,
-            on_list_candidate=lambda _candidate: True,
-            on_candidate=lambda _candidate: False,
-            on_parse_failed=lambda reason: self.fail(reason),
-            on_event=lambda **_kwargs: None,
+    def test_api_item_keeps_51job_platform_identity(self):
+        candidate = Job51Collector._item_to_candidate(
+            {
+                "jobId": "job-51",
+                "jobName": "AI 产品经理",
+                "jobDescribe": "负责 AI 产品规划",
+                "fullCompanyName": "示例公司",
+                "jobAreaString": "上海·浦东新区",
+                "jobHref": "https://jobs.51job.com/job-51.html",
+            },
+            "上海",
+            "020000",
+            "AI 产品",
         )
 
-        result = Job51Collector(browser=browser, sleep=sleeps.append).collect(
-            PlatformCollectionRequest("51job", ["AI运营"], ["上海"], {"上海": "020000"}, max_pages=1),
-            hooks,
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.platform, "51job")
+        self.assertEqual(candidate.storage_id, "51job:job-51")
+        self.assertEqual(candidate.city, "上海")
+
+    def test_probe_risk_signal_stops_without_marking_keyword_complete(self):
+        collector = Job51Collector(safety_conn=object())
+        limiter = Mock()
+        limiter.wait_before_request.return_value = True
+        blocked = {
+            "ok": False,
+            "level": 3,
+            "signal": "hard_risk",
+            "note": "请完成滑块验证",
+            "jobs": [],
+            "total": 0,
+        }
+
+        with (
+            patch("bosshunter.collection.platforms.job51.get_page_progress", return_value=0),
+            patch.object(Job51Collector, "_plan_probe_pages", return_value=[1]),
+            patch.object(collector, "_fetch_page", return_value=blocked),
+            patch("bosshunter.collection.platforms.job51.mark_combo_collected") as mark_complete,
+        ):
+            with self.assertRaises(CollectionBlockedError) as raised:
+                collector._collect_keyword(
+                    PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=1),
+                    self.hooks,
+                    "host-tab",
+                    limiter,
+                    max_pages=1,
+                    **self.common_args,
+                )
+
+        self.assertEqual(raised.exception.code, "rate_limit")
+        mark_complete.assert_not_called()
+
+    def test_hot_pages_are_checkpointed_in_ascending_order(self):
+        collector = Job51Collector(safety_conn=object())
+        limiter = Mock()
+        limiter.wait_before_request.return_value = True
+        jobs = [
+            {
+                "jobId": f"job-{index}",
+                "jobName": "AI 工程师",
+                "jobDescribe": "负责 AI 平台研发",
+                "fullCompanyName": "示例公司",
+            }
+            for index in range(API_PAGE_SIZE)
+        ]
+        analysis = {
+            "ok": True,
+            "level": 0,
+            "signal": "ok",
+            "note": "正常",
+            "jobs": jobs,
+            "total": API_PAGE_SIZE * 5,
+        }
+        fetched_pages = []
+        checkpoints = []
+
+        def fetch_page(_host, _keyword, _area, page):
+            fetched_pages.append(page)
+            return analysis
+
+        with (
+            patch("bosshunter.collection.platforms.job51.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.job51.upsert_page_progress",
+                  side_effect=lambda _conn, _source, _city, _keyword, page: checkpoints.append(page)),
+            patch("bosshunter.collection.platforms.job51.mark_combo_collected") as mark_complete,
+            patch("bosshunter.collection.platforms.job51.delete_page_progress"),
+            patch("bosshunter.collection.platforms.job51._wait_or_stop", return_value=False),
+            patch.object(Job51Collector, "_plan_probe_pages", return_value=[3]),
+            patch.object(collector, "_fetch_page", side_effect=fetch_page),
+            patch.object(collector, "_would_be_collected", return_value=True),
+        ):
+            collector._collect_keyword(
+                PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=5),
+                self.hooks,
+                "host-tab",
+                limiter,
+                max_pages=5,
+                **self.common_args,
+            )
+
+        self.assertEqual(fetched_pages, [3, 1, 2, 4, 5])
+        self.assertEqual(checkpoints, [1, 2, 3, 4, 5])
+        mark_complete.assert_called_once()
+
+    def test_collect_only_closes_temporary_host_tab(self):
+        request = PlatformCollectionRequest(
+            "51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=1,
         )
 
-        self.assertEqual(result.reason_code, "callback_stopped")
-        self.assertEqual(evaluations, 3)
-        self.assertEqual(sleeps, [0.75, 0.75])
+        for owned in (False, True):
+            with self.subTest(owned=owned):
+                close_tab = Mock(return_value=True)
+                collector = Job51Collector(browser=Job51Browser(close_tab=close_tab))
+                with (
+                    patch("bosshunter.collection.platforms.job51.SendWindowChecker.is_active", return_value=True),
+                    patch("bosshunter.collection.platforms.job51.should_take_day_off", return_value=False),
+                    patch.object(collector, "_ensure_host_tab", return_value=("host-tab", owned)),
+                    patch.object(collector, "_collect_keyword"),
+                ):
+                    result = collector.collect(request, self.hooks)
+
+                self.assertEqual(result.status, "completed")
+                self.assertEqual(close_tab.call_count, int(owned))
 
 
-    def test_multi_page_collection_clicks_next_and_applies_pacing(self):
-        # 覆盖 page>1 的翻页分支（此前无测试）：第一页采集后点击下一页，
-        # 第二页再次渲染出岗位；翻页安全间隔应被施加一次。
-        list_calls = {"n": 0}
-        next_clicks = []
-
-        def evaluate(target, script):
-            if ".joblist-item" in script:
-                list_calls["n"] += 1
-                if list_calls["n"] == 1:
-                    return json.dumps({"status": "ready", "jobs": [{
-                        "source_job_id": "job-p1",
-                        "title": "AI 算法工程师",
-                        "company": "示例公司",
-                        "city": "上海",
-                        "url": "https://jobs.51job.com/shanghai/job-p1.html",
-                    }]})
-                return json.dumps({"status": "ready", "jobs": [{
-                    "source_job_id": "job-p2",
-                    "title": "AI 数据工程师",
-                    "company": "示例公司",
-                    "city": "上海",
-                    "url": "https://jobs.51job.com/shanghai/job-p2.html",
-                }]})
-            if "btn-next" in script:
-                next_clicks.append(script)
-                return True  # 模拟存在下一页按钮
-            return json.dumps({
-                "status": "ready", "title": "AI 工程师", "company": "示例公司",
-                "city": "上海", "jd": "负责 AI 平台研发。",
-            })
-
-        sleeps = []
-        browser = Job51Browser(
-            new_tab=lambda url, **_kwargs: url,
-            close_tab=lambda _target: True,
-            evaluate=evaluate,
-            scroll=lambda *_args, **_kwargs: True,
-            wait_for_load=lambda *_args, **_kwargs: True,
-        )
-        collected = []
-        hooks = CollectorHooks(
-            stop_event=None,
-            on_list_candidate=lambda _candidate: True,
-            on_candidate=lambda candidate: collected.append(candidate) or True,
-            on_parse_failed=lambda _reason: None,
-            on_event=lambda **_kwargs: None,
-        )
-        result = Job51Collector(
-            browser=browser,
-            sleep=sleeps.append,
-            uniform=lambda _low, _high: 33.0,
-        ).collect(
-            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=2),
-            hooks,
-        )
-
-        self.assertEqual(result.status, "completed")
-        self.assertEqual(result.reason_code, "search_exhausted")
-        self.assertEqual(
-            [c.storage_id for c in collected],
-            ["51job:job-p1", "51job:job-p2"],
-        )
-        # 第二页触发了一次 JS_CLICK_NEXT 调用
-        self.assertEqual(len(next_clicks), 1)
-        # 一次翻页间隔，另一次是第二个详情页之前的安全间隔。
-        self.assertEqual(sleeps, [33.0, 33.0])
-
-    def test_last_page_without_next_button_completes_gracefully(self):
-        # 翻到第二页时若已无下一页按钮（JS_CLICK_NEXT 返回 False），
-        # 应优雅结束而非报错。
-        list_calls = {"n": 0}
-
-        def evaluate(target, script):
-            if ".joblist-item" in script:
-                list_calls["n"] += 1
-                return json.dumps({"status": "ready", "jobs": [{
-                    "source_job_id": f"job-{list_calls['n']}",
-                    "title": "AI 工程师",
-                    "company": "示例公司",
-                    "city": "上海",
-                    "url": f"https://jobs.51job.com/shanghai/job-{list_calls['n']}.html",
-                }]})
-            if "btn-next" in script:
-                return False  # 最后一页，无下一页按钮
-            return json.dumps({
-                "status": "ready", "title": "AI 工程师", "company": "示例公司",
-                "city": "上海", "jd": "负责 AI 研发。",
-            })
-
-        browser = Job51Browser(
-            new_tab=lambda url, **_kwargs: url,
-            close_tab=lambda _target: True,
-            evaluate=evaluate,
-            scroll=lambda *_args, **_kwargs: True,
-            wait_for_load=lambda *_args, **_kwargs: True,
-        )
-        collected = []
-        hooks = CollectorHooks(
-            stop_event=None,
-            on_list_candidate=lambda _candidate: True,
-            on_candidate=lambda candidate: collected.append(candidate) or True,
-            on_parse_failed=lambda _reason: None,
-            on_event=lambda **_kwargs: None,
-        )
-        result = Job51Collector(
-            browser=browser,
-            sleep=lambda _s: None,
-            uniform=lambda _low, _high: 33.0,
-        ).collect(
-            PlatformCollectionRequest("51job", ["AI"], ["上海"], {"上海": "020000"}, max_pages=3),
-            hooks,
-        )
-
-        self.assertEqual(result.status, "completed")
-        self.assertEqual(result.reason_code, "search_exhausted")
-        self.assertEqual([c.storage_id for c in collected], ["51job:job-1"])
 class JobDescriptionCleanupTests(TestCase):
     def test_known_platform_source_noise_is_removed(self):
         dirty = "[岗位kanzhun职责]1.公司业务后台开发 来自BOSS直聘 2.掌握 SQL"


### PR DESCRIPTION
## 背景

直接接续并整合 #81 与 yuj-029/BossHunter#1，基于当前最新 `main` 重建，避免旧分支覆盖后续数据库、猎聘及其他回归修复。原提交人的署名已通过 Co-authored-by 保留。

## 主要改动

- 51job 从 DOM 解析切换为页面上下文中的只读搜索 API。
- 加入采样、请求限速、真实末页判断及词级/页级断点。
- 合入原补丁的关键路径测试和 KeyError 安全回退语义。
- 修复探针遇到 403、验证码、断连时被误记为“采集完成”的问题。
- 区分真正零结果、越过真实末页和异常空响应。
- 热区改为升序处理，保证单页码断点从 N+1 恢复时不会漏掉较小页码。
- 复用用户已有 51job 页面时不再错误关闭该页面。
- 更新设计文档，使 fail-closed 说明与实际代码一致。

## 验证

- `tests/test_job51_collector.py`：34 passed，2 subtests passed
- 全量测试：599 passed，21 subtests passed
- `git diff --check`：通过

## 合并前最后一步

这是平台采集路径的大改动，仍建议在真实登录环境进行一次最小冒烟：**1 个城市 + 1 个关键词 + `max_pages=1`**。只验证采集，不发送、不招呼；出现验证码、限流或异常立即停止。

Supersedes #81 after this PR is validated and merged.