### PR TITLE
fix(preflight): classify AI client-init crashes as local environment errors

### DIFF
--- a/src/bosshunter/web/preflight.py
+++ b/src/bosshunter/web/preflight.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+from bosshunter import __version__
 
 from bosshunter.ai.credentials import (
 	get_ai_api_key,
@@ -22,6 +25,23 @@ from bosshunter.collection.orchestrator import normalize_collection_options
 
 
 VALID_MODES = {"full", "collect", "rescore", "monitor"}
+
+
+def _python_release_checks() -> list[dict[str, str]]:
+	"""Warn when BossHunter runs on a pre-release Python (alpha/beta/candidate)."""
+	if sys.version_info.releaselevel == "final":
+		return []
+	return [
+		_check(
+			"python_release",
+			"Python 运行环境",
+			"warning",
+			f"当前为预发布版 Python {sys.version.split()[0]} {sys.version_info.releaselevel}",
+			"预发布版本的兼容性问题可能引发 HTTP 客户端初始化等本地异常；"
+			"建议使用稳定版 Python 3.11/3.12/3.13 并重建虚拟环境。",
+			"config",
+		)
+	]
 
 
 def collect_preflight_checks(mode: str, config: dict, options: dict | None = None) -> list[dict[str, str]]:
@@ -47,6 +67,7 @@ def collect_preflight_checks(mode: str, config: dict, options: dict | None = Non
 		# Pure collection must not perform an AI connectivity request. This keeps
 		# ``auto_score=false`` genuinely AI-free even when credentials are saved.
 		checks.append(_check("ai_connection", "AI 接口连接", "pass", "纯采集不需要 AI", "关闭“采集后自动评分”时不会调用 AI。"))
+		checks.extend(_python_release_checks())
 		try:
 			checks.extend(check_browser_connection(deepcopy(config), collection_options))
 		except Exception:
@@ -98,6 +119,7 @@ def collect_preflight_checks(mode: str, config: dict, options: dict | None = Non
 					f"执行顺序：{' → '.join(full_options.get('platform_order', []))}；只有支持投递的平台可进入全流程。",
 				)
 			)
+	checks.extend(_python_release_checks())
 	return checks
 
 
@@ -190,6 +212,20 @@ def check_ai_connection(config: dict, required: bool = True) -> list[dict[str, s
 				severity,
 				"无法连接 AI 接口",
 				"请检查 Base URL、网络或代理设置，然后重新检测。",
+				"config",
+			)
+		]
+	except TypeError:
+		# 客户端初始化阶段的崩溃（如预发布版 Python 上的 httpx 兼容问题）发生在
+		# 请求发出之前，与 API Key/Base URL 配置无关，不能笼统提示"检查 AI 设置"。
+		return [
+			_check(
+				"ai_connection",
+				"AI 接口连接",
+				severity,
+				"AI 请求尚未发出：本地 Python/HTTPX 运行环境异常",
+				f"当前 Python {sys.version.split()[0]} · HTTPX {httpx.__version__} · BossHunter {__version__}；"
+				"建议使用稳定版 Python 3.11/3.12/3.13 并重建虚拟环境。",
 				"config",
 			)
 		]

--- a/tests/test_web_preflight.py
+++ b/tests/test_web_preflight.py
@@ -61,6 +61,37 @@ class AiPreflightTests(unittest.TestCase):
 		self.assertEqual(checks[0]["status"], "error")
 		self.assertIn("连接超时", checks[0]["message"])
 
+	@patch("bosshunter.web.preflight.httpx.get")
+	def test_client_init_crash_is_reported_as_environment_error(self, http_get):
+		http_get.side_effect = TypeError("cannot convert 'NoneType' object to bytes")
+		config = {"ai": {"api_key": "secret-key", "base_url": "http://127.0.0.1:8000", "model": "local-model"}}
+
+		checks = check_ai_connection(config, required=True)
+
+		self.assertEqual(checks[0]["status"], "error")
+		self.assertIn("请求尚未发出", checks[0]["message"])
+		self.assertIn("运行环境异常", checks[0]["message"])
+		self.assertNotIn("请检查 AI 设置", str(checks))
+		self.assertIn(f"HTTPX {httpx.__version__}", checks[0]["detail"])
+		self.assertNotIn("secret-key", str(checks))
+		self.assertNotIn("127.0.0.1:8000", str(checks))
+
+	def test_pre_release_python_adds_warning_check(self):
+		from types import SimpleNamespace
+
+		from bosshunter.web.preflight import _python_release_checks
+
+		with patch("sys.version_info", SimpleNamespace(releaselevel="alpha")):
+			checks = _python_release_checks()
+
+		self.assertEqual(len(checks), 1)
+		self.assertEqual(checks[0]["status"], "warning")
+		self.assertIn("预发布版 Python", checks[0]["message"])
+		self.assertIn("稳定版 Python", checks[0]["detail"])
+
+		with patch("sys.version_info", SimpleNamespace(releaselevel="final")):
+			self.assertEqual(_python_release_checks(), [])
+
 
 class BrowserPreflightTests(unittest.TestCase):
 	@patch("bosshunter.web.preflight.run_browser_diagnostics")


### PR DESCRIPTION
## Summary

修复 #163：Python 预发布版（如 3.13.0a5）上 httpx 客户端初始化会抛 `TypeError`，该异常穿透 `check_ai_connection` 后被兜底渲染成误导性的「AI 接口检测失败，请检查 AI 设置后重试」，导致用户反复修改本来正确的 API 配置。

Fixes #163

## Changes

- `src/bosshunter/web/preflight.py`：
  - `check_ai_connection` 在 `except httpx.HTTPError` 后新增 `except TypeError` 分支：返回「AI 请求尚未发出：本地 Python/HTTPX 运行环境异常」，并附脱敏版本信息（当前 Python / HTTPX / BossHunter 版本；密钥与 Base URL 不可能进入异常文本——try 块内仅 `httpx.get` 一行，headers 在块外构建）
  - 新增 `_python_release_checks()`：`sys.version_info.releaselevel` 非 `final`（alpha/beta/candidate）时，`collect_preflight_checks` 结果追加一条 warning（id=`python_release`），提示使用稳定版 Python 3.11/3.12/3.13 并重建虚拟环境
- `tests/test_web_preflight.py`：+2 回归测试（mock `httpx.get` 抛 `TypeError` 断言被识别为环境分类且凭据/Base URL 不出现在检查结果；releaselevel 警告的开/关）
- CLI 无需改动：`ai-status` 只消费检查列表，分类修好后自然输出一条简洁的错误项

## Test

- `tests/test_web_preflight.py` 15/15 通过
- 全量 625 passed + 22 subtests（3 个失败均为与本 PR 无关的预存环境问题：Windows chmod 权限断言、跨盘符 relpath、1 例 WinError 145 隔离重跑通过）
- `ruff check src/` 162 = 基线 162，零新增

## Note

- 在审的 #172 同样改动 `check_ai_connection` 的 try 块与 `tests/test_web_preflight.py`（`InvalidURL` 分类），两个 PR 场景不重叠；后合并的一方 rebase 时两边保留即可。
