### PR TITLE
fix(collection): 移除 boss.py 未使用的 CollectionError 导入

### DIFF
--- a/src/bosshunter/collection/platforms/boss.py
+++ b/src/bosshunter/collection/platforms/boss.py
@@ -13,7 +13,7 @@ from urllib.parse import quote, urlencode
 
 from bosshunter.ai.prefilter import quick_score
 from bosshunter.browser import close_tab, evaluate, navigate, new_tab, scroll, wait_for_load
-from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.collection.base import CollectorHooks
 from bosshunter.collection.models import JobCandidate, PlatformCollectionRequest, PlatformCollectionResult
 from bosshunter.config import CITY_CODES
 from bosshunter.db import add_risk_event


### PR DESCRIPTION
pyflakes 检出 \oss.py:16\ 导入了 \CollectionError\ 但从未使用。该符号在 boss.py 中无任何引用，移除以保持导入清洁。

\\\diff
-from bosshunter.collection.base import CollectionError, CollectorHooks
+from bosshunter.collection.base import CollectorHooks
\\\

测试：20 passed（test_boss_collector.py），无回归。