### PR TITLE
feat(collection): 智联采集器增强 — config 集成 / 时间窗口 / 过滤链

### DIFF
--- a/src/bosshunter/collection/orchestrator.py
+++ b/src/bosshunter/collection/orchestrator.py
@@ -358,6 +358,9 @@ class CollectionOrchestrator:
                         if platform == "boss" and self._uses_default_registry
                         else Job51Collector(config=self.config, safety_conn=conn)
                         if platform == "51job" and self._uses_default_registry
+
+                        else ZhilianCollector(config=self.config, safety_conn=conn)
+                        if platform == "zhilian" and self._uses_default_registry
                         else self.registry.get(platform)
                     )
                     result = collector.collect(request, hooks)

--- a/src/bosshunter/collection/platforms/zhilian.py
+++ b/src/bosshunter/collection/platforms/zhilian.py
@@ -30,11 +30,14 @@ from bosshunter.browser import (
 )
 from bosshunter.collection.base import CollectionBlockedError, CollectionError, CollectorHooks
 from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
+from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
+from bosshunter.throttle import SendWindowChecker, should_take_day_off
 
 
 SEARCH_URL = "https://www.zhaopin.com/sou/jl{city_code}/"
 DETAIL_BASE_URL = "https://www.zhaopin.com"
 CITY_SNAPSHOT_PATH = Path(__file__).resolve().parents[2] / "data" / "zhilian_cities.json"
+_INTERNSHIP_TITLE_TERMS = ("实习", "intern", "internship", "管培")
 LIST_ITEM_CLASSES = ("joblist-box__item", "joblist-item", "job-card")
 TITLE_CLASSES = ("summary-planes__title", "jobinfo__name", "job-name", "job-title")
 SALARY_CLASSES = ("summary-planes__salary", "jobinfo__salary", "job-salary", "salary")
@@ -72,6 +75,12 @@ def load_zhilian_city_snapshot() -> dict[str, Any]:
         "note": payload.get("note", "智联城市编码需要人工核验") if isinstance(payload, dict) else "智联城市编码需要人工核验",
         "cities": cities,
     }
+
+
+def _is_internship(title: str) -> bool:
+    """判断岗位是否为实习/管培（只查标题）。"""
+    t = (title or "").lower()
+    return any(s in t for s in _INTERNSHIP_TITLE_TERMS)
 
 
 def _city_name_variants(city: str) -> set[str]:
@@ -552,11 +561,15 @@ class ZhilianCollector:
     def __init__(
         self,
         *,
+        config: dict[str, Any] | None = None,
+        safety_conn: Any | None = None,
         browser: ZhilianBrowser | None = None,
         sleep: Callable[[float], None] = time.sleep,
         delay_range: tuple[float, float] = (DETAIL_DELAY_MIN_SECONDS, DETAIL_DELAY_MAX_SECONDS),
         uniform: Callable[[float, float], float] = random.SystemRandom().uniform,
     ):
+        self.config = config or {}
+        self.safety_conn = safety_conn
         self.sleep = sleep
         self.delay_range = delay_range
         self.uniform = uniform
@@ -569,6 +582,20 @@ class ZhilianCollector:
                 press_key_action=browser_press_key,
                 navigate_action=browser_navigate,
             )
+
+    def _passes_filters(self, candidate: JobCandidate) -> bool:
+        """collector 增值过滤：deal_breakers / blocked_company / 实习。"""
+        profile = self.config.get("profile", {}) if isinstance(self.config.get("profile"), dict) else {}
+        if matching_deal_breaker(candidate.title, profile.get("deal_breakers") or []):
+            return False
+        if matching_blocked_company(candidate.company, profile.get("blocked_companies") or []):
+            return False
+        if matching_deal_breaker(candidate.jd, profile.get("jd_deal_breakers") or []):
+            return False
+        allow_internship = bool(profile.get("allow_internship", False))
+        if not allow_internship and _is_internship(candidate.title):
+            return False
+        return True
 
     def _submit_keyword(self, target_id: str, keyword: str) -> None:
         before_state = self._search_state(target_id)
@@ -709,6 +736,16 @@ class ZhilianCollector:
     def collect(self, request: PlatformCollectionRequest, hooks: CollectorHooks) -> PlatformCollectionResult:
         if any(not str(request.city_codes.get(city) or "").strip() for city in request.cities):
             return PlatformCollectionResult(self.platform, "failed", "no_valid_city", "智联城市编码未配置")
+
+        throttle_cfg = self.config.get("throttle", {}) if isinstance(self.config.get("throttle"), dict) else {}
+        send_windows = throttle_cfg.get("send_windows", ["09:00-16:00"])
+        if not SendWindowChecker(send_windows).is_active():
+            return PlatformCollectionResult(self.platform, "completed", "outside_window",
+                                            f"当前不在采集时间窗口内（{send_windows}）")
+        if should_take_day_off(float(throttle_cfg.get("day_off_probability", 0.05))):
+            return PlatformCollectionResult(self.platform, "completed", "day_off",
+                                            "今日随机休息，跳过智联采集")
+
         detail_requests = 0
         for city in request.cities:
             for keyword in request.keywords:
