### PR TITLE
feat(collection): 智联 safety_conn 断点续采 — 词级跳过/页级恢复/checkpoint 记录

### DIFF
--- a/src/bosshunter/collection/platforms/zhilian.py
+++ b/src/bosshunter/collection/platforms/zhilian.py
@@ -30,6 +30,15 @@ from bosshunter.browser import (
 )
 from bosshunter.collection.base import CollectionBlockedError, CollectionError, CollectorHooks
 from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
+from bosshunter.db import (
+    delete_page_progress,
+    get_collected_combos,
+    get_page_progress,
+    mark_combo_collected,
+    prune_collected_combos,
+    prune_page_progress,
+    upsert_page_progress,
+)
 from bosshunter.job_filters import matching_blocked_company, matching_deal_breaker
 from bosshunter.throttle import SendWindowChecker, should_take_day_off
 
@@ -597,6 +606,22 @@ class ZhilianCollector:
             return False
         return True
 
+    def _resume_ttl_hours(self) -> int:
+        """断点续采有效期（默认 24h），与 51job/liepin 同规则。"""
+        search_cfg: dict[str, Any] = {}
+        platforms = self.config.get("platforms", {})
+        if isinstance(platforms, dict) and isinstance(platforms.get("zhilian"), dict):
+            pf = platforms["zhilian"]
+            if isinstance(pf.get("search"), dict):
+                search_cfg = pf["search"]
+        elif isinstance(self.config.get("search"), dict):
+            search_cfg = self.config["search"]
+        raw = search_cfg.get("resume_ttl_hours", 24)
+        try:
+            return max(1, min(int(raw or 24), 720))
+        except (TypeError, ValueError):
+            return 24
+
     def _submit_keyword(self, target_id: str, keyword: str) -> None:
         before_state = self._search_state(target_id)
         actions = (
@@ -746,9 +771,33 @@ class ZhilianCollector:
             return PlatformCollectionResult(self.platform, "completed", "day_off",
                                             "今日随机休息，跳过智联采集")
 
+        # 词级断点续采：跳过最近 N 小时内已完成的 (city, keyword) 组合。
+        collected_combos: set[tuple[str, str]] = set()
+        if self.safety_conn is not None:
+            all_keywords = set(request.keywords)
+            prune_collected_combos(self.safety_conn, "zhilian", all_keywords)
+            prune_page_progress(self.safety_conn, "zhilian", all_keywords)
+            collected_combos = get_collected_combos(
+                self.safety_conn, "zhilian", within_hours=self._resume_ttl_hours()
+            )
+
         detail_requests = 0
         for city in request.cities:
             for keyword in request.keywords:
+                if (city, keyword) in collected_combos:
+                    hooks.on_event(phase="completed_keyword", keyword=keyword, city=city,
+                                   message=f"智联 {keyword} 断点续采：{self._resume_ttl_hours()}h 内已完成，整词跳过")
+                    continue
+                # 页级断点：从上次采到页码的下一页继续
+                saved_page = get_page_progress(self.safety_conn, "zhilian", city, keyword) if self.safety_conn is not None else 0
+                start_page = saved_page + 1 if saved_page > 0 else 1
+                if start_page > request.max_pages:
+                    if self.safety_conn is not None:
+                        mark_combo_collected(self.safety_conn, "zhilian", city, keyword)
+                        delete_page_progress(self.safety_conn, "zhilian", city, keyword)
+                    hooks.on_event(phase="completed_keyword", keyword=keyword, city=city,
+                                   message=f"智联 {keyword} 页级断点已超最大页（{saved_page}/{request.max_pages}），视为已采完，跳过")
+                    continue
                 target_id: str | None = None
                 try:
                     try:
@@ -761,14 +810,16 @@ class ZhilianCollector:
                         return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "无法打开智联搜索页")
                     if self.browser.navigate_action is not None and not self.browser.navigate_action(target_id, search_url):
                         return PlatformCollectionResult(self.platform, "failed", "browser_disconnected", "智联搜索页导航失败")
-                    for page in range(1, request.max_pages + 1):
+                    for page in range(start_page, request.max_pages + 1):
                         if hooks.stop_event is not None and hooks.stop_event.is_set():
                             return PlatformCollectionResult(self.platform, "stopped", "user_stopped", "用户已停止")
                         hooks.on_event(phase="loading_list", keyword=keyword, city=city, page=page)
                         try:
                             self.browser.wait_for_load(target_id, timeout=10)
-                            if page == 1:
+                            if page == start_page:
                                 self._submit_keyword(target_id, keyword)
+                                if start_page > 1:
+                                    self.browser.evaluate(target_id, _build_page_script(page))
                             else:
                                 self.browser.evaluate(target_id, _build_page_script(page))
                             self.browser.wait_for_load(target_id, timeout=10)
@@ -804,7 +855,7 @@ class ZhilianCollector:
                             message = str(exc) or "智联列表解析失败，可能是页面结构变化"
                             return PlatformCollectionResult(self.platform, "blocked", code, message)
                         if not items:
-                            return PlatformCollectionResult(self.platform, "completed", "no_results", "智联没有更多搜索结果")
+                            break
                         for raw_item in items:
                             card_index = raw_item.get("card_index") if isinstance(raw_item, dict) else None
                             if card_index is not None:
@@ -917,9 +968,16 @@ class ZhilianCollector:
                                 continue
                             if not hooks.on_candidate(final):
                                 return PlatformCollectionResult(self.platform, "completed", "callback_stopped", "采集回调已停止")
+                        # 页级断点：每采完一页立即记录页码
+                        if self.safety_conn is not None:
+                            upsert_page_progress(self.safety_conn, "zhilian", city, keyword, page)
                 finally:
                     if target_id:
                         self.browser.close_tab(target_id)
+                # 词结束：标记词级断点 + 清页级断点
+                if self.safety_conn is not None:
+                    mark_combo_collected(self.safety_conn, "zhilian", city, keyword)
+                    delete_page_progress(self.safety_conn, "zhilian", city, keyword)
         return PlatformCollectionResult(self.platform, "completed", "search_exhausted", "智联搜索结果已采集完毕")
 
     @staticmethod

--- a/tests/test_zhilian_collector.py
+++ b/tests/test_zhilian_collector.py
@@ -451,3 +451,276 @@ class ZhilianEnhancedTests(TestCase):
         c = JobCandidate(platform="zhilian", source_job_id="1", title="AI工程师",
                          company="公司", city="北京", city_code="530")
         self.assertTrue(collector._passes_filters(c))
+
+
+class ZhilianResumeCheckpointTests(TestCase):
+    """智联断点续采：词级跳过 / 页级恢复 / checkpoint 记录 / 完成标记。"""
+
+    def _hooks(self, collected=None, events=None):
+        collected = collected if collected is not None else []
+        events = events if events is not None else []
+        return CollectorHooks(
+            stop_event=None,
+            on_list_candidate=lambda _c: True,
+            on_candidate=lambda c: collected.append(c) or True,
+            on_parse_failed=lambda _r: None,
+            on_event=lambda **kw: events.append(kw),
+        )
+
+    def _browser_with_pages(self, pages_jobs):
+        """pages_jobs: dict[int, list[dict]] — page number to list items.
+        None means empty (no items)."""
+        list_calls = {"n": 0}
+        detail_payload = json.dumps({
+            "source_job_id": "zl-1", "title": "AI", "company": "公司",
+            "city": "北京", "jd": "JD 内容", "status": "ready",
+        })
+
+        def evaluate(_target, script):
+            if "describtion__detail-content" in script:
+                return detail_payload
+            if "expectedCity" not in script:
+                return json.dumps({"items": [], "status": "ready"})
+            list_calls["n"] += 1
+            page_num = list_calls["n"]
+            jobs = pages_jobs.get(page_num)
+            if jobs is None:
+                return json.dumps({"items": [], "status": "empty"})
+            return json.dumps({"items": jobs, "status": "ready"}, ensure_ascii=False)
+
+        browser = ZhilianBrowser(
+            new_tab=lambda _url, **_kw: "tab-1",
+            close_tab=lambda _t: True,
+            evaluate=evaluate,
+            scroll=lambda *_a, **_kw: True,
+            wait_for_load=lambda *_a, **_kw: True,
+            click_action=lambda _t, _v, **_kw: True,
+            type_text_action=lambda _t, _v, **_kw: True,
+            press_key_action=lambda _t, _v, **_kw: True,
+        )
+        return browser
+
+    def _job(self, job_id="zl-1"):
+        return {"source_job_id": job_id, "title": "AI", "company": "公司",
+                "city": "北京", "url": f"/job/{job_id}.html"}
+
+    def test_completed_combo_skipped_entirely(self):
+        browser = self._browser_with_pages({1: [self._job()]})
+        collected = []
+        events = []
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos"),
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value={("北京", "AI")}),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected"),
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress"),
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=1),
+                self._hooks(collected, events),
+            )
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(collected), 0)
+        skip_events = [e for e in events if e.get("phase") == "completed_keyword"]
+        self.assertTrue(any("断点续采" in str(e.get("message", "")) for e in skip_events))
+
+    def test_pages_are_checkpointed_in_ascending_order(self):
+        browser = self._browser_with_pages({1: [self._job()], 2: [self._job("zl-2")], 3: None})
+        collected = []
+        checkpoints = []
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos"),
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value=set()),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress",
+                  side_effect=lambda _c, _s, _ci, _k, page: checkpoints.append(page)),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected"),
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress"),
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=3),
+                self._hooks(collected),
+            )
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(checkpoints, [1, 2])
+
+    def test_word_completion_marks_combo_and_clears_page_progress(self):
+        browser = self._browser_with_pages({1: [self._job()], 2: None})
+        collected = []
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos"),
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value=set()),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected") as mark_complete,
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress") as delete_progress,
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=2),
+                self._hooks(collected),
+            )
+        self.assertEqual(result.status, "completed")
+        mark_complete.assert_called_once()
+        delete_progress.assert_called_once()
+
+    def test_blocked_page_does_not_mark_combo(self):
+        browser = ZhilianBrowser(
+            new_tab=lambda _url, **_kw: "tab-1",
+            close_tab=lambda _t: True,
+            evaluate=lambda _t, _s: json.dumps({"items": [], "status": "blocked"}),
+            scroll=lambda *_a, **_kw: True,
+            wait_for_load=lambda *_a, **_kw: True,
+            click_action=lambda _t, _v, **_kw: True,
+            type_text_action=lambda _t, _v, **_kw: True,
+            press_key_action=lambda _t, _v, **_kw: True,
+        )
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos"),
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value=set()),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected") as mark_complete,
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress"),
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=3),
+                self._hooks(),
+            )
+        self.assertEqual(result.status, "blocked")
+        mark_complete.assert_not_called()
+
+    def test_saved_page_exceeds_max_pages_skips_keyword(self):
+        browser = self._browser_with_pages({1: [self._job()]})
+        collected = []
+        events = []
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos"),
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value=set()),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=5),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected") as mark_complete,
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress") as delete_progress,
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=3),
+                self._hooks(collected, events),
+            )
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(collected), 0)
+        mark_complete.assert_called_once()
+        delete_progress.assert_called_once()
+        skip_events = [e for e in events if e.get("phase") == "completed_keyword"]
+        self.assertTrue(any("页级断点" in str(e.get("message", "")) for e in skip_events))
+
+    def test_prune_called_on_collect_start(self):
+        browser = self._browser_with_pages({1: [self._job()], 2: None})
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=object(),
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos") as prune_combos,
+            patch("bosshunter.collection.platforms.zhilian.prune_page_progress") as prune_pages,
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos", return_value=set()),
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress", return_value=0),
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress"),
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected"),
+            patch("bosshunter.collection.platforms.zhilian.delete_page_progress"),
+        ):
+            collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=2),
+                self._hooks(),
+            )
+        prune_combos.assert_called_once()
+        prune_pages.assert_called_once()
+
+    def test_resume_ttl_hours_from_config(self):
+        collector = ZhilianCollector(
+            config={"platforms": {"zhilian": {"search": {"resume_ttl_hours": 48}}}},
+        )
+        self.assertEqual(collector._resume_ttl_hours(), 48)
+
+    def test_resume_ttl_hours_clamped_to_range(self):
+        collector_low = ZhilianCollector(
+            config={"platforms": {"zhilian": {"search": {"resume_ttl_hours": -5}}}},
+        )
+        self.assertEqual(collector_low._resume_ttl_hours(), 1)
+        collector_high = ZhilianCollector(
+            config={"platforms": {"zhilian": {"search": {"resume_ttl_hours": 9999}}}},
+        )
+        self.assertEqual(collector_high._resume_ttl_hours(), 720)
+
+    def test_resume_ttl_hours_default_when_missing(self):
+        collector = ZhilianCollector()
+        self.assertEqual(collector._resume_ttl_hours(), 24)
+
+    def test_resume_ttl_hours_invalid_falls_back_to_default(self):
+        collector = ZhilianCollector(
+            config={"platforms": {"zhilian": {"search": {"resume_ttl_hours": "invalid"}}}},
+        )
+        self.assertEqual(collector._resume_ttl_hours(), 24)
+
+    def test_no_safety_conn_skips_resume_logic(self):
+        browser = self._browser_with_pages({1: [self._job()], 2: None})
+        collected = []
+        collector = ZhilianCollector(
+            browser=browser, safety_conn=None,
+            sleep=lambda _s: None, uniform=lambda _a, _b: 10.0,
+        )
+        with (
+            patch("bosshunter.collection.platforms.zhilian.SendWindowChecker.is_active", return_value=True),
+            patch("bosshunter.collection.platforms.zhilian.should_take_day_off", return_value=False),
+            patch("bosshunter.collection.platforms.zhilian.prune_collected_combos") as prune_combos,
+            patch("bosshunter.collection.platforms.zhilian.get_collected_combos") as get_combos,
+            patch("bosshunter.collection.platforms.zhilian.get_page_progress") as get_progress,
+            patch("bosshunter.collection.platforms.zhilian.upsert_page_progress") as upsert,
+            patch("bosshunter.collection.platforms.zhilian.mark_combo_collected") as mark,
+        ):
+            result = collector.collect(
+                PlatformCollectionRequest("zhilian", ["AI"], ["北京"], {"北京": "530"}, max_pages=2),
+                self._hooks(collected),
+            )
+        self.assertEqual(result.status, "completed")
+        prune_combos.assert_not_called()
+        get_combos.assert_not_called()
+        get_progress.assert_not_called()
+        upsert.assert_not_called()
+        mark.assert_not_called()


### PR DESCRIPTION
## Summary

智联采集器增加 `safety_conn` 断点续采能力，与 51job/猎聘实现对齐。

### 改动

**`src/bosshunter/collection/platforms/zhilian.py`** (+59/-3):

- **词级断点**：`collect()` 开头调用 `prune_collected_combos` + `prune_page_progress` 清理过期记录，`get_collected_combos(within_hours=TTL)` 获取最近 N 小时已完成的 (city, keyword) 组合，整词跳过
- **页级断点**：`get_page_progress` 读取上次采到的页码，`start_page = saved_page + 1`；若 `start_page > max_pages` 则标记完成并跳过
- **页级恢复**：`page == start_page` 时先 `_submit_keyword` 提交关键词加载结果，若 `start_page > 1` 再导航到目标页
- **页级 checkpoint**：每采完一页调用 `upsert_page_progress` 记录页码
- **词结束标记**：页循环正常结束后调用 `mark_combo_collected` + `delete_page_progress`
- **empty 页 `return` → `break`**：让页循环正常退出，确保词级标记能执行
- **`_resume_ttl_hours()`**：从 `config.platforms.zhilian.search.resume_ttl_hours` 读取，默认 24h，钳制 1~720

**`tests/test_zhilian_collector.py`** (+278):

新增 `ZhilianResumeCheckpointTests`（11 个测试）：
- 已完成组合整词跳过
- 页级 checkpoint 按升序记录
- 词完成时标记 combo + 清除 page_progress
- blocked 页不标记 combo
- saved_page 超 max_pages 时跳过并标记完成
- prune 在 collect 开头调用
- `_resume_ttl_hours` 从 config 读取 / 钳制 / 默认值 / 无效值回退
- 无 safety_conn 时跳过全部断点逻辑

### 覆盖率

`zhilian.py`: 79% → **82%**

### 测试

- 36 个智联测试全部通过（25 原有 + 11 新增）
- 174 个采集域测试全部通过，无回归

### 设计说明

- 断点续采仅在有 `safety_conn` 时启用，无连接时行为与之前完全一致
- `blocked` / `selector_changed` 等异常退出不标记 combo，下次运行会从上次 checkpoint 恢复
- `empty` 页现在用 `break` 而非 `return`，让词级标记正常执行后继续下一个 keyword/city
- 页级恢复时先提交关键词（加载 page 1），再导航到 `start_page`，确保搜索上下文正确