### PR TITLE
fix(ai): 区分运行环境异常与 API 配置错误

### DIFF
--- a/src/bosshunter/web/preflight.py
+++ b/src/bosshunter/web/preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
@@ -10,6 +11,7 @@ from typing import Any
 
 import httpx
 
+from bosshunter import __version__
 from bosshunter.ai.credentials import (
 	get_ai_api_key,
 	get_ai_base_url,
@@ -19,7 +21,6 @@ from bosshunter.ai.credentials import (
 )
 from bosshunter.browser.diagnostics import run_browser_diagnostics
 from bosshunter.collection.orchestrator import normalize_collection_options
-
 
 VALID_MODES = {"full", "collect", "rescore", "monitor"}
 
@@ -103,6 +104,11 @@ def collect_preflight_checks(mode: str, config: dict, options: dict | None = Non
 
 def check_ai_connection(config: dict, required: bool = True) -> list[dict[str, str]]:
 	"""Validate AI credentials and perform a no-token model-list request."""
+	return [*_check_ai_connection(config, required), *_python_runtime_checks()]
+
+
+def _check_ai_connection(config: dict, required: bool) -> list[dict[str, str]]:
+	"""Run the AI configuration and connectivity checks."""
 	ai_cfg = config.get("ai", {}) if isinstance(config.get("ai"), dict) else {}
 	severity = "error" if required else "warning"
 	provider = str(ai_cfg.get("provider") or "anthropic")
@@ -193,6 +199,19 @@ def check_ai_connection(config: dict, required: bool = True) -> list[dict[str, s
 				"config",
 			)
 		]
+	except TypeError:
+		# Dependency initialization errors may echo request data, so never expose
+		# the original exception text in this user-facing diagnostic.
+		return [
+			_check(
+				"ai_runtime",
+				"AI 运行环境",
+				severity,
+				"AI 请求尚未发出：本地 Python/HTTPX 运行环境异常",
+				f"当前 Python {sys.version.split()[0]}、HTTPX {httpx.__version__}、BossHunter {__version__}；"
+				"请使用稳定版 Python 3.11、3.12 或 3.13，并重新创建虚拟环境。",
+			)
+		]
 
 	if result.status_code in {401, 403}:
 		return [
@@ -246,6 +265,22 @@ def check_ai_connection(config: dict, required: bool = True) -> list[dict[str, s
 			"pass",
 			"AI 接口连接正常",
 			f"已验证凭证和服务地址，当前模型：{model}；Key 来源：{key_source or '未知'}；Base URL 来源：{base_url_source or '官方默认'}。",
+		)
+	]
+
+
+def _python_runtime_checks() -> list[dict[str, str]]:
+	"""Warn when dependency behavior may differ on a prerelease interpreter."""
+	if sys.version_info.releaselevel == "final":
+		return []
+	return [
+		_check(
+			"python_runtime",
+			"Python 运行环境",
+			"warning",
+			"当前使用的是 Python 预发布版本",
+			f"检测到 Python {sys.version.split()[0]}；预发布解释器可能与 HTTP 客户端不兼容。"
+			"请使用稳定版 Python 3.11、3.12 或 3.13，并重新创建虚拟环境。",
 		)
 	]
 

--- a/tests/test_web_preflight.py
+++ b/tests/test_web_preflight.py
@@ -52,6 +52,50 @@ class AiPreflightTests(unittest.TestCase):
 		self.assertEqual(checks[0]["status"], "error")
 
 	@patch("bosshunter.web.preflight.httpx.get")
+	def test_ai_client_initialization_error_is_reported_as_runtime_failure(self, http_get):
+		"""客户端初始化失败发生在请求前，应提示本地环境且不得泄露配置。"""
+		api_key = "secret-key-that-must-not-leak"
+		base_url = "https://private-api.example/v1"
+		http_get.side_effect = TypeError(f"failed with {api_key} at {base_url}")
+		config = {
+			"ai": {
+				"provider": "openai_compatible",
+				"service": "custom",
+				"base_url": base_url,
+				"api_key": api_key,
+				"model": "private-model",
+			}
+		}
+
+		checks = check_ai_connection(config, required=True)
+
+		self.assertEqual(checks[0]["id"], "ai_runtime")
+		self.assertEqual(checks[0]["status"], "error")
+		self.assertIn("运行环境", checks[0]["message"])
+		self.assertIn("Python", checks[0]["detail"])
+		self.assertIn("HTTPX", checks[0]["detail"])
+		self.assertIn("BossHunter", checks[0]["detail"])
+		self.assertNotIn(api_key, str(checks))
+		self.assertNotIn(base_url, str(checks))
+
+	@patch("bosshunter.web.preflight.sys.version", "3.13.0a5 (test build)")
+	@patch("bosshunter.web.preflight.sys.version_info", Mock(releaselevel="alpha"))
+	@patch("bosshunter.web.preflight.httpx.get")
+	def test_prerelease_python_adds_runtime_warning(self, http_get):
+		"""预发布 Python 可能存在依赖兼容风险，连接成功时也应明确警告。"""
+		http_get.return_value = Mock(status_code=200)
+		config = {"ai": {"api_key": "secret-key", "model": "claude-sonnet-4-6"}}
+
+		checks = check_ai_connection(config, required=True)
+
+		self.assertEqual(checks[0]["status"], "pass")
+		warning = next(check for check in checks if check["id"] == "python_runtime")
+		self.assertEqual(warning["status"], "warning")
+		self.assertIn("预发布", warning["message"])
+		self.assertIn("3.13.0a5", warning["detail"])
+		self.assertNotIn("secret-key", str(checks))
+
+	@patch("bosshunter.web.preflight.httpx.get")
 	def test_ai_timeout_has_specific_feedback(self, http_get):
 		http_get.side_effect = httpx.ReadTimeout("timed out")
 		config = {"ai": {"api_key": "secret-key", "model": "claude-sonnet-4-6"}}


### PR DESCRIPTION
## 问题

`check_ai_connection()` 只处理 HTTPX 网络异常。HTTP 客户端初始化阶段抛出的 `TypeError` 会穿透预检，并被上层统一渲染成“请检查 AI 设置”，导致用户把本地运行环境问题误判为 API 配置问题。

## 改动

- 将请求阶段的 `TypeError` 分类为独立的 `ai_runtime` 错误，明确提示请求尚未发出。
- 错误详情只展示 Python、HTTPX 和 BossHunter 版本，不回显异常原文、API Key、Token 或 Base URL。
- 当 `sys.version_info.releaselevel` 不是 `final` 时，追加 `python_runtime` 警告，建议使用稳定版 Python 并重建虚拟环境。
- 增加客户端初始化异常、敏感信息不泄露和预发布 Python 警告的回归测试。

## 范围

本 PR 只修复 Issue #163，不包含启动脚本、安全与隐私 PRD、Windows 测试兼容修复或其他重构。

已检查 PR #172 的最新提交：两者修改同一请求区域，但三方合并可以自动完成。#172 的 `httpx.InvalidURL` 专用分类应位于 `httpx.HTTPError` 之前；本 PR 的 `TypeError` 环境分类位于 HTTPX 异常分支之后，两个场景可以同时保留。

## 验证

- `pytest tests/test_web_preflight.py -q`：15 passed
- `pytest -q`：626 passed，22 subtests passed；另有 2 个当前 main 已存在的 Windows 测试失败（POSIX `0600` 权限断言、跨盘 `relpath`）
- `ruff check --select I src/bosshunter/web/preflight.py tests/test_web_preflight.py`：通过
- `git diff --check`：通过
- `bosshunter --help`：通过
- 使用实际 Python 3.13.0a5 重放：不再输出 Traceback，返回 `ai_runtime` error 和 `python_runtime` warning
- 使用稳定版 Python 3.11 与相同 AI 配置验证：连接正常

Fixes #163