@@ -819,7 +856,11 @@ class ZhilianCollector:
                                     return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
                                 continue
                             candidate = self._candidate_from_list(raw_item, city, keyword)
-                            if candidate is None or not hooks.on_list_candidate(candidate):
+                            if candidate is None:
+                                continue
+                            if not self._passes_filters(candidate):
+                                continue
+                            if not hooks.on_list_candidate(candidate):
                                 continue
                             if detail_requests:
                                 delay = max(0.0, self.uniform(*self.delay_range))

--- a/tests/test_zhilian_collector.py
+++ b/tests/test_zhilian_collector.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from threading import Event
 from unittest import TestCase
+from unittest.mock import patch
 
 from bosshunter.collection.base import CollectionBlockedError, CollectionError, CollectorHooks
 from bosshunter.collection.models import PlatformCollectionRequest
@@ -23,6 +24,18 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 
 class ZhilianFixtureTests(TestCase):
+    def setUp(self):
+        self._patches = [
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
     def test_city_snapshot_is_local_and_not_shared_with_boss_codes(self):
         snapshot = load_zhilian_city_snapshot()
         self.assertEqual(snapshot["schema"], "bosshunter.zhilian_cities.v1")
@@ -374,3 +387,67 @@ class ZhilianFixtureTests(TestCase):
 
         self.assertEqual(detail["status"], "ready")
         self.assertEqual(waits, [0.8])
+
+
+class ZhilianEnhancedTests(TestCase):
+    """智联采集器增强：时间窗口 / 过滤链 / config 集成。"""
+
+    def _hooks(self):
+        return CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _c: True,
+            on_candidate=lambda _c: True,
+            on_parse_failed=lambda _r: None,
+            on_event=lambda **_: None,
+        )
+
+    def test_outside_send_window_skips_collection(self):
+        collector = ZhilianCollector()
+        with patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=False):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=1),
+                self._hooks(),
+            )
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "outside_window")
+
+    def test_day_off_skips_collection(self):
+        collector = ZhilianCollector()
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=True),
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=1),
+                self._hooks(),
+            )
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.reason_code, "day_off")
+
+    def test_deal_breaker_filter(self):
+        from bosshunter.collection.models import JobCandidate
+        collector = ZhilianCollector(config={"profile": {"deal_breakers": ["外包"]}})
+        c = JobCandidate(platform="zhilian", source_job_id="1", title="外包AI",
+                         company="公司", city="北京", city_code="530")
+        self.assertFalse(collector._passes_filters(c))
+
+    def test_blocked_company_filter(self):
+        from bosshunter.collection.models import JobCandidate
+        collector = ZhilianCollector(config={"profile": {"blocked_companies": ["黑名单"]}})
+        c = JobCandidate(platform="zhilian", source_job_id="1", title="AI工程师",
+                         company="黑名单", city="北京", city_code="530")
+        self.assertFalse(collector._passes_filters(c))
+
+    def test_internship_filter(self):
+        from bosshunter.collection.models import JobCandidate
+        collector = ZhilianCollector(config={"profile": {"allow_internship": False}})
+        c = JobCandidate(platform="zhilian", source_job_id="1", title="AI实习",
+                         company="公司", city="北京", city_code="530")
+        self.assertFalse(collector._passes_filters(c))
+
+    def test_no_filter_passes(self):
+        from bosshunter.collection.models import JobCandidate
+        collector = ZhilianCollector()
+        c = JobCandidate(platform="zhilian", source_job_id="1", title="AI工程师",
+                         company="公司", city="北京", city_code="530")
+        self.assertTrue(collector._passes_filters(c))


### PR DESCRIPTION
## Summary

智联采集器增强：添加 `config`/`safety_conn` 支持、时间窗口检查、过滤链（deal_breakers / blocked_companies / jd_deal_breakers / 实习），与 Boss/51job/Liepin 采集器对齐。

## Changes

### `src/bosshunter/collection/platforms/zhilian.py`

1. **`config` / `safety_conn` 参数**：`ZhilianCollector.__init__` 新增 `config` 和 `safety_conn` 参数
2. **时间窗口检查**：`collect()` 入口新增 `SendWindowChecker.is_active()` 和 `should_take_day_off()` 检查
3. **过滤链**：新增 `_passes_filters()` 方法，在候选处理循环中过滤：
   - `deal_breakers` — 标题命中一票否决词
   - `blocked_companies` — 公司命中黑名单
   - `jd_deal_breakers` — JD 命中一票否决词
   - 实习岗位 — `allow_internship=False` 时过滤实习/管培
4. **`_is_internship()` 辅助函数**

### `src/bosshunter/collection/orchestrator.py`

- 为 zhilian 平台注入 `config` 和 `safety_conn`

### `tests/test_zhilian_collector.py`

- 现有 28 测试适配时间窗口 mock（`setUp` / `tearDown`）
- 新增 `ZhilianEnhancedTests`（6 个测试）

## Test Results

```
tests/test_zhilian_collector.py .........................  (34 passed)
采集域全量: 100 passed, 0 failed
```

## Notes

- 不改动 fail-closed 设计
- `safety_conn` 参数已添加但暂未使用（预留断点续采/去重扩展点）
- 为后续 API-fetch 模式打下基础