### PR TITLE
docs: 更新项目与维护贡献榜单及候选记录

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,8 @@
 # BossHunter 贡献记录
 
-本页保存近 30 天榜单、完整贡献榜、历史快照和计算口径。README 先展示现任维护者及其维护贡献占比，再展示近 30 天前 10，最后展示贡献总榜前 10。
+本页记录主线已采用的项目贡献，展示近 30 天榜、贡献总榜及历月结果。功能、修复、测试和文档按实际采用范围署名。
 
-本页记录被主线采用的 PR 项目贡献；维护贡献及其评分另见 [MAINTENANCE_CONTRIBUTIONS.md](MAINTENANCE_CONTRIBUTIONS.md)。两类贡献文档均由项目负责人 `@powerycy` 负责，同一项成果不得重复计分。维护者身份、候选观察期和历任记录见 [MAINTAINERS.md](MAINTAINERS.md)，贡献排名不会自动产生维护权限。
+维护工作另见 [维护贡献记录](MAINTENANCE_CONTRIBUTIONS.md)，同一成果不重复计入两榜。身份及候选记录见 [维护者记录](MAINTAINERS.md)。本次结果已由项目负责人确认。
 
 ## 近 30 天贡献榜
 
@@ -65,76 +65,6 @@
 | 24 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **0.8%** | 部分适配合入 | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
 | 24 | [@zeroTwo0617](https://github.com/zeroTwo0617) | **0.8%** | 已适配合入 | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
 
-## 计算口径
-
-| 维度 | 权重 | 判断内容 |
-|---|:---:|---|
-| 产品影响 | 40% | 是否解决真实问题、覆盖用户范围及功能完整度 |
-| 可靠性与安全 | 25% | 是否守住人工确认、隐私、账号安全和异常恢复边界 |
-| 测试与可维护性 | 20% | 测试质量、回归保护、结构清晰度及后续维护成本 |
-| 采纳状态 | 15% | 完整合入、选择性合入及最终进入主线的实际范围 |
-
-- 只计算已经进入 `main` 的内容；仍在审查、关闭但未采用的部分暂不计入。
-- 选择性整合必须同时链接原始 PR 和最终整合 PR，并只计算被采用的部分。
-- 同一项成果只记一次，不因拆分提交、重复提交或代码行数增加而重复加权。
-- 项目发起人、AI 工具和机器人账号不进入社区贡献榜。
-- 总榜按同一口径重新归一化为 100%；近 30 天榜使用相同维度独立排序，不直接复用历史百分比。占比保留一位小数，采用最大余数法补齐至 100.0%；同分并列，以未舍入的综合分确定名次，同分展示按 GitHub ID 排序。
-- 近 30 天榜每周更新一次；每月结束后按自然月保存一次不可覆盖的历史快照。
-- 更名、账号迁移或退出社区不会删除已经核实的历史贡献。
-
-## 本次评分明细与修订说明
-
-本次按既有四个维度，对截至核对时点已经进入主线的累计成果重新评估；不是在旧百分比上追加，也不按 PR 数量计分。以下为项目负责人发布的影响评估分，属于对证据的人工判断，不是客观产出测量。四列分别为加权后的分值，上限为 40 / 25 / 20 / 15；综合分是四列之和，贡献度为个人综合分除以所有参评人的综合分总和。采纳分结合实际采用范围，不因一个小 PR 完整合并就自动获得 15 分。
-
-每行证据见上方完整榜。相近成果按整体范围评估：采集恢复与测试补齐合并看影响，简历工作流只计已合入的后端/渲染/确认接口，不把尚未发布的前端界面计入。窗口内分值只使用窗口内实际采用的成果。
-
-| 贡献者 | 产品影响 /40 | 可靠性与安全 /25 | 测试与可维护性 /20 | 采纳状态 /15 | 综合分 | 窗口内分值（同维度顺序） | 窗口分 |
-|---|---:|---:|---:|---:|---:|---|---:|
-| [@yuppiez99999](https://github.com/yuppiez99999) | 35 | 22 | 20 | 14 | 91 | 35 / 22 / 20 / 14 | 91 |
-| [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 26 | 20 | 14 | 12 | 72 | 26 / 20 / 14 / 12 | 72 |
-| [@yukinoshi](https://github.com/yukinoshi) | 25 | 19 | 16 | 12 | 72 | 21 / 18 / 14 / 11 | 64 |
-| [@zhenian-666](https://github.com/zhenian-666) | 30 | 16 | 14 | 12 | 72 | 30 / 16 / 14 / 12 | 72 |
-| [@GioiaZheng](https://github.com/GioiaZheng) | 20 | 20 | 12 | 10 | 62 | 0 / 0 / 0 / 0 | 0 |
-| [@atticus-zhou](https://github.com/atticus-zhou) | 22 | 18 | 10 | 9 | 59 | 0 / 0 / 0 / 0 | 0 |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 17 | 19 | 12 | 10 | 58 | 17 / 19 / 12 / 10 | 58 |
-| [@haohao-fly](https://github.com/haohao-fly) | 20 | 12 | 10 | 7 | 49 | 20 / 12 / 10 / 7 | 49 |
-| [@hdfhssg](https://github.com/hdfhssg) | 18 | 10 | 8 | 6 | 42 | 18 / 10 / 8 / 6 | 42 |
-| [@meixiaoxie](https://github.com/meixiaoxie) | 14 | 14 | 8 | 6 | 42 | 14 / 14 / 8 / 6 | 42 |
-| [@Hebuyu688](https://github.com/Hebuyu688) | 14 | 10 | 7 | 5 | 36 | 14 / 10 / 7 / 5 | 36 |
-| [@yuj-029](https://github.com/yuj-029) | 14 | 10 | 6 | 5 | 35 | 14 / 10 / 6 / 5 | 35 |
-| [@bianshilong0604](https://github.com/bianshilong0604) | 12 | 7 | 7 | 4 | 30 | 12 / 7 / 7 / 4 | 30 |
-| [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 9 | 10 | 5 | 4 | 28 | 9 / 10 / 5 / 4 | 28 |
-| [@likris588-ux](https://github.com/likris588-ux) | 8 | 7 | 3 | 3 | 21 | 8 / 7 / 3 / 3 | 21 |
-| [@Nourishman](https://github.com/Nourishman) | 7 | 7 | 4 | 3 | 21 | 7 / 7 / 4 / 3 | 21 |
-| [@txz990](https://github.com/txz990) | 7 | 7 | 4 | 3 | 21 | 7 / 7 / 4 / 3 | 21 |
-| [@CaoJun1015](https://github.com/CaoJun1015) | 5 | 7 | 4 | 2 | 18 | 5 / 7 / 4 / 2 | 18 |
-| [@gaogao34](https://github.com/gaogao34) | 7 | 5 | 3 | 3 | 18 | 7 / 5 / 3 / 3 | 18 |
-| [@Henry369-0](https://github.com/Henry369-0) | 7 | 3 | 4 | 3 | 17 | 7 / 3 / 4 / 3 | 17 |
-| [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | 3 | 4 | 2 | 1 | 10 | 0 / 0 / 0 / 0 | 0 |
-| [@HanmmJade](https://github.com/HanmmJade) | 4 | 2 | 2 | 2 | 10 | 4 / 2 / 2 / 2 | 10 |
-| [@heroims](https://github.com/heroims) | 4 | 3 | 1 | 2 | 10 | 4 / 3 / 1 / 2 | 10 |
-| [@Colin-Cai0318](https://github.com/Colin-Cai0318) | 2 | 2 | 2 | 1 | 7 | 2 / 2 / 2 / 1 | 7 |
-| [@zeroTwo0617](https://github.com/zeroTwo0617) | 2 | 3 | 1 | 1 | 7 | 2 / 3 / 1 / 1 | 7 |
-
-累计综合分合计：**908**；窗口分合计：**769**。
-
-本次证据修订：
-
-- 新增 @bianshilong0604、@Hebuyu688、@txz990、@CaoJun1015、@heroims、@HanmmJade 六位已合入贡献者；其中维护者提交代码也计入本榜。
-- 补入 #155（9 月 1 日榜单提交后才合并）及 #147、#151、#153、#156–#159、#162、#170，既有城市数据来源 #137/#138/#140 只按 #156 的最终采纳记一次。
-- @yuppiez99999 对 #142 的安全审核从项目贡献中剔除，只记维护贡献；#142 的采集核心仍归 @yuj-029。
-- #77 的评分解释主体归 @bianshilong0604；@yukinoshi 的批次删除保护补丁单列实际采用范围。#158 的采集增强、续采与 TTL 主体归 @yuppiez99999；@fengziliang43-cmyk 的失败保存/断点补丁计入共同实现。同一人针对这些成果的发现、修复和合并推进不再在维护榜重复评分；纯合并提交不自动增加项目分。
-- 补全 @Nourishman 的原始 #29 → 最终 #44 采纳链。早于窗口的 @GioiaZheng（6 月）及 @atticus-zhou、@elowenzhouyb-source（8 月 2 日的 #28）保留总榜，窗口分为 0；@yukinoshi 的 #25 → #28 部分同样不进入窗口分。
-- 截至核对时仍开放的 #61、#67、#69、#82、#90、#92、#139、#145、#164、#176、#181、#189、#193 不新增项目贡献；已有部分适配记录仍仅保留此前进入主线的范围。维护申请 #186 尚待补充资料，不据此变更维护者身份。
-
-## 更新与审批
-
-- 榜单变更必须通过 Pull Request，并给出 PR、Issue、Review 或 Release 链接。
-- 贡献者可以提交更正或补充证据，但不能批准或合并涉及自己排名的修改。
-- 自动化和维护者可以提供候选数据与证据，本页最终采纳范围、排序和记录由项目负责人 `@powerycy` 确认；项目负责人同时可按 [治理规则](GOVERNANCE.md) 参与技术审核，贡献记录的确认不代替技术 PR 审批。
-- README 的近 30 天和总榜两个 Top 10 由正式维护者按本页同一数据快照同步并审核，无须项目负责人审核整个 README；不得在展示同步时自行改变已定稿排序或数值。
-- 排名争议先保留原记录，通过 Issue 收集证据，不直接删除历史。
-
 ## 历月快照
 
 自然月快照从 **2026-08** 开始建立。每次归档应记录统计区间、榜单、证据和合并该快照的治理 PR；旧快照只追加更正说明，不覆盖原始记录。
@@ -155,57 +85,3 @@
 | 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 | [#49/#50/#51 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
 | 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 | [#54/#55/#64/#65 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
 | 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
-
-## 历次更新快照
-
-### 2026-09-01（原始记录）
-
-以下原样保留上次滚动榜与总榜，以便追溯本次重评。旧表中 #142 审核的分类错误和 #29 采纳链遗漏由本次修订说明更正，不覆盖原始快照。来源：[#149](https://github.com/shengjidaguai-china/BossHunter/pull/149)。
-
-<details>
-<summary>展开 2026-09-01 原始榜单</summary>
-
-
-当前统计窗口：**2026-08-03 00:00 至 2026-09-01 23:59（Asia/Shanghai）**。窗口按榜单更新日向前滚动 30 个自然日；同分并列，后续名次顺延。
-
-| 排名 | 贡献者 | 本期主要贡献 | 证据 |
-|:---:|---|---|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | 可恢复岗位工具与智联统一采集架构 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | 评分 JSON 兼容、错误传播、暂停恢复和凭据优先级 | [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
-| 🥉 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测会话闭环、安全操作、本地凭据迁移和面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
-| 4 | [@yuppiez99999](https://github.com/yuppiez99999) | 平台采集回归、能力边界、注册模型和 51job API 安全复核 | [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 5 | [@yuj-029](https://github.com/yuj-029) | 51job API 只读采集、保守采样与断点续采核心 | [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、评分与投递队列 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置安全、公司屏蔽与城市查询 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
-
-#### 贡献总榜
-
-数据快照：**2026-09-01**。
-
-| 排名 | 贡献者 | 贡献度 | 状态 | 主要贡献 | 证据 |
-|:---:|---|:---:|:---:|---|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | **11%** | 已适配合入 | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) → [#41](https://github.com/shengjidaguai-china/BossHunter/pull/41) · [#42](https://github.com/shengjidaguai-china/BossHunter/pull/42) · [#43](https://github.com/shengjidaguai-china/BossHunter/pull/43) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **10%** | 已合并/适配合入 | Thinking 与多 AI 兼容；评分 JSON、错误传播、暂停恢复和凭据优先级修复 | [#25](https://github.com/shengjidaguai-china/BossHunter/pull/25) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) · [#48](https://github.com/shengjidaguai-china/BossHunter/pull/48) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
-| 🥉 | [@GioiaZheng](https://github.com/GioiaZheng) | **9.5%** | 已合并 | API Key 脱敏与安全读取；PDF 依赖降级；人工确认、招呼语和发送选择修复 | [#6](https://github.com/shengjidaguai-china/BossHunter/pull/6) · [#7](https://github.com/shengjidaguai-china/BossHunter/pull/7) · [#8](https://github.com/shengjidaguai-china/BossHunter/pull/8) · [#9](https://github.com/shengjidaguai-china/BossHunter/pull/9) · [#10](https://github.com/shengjidaguai-china/BossHunter/pull/10) · [#12](https://github.com/shengjidaguai-china/BossHunter/pull/12) |
-| 4 | [@atticus-zhou](https://github.com/atticus-zhou) | **8%** | 已合并 | AI 评分与招呼语重试、前台浏览器交互、送达验证和防重复发送 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
-| 5 | [@yuppiez99999](https://github.com/yuppiez99999) | **7.5%** | 已合并/适配合入 | BOSS、51job 与猎聘采集回归；平台能力、注册模型和运行边界测试；51job API 安全复核 | [#95/#97/#98/#99 → #126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#121 → #127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | **7%** | 已合并 | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | **6%** | 已合并 | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **6%** | 已适配合入 | 会话级送达确认、消息方向识别和确定性招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | **6%** | 已适配合入 | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) · [#64](https://github.com/shengjidaguai-china/BossHunter/pull/64) · [#65](https://github.com/shengjidaguai-china/BossHunter/pull/65) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 10 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **5.5%** | 已合并/适配合入 | 监测回复轮次、安全读取待处理消息、会话精确跳转、本地凭据迁移与面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
-| 11 | [@yuj-029](https://github.com/yuj-029) | **5%** | 已适配合入 | 51job 页面研究、只读采集核心、API 采样与断点续采实现 | [#58 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 12 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | **4%** | 已合并 | 招呼语发送队列进度、明确任务状态及生成网址白名单安全校验 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
-| 13 | [@Nourishman](https://github.com/Nourishman) | **3%** | 部分适配合入 | 带文字层 PDF 简历、模型 ID 规范化、岗位恢复与确认交接竞态修复 | [#29](https://github.com/shengjidaguai-china/BossHunter/pull/29) |
-| 13 | [@likris588-ux](https://github.com/likris588-ux) | **3%** | 部分适配合入 | 猎聘只读采集器、城市编码、分页与登录墙安全处理 | [#89](https://github.com/shengjidaguai-china/BossHunter/pull/89) → [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) |
-| 15 | [@Henry369-0](https://github.com/Henry369-0) | **2.5%** | 已适配合入 | Windows 启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/shengjidaguai-china/BossHunter/pull/57) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 15 | [@gaogao34](https://github.com/gaogao34) | **2.5%** | 部分适配合入 | BOSS 搜索筛选、筛选配置传递和人工招呼语保护 | [#104](https://github.com/shengjidaguai-china/BossHunter/pull/104) → [#125](https://github.com/shengjidaguai-china/BossHunter/pull/125) |
-| 17 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **1.5%** | 已合并 | AI 评分、招呼语与发送可靠性方案及整体验证 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
-| 18 | [@zeroTwo0617](https://github.com/zeroTwo0617) | **1%** | 已适配合入 | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
-| 18 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **1%** | 部分适配合入 | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-
-
-</details>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,46 +6,64 @@
 
 ## 近 30 天贡献榜
 
-当前统计窗口：**2026-08-03 00:00 至 2026-09-01 23:59（Asia/Shanghai）**。窗口按榜单更新日向前滚动 30 个自然日；同分并列，后续名次顺延。
+当前统计窗口：**2026-08-09 00:00 至 2026-09-07 23:59（Asia/Shanghai）**。窗口按榜单更新日向前滚动 30 个自然日；本次实际核对截至 **2026-09-07 14:00（Asia/Shanghai）**，当日其后发生的合并不包含在本快照。同分并列，后续名次顺延。
 
 | 排名 | 贡献者 | 本期主要贡献 | 证据 |
 |:---:|---|---|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | 可恢复岗位工具与智联统一采集架构 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | 评分 JSON 兼容、错误传播、暂停恢复和凭据优先级 | [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
-| 🥉 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测会话闭环、安全操作、本地凭据迁移和面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
-| 4 | [@yuppiez99999](https://github.com/yuppiez99999) | 平台采集回归、能力边界、注册模型和 51job API 安全复核 | [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 5 | [@yuj-029](https://github.com/yuj-029) | 51job API 只读采集、保守采样与断点续采核心 | [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、评分与投递队列 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置安全、公司屏蔽与城市查询 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+| 🥇 | [@yuppiez99999](https://github.com/yuppiez99999) | BOSS、51job 与猎聘采集回归；智联 API 与过滤链；三平台续采、城市快照及前端构建交付 | [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#95](https://github.com/shengjidaguai-china/BossHunter/pull/95)/[#97](https://github.com/shengjidaguai-china/BossHunter/pull/97)/[#98](https://github.com/shengjidaguai-china/BossHunter/pull/98)/[#99](https://github.com/shengjidaguai-china/BossHunter/pull/99) → [#126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130) · [#131](https://github.com/shengjidaguai-china/BossHunter/pull/131) · [#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#147](https://github.com/shengjidaguai-china/BossHunter/pull/147) · [#151](https://github.com/shengjidaguai-china/BossHunter/pull/151) · [#153](https://github.com/shengjidaguai-china/BossHunter/pull/153) · [#155](https://github.com/shengjidaguai-china/BossHunter/pull/155) · [#156](https://github.com/shengjidaguai-china/BossHunter/pull/156) · [#157](https://github.com/shengjidaguai-china/BossHunter/pull/157) · [#158](https://github.com/shengjidaguai-china/BossHunter/pull/158) · [#159](https://github.com/shengjidaguai-china/BossHunter/pull/159) · [#162](https://github.com/shengjidaguai-china/BossHunter/pull/162) · [#170](https://github.com/shengjidaguai-china/BossHunter/pull/170) |
+| 🥈 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束；母版项目保留、PNG/PDF 定制简历预览和显式人工确认 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#143](https://github.com/shengjidaguai-china/BossHunter/pull/143) |
+| 🥈 | [@zhenian-666](https://github.com/zhenian-666) | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) → [#41](https://github.com/shengjidaguai-china/BossHunter/pull/41) · [#42](https://github.com/shengjidaguai-china/BossHunter/pull/42) · [#43](https://github.com/shengjidaguai-china/BossHunter/pull/43) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 4 | [@yukinoshi](https://github.com/yukinoshi) | 多 AI 兼容、评分 JSON、错误恢复、凭据优先级与批次删除保护 | [#48](https://github.com/shengjidaguai-china/BossHunter/pull/48) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) · [#77](https://github.com/shengjidaguai-china/BossHunter/pull/77) |
+| 5 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测回复轮次、安全操作、本地凭据与面板交互；猎聘临时失败/保存失败保留断点的共同实现 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) · [#158 共同实现](https://github.com/shengjidaguai-china/BossHunter/pull/158)（[补丁范围](https://github.com/shengjidaguai-china/BossHunter/pull/158#issuecomment-5558085870)） |
+| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) · [#64](https://github.com/shengjidaguai-china/BossHunter/pull/64) · [#65](https://github.com/shengjidaguai-china/BossHunter/pull/65) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 9 | [@Hebuyu688](https://github.com/Hebuyu688) | AI 诊断和模型别名解析、薪资区间过滤、招呼语正向依据与毕业届别校验 | [#172](https://github.com/shengjidaguai-china/BossHunter/pull/172) |
+| 10 | [@yuj-029](https://github.com/yuj-029) | 51job 页面研究、只读采集核心、API 采样与断点续采实现 | [#58 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 11 | [@bianshilong0604](https://github.com/bianshilong0604) | 持久化评分解释快照、只读查询 API、状态降级与隐私白名单 | [#77](https://github.com/shengjidaguai-china/BossHunter/pull/77) |
+| 12 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语发送队列进度、明确任务状态及生成网址白名单安全校验 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+| 13 | [@likris588-ux](https://github.com/likris588-ux) | 猎聘只读采集器、城市编码、分页与登录墙安全处理 | [#89](https://github.com/shengjidaguai-china/BossHunter/pull/89) → [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) |
+| 13 | [@Nourishman](https://github.com/Nourishman) | 带文字层 PDF 简历、模型 ID 规范化、岗位恢复与确认交接竞态修复 | [#29](https://github.com/shengjidaguai-china/BossHunter/pull/29) → [#44](https://github.com/shengjidaguai-china/BossHunter/pull/44) |
+| 13 | [@txz990](https://github.com/txz990) | 持久化真实发送失败原因与错误码，识别已关闭或下架岗位 | [#161](https://github.com/shengjidaguai-china/BossHunter/pull/161) |
+| 16 | [@CaoJun1015](https://github.com/CaoJun1015) | 区分 Python/HTTPX 运行环境异常与 API 配置错误，并防止诊断泄露敏感信息 | [#179](https://github.com/shengjidaguai-china/BossHunter/pull/179) |
+| 16 | [@gaogao34](https://github.com/gaogao34) | BOSS 搜索筛选、筛选配置传递和人工招呼语保护 | [#104](https://github.com/shengjidaguai-china/BossHunter/pull/104) → [#125](https://github.com/shengjidaguai-china/BossHunter/pull/125) |
+| 18 | [@Henry369-0](https://github.com/Henry369-0) | Windows 启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/shengjidaguai-china/BossHunter/pull/57) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 19 | [@HanmmJade](https://github.com/HanmmJade) | 工作台独立全流程预检入口与 BOSS 关键词输入提示 | [#171](https://github.com/shengjidaguai-china/BossHunter/pull/171) |
+| 19 | [@heroims](https://github.com/heroims) | 修复 macOS TCC 下静态资源被误判为 403，恢复本地面板加载 | [#175](https://github.com/shengjidaguai-china/BossHunter/pull/175) |
+| 21 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 21 | [@zeroTwo0617](https://github.com/zeroTwo0617) | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
 
 ## 贡献总榜
 
-数据快照：**2026-09-01**。
+数据快照：**2026-09-07 14:00（Asia/Shanghai）**；已核对主线 [`a493849`](https://github.com/shengjidaguai-china/BossHunter/commit/a493849)。
 
 | 排名 | 贡献者 | 贡献度 | 状态 | 主要贡献 | 证据 |
 |:---:|---|:---:|:---:|---|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | **11%** | 已适配合入 | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) → [#41](https://github.com/shengjidaguai-china/BossHunter/pull/41) · [#42](https://github.com/shengjidaguai-china/BossHunter/pull/42) · [#43](https://github.com/shengjidaguai-china/BossHunter/pull/43) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **10%** | 已合并/适配合入 | Thinking 与多 AI 兼容；评分 JSON、错误传播、暂停恢复和凭据优先级修复 | [#25](https://github.com/shengjidaguai-china/BossHunter/pull/25) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) · [#48](https://github.com/shengjidaguai-china/BossHunter/pull/48) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
-| 🥉 | [@GioiaZheng](https://github.com/GioiaZheng) | **9.5%** | 已合并 | API Key 脱敏与安全读取；PDF 依赖降级；人工确认、招呼语和发送选择修复 | [#6](https://github.com/shengjidaguai-china/BossHunter/pull/6) · [#7](https://github.com/shengjidaguai-china/BossHunter/pull/7) · [#8](https://github.com/shengjidaguai-china/BossHunter/pull/8) · [#9](https://github.com/shengjidaguai-china/BossHunter/pull/9) · [#10](https://github.com/shengjidaguai-china/BossHunter/pull/10) · [#12](https://github.com/shengjidaguai-china/BossHunter/pull/12) |
-| 4 | [@atticus-zhou](https://github.com/atticus-zhou) | **8%** | 已合并 | AI 评分与招呼语重试、前台浏览器交互、送达验证和防重复发送 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
-| 5 | [@yuppiez99999](https://github.com/yuppiez99999) | **7.5%** | 已合并/适配合入 | BOSS、51job 与猎聘采集回归；平台能力、注册模型和运行边界测试；51job API 安全复核 | [#95/#97/#98/#99 → #126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#121 → #127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | **7%** | 已合并 | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | **6%** | 已合并 | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **6%** | 已适配合入 | 会话级送达确认、消息方向识别和确定性招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | **6%** | 已适配合入 | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) · [#64](https://github.com/shengjidaguai-china/BossHunter/pull/64) · [#65](https://github.com/shengjidaguai-china/BossHunter/pull/65) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 10 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **5.5%** | 已合并/适配合入 | 监测回复轮次、安全读取待处理消息、会话精确跳转、本地凭据迁移与面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
-| 11 | [@yuj-029](https://github.com/yuj-029) | **5%** | 已适配合入 | 51job 页面研究、只读采集核心、API 采样与断点续采实现 | [#58 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
-| 12 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | **4%** | 已合并 | 招呼语发送队列进度、明确任务状态及生成网址白名单安全校验 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
-| 13 | [@Nourishman](https://github.com/Nourishman) | **3%** | 部分适配合入 | 带文字层 PDF 简历、模型 ID 规范化、岗位恢复与确认交接竞态修复 | [#29](https://github.com/shengjidaguai-china/BossHunter/pull/29) |
-| 13 | [@likris588-ux](https://github.com/likris588-ux) | **3%** | 部分适配合入 | 猎聘只读采集器、城市编码、分页与登录墙安全处理 | [#89](https://github.com/shengjidaguai-china/BossHunter/pull/89) → [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) |
-| 15 | [@Henry369-0](https://github.com/Henry369-0) | **2.5%** | 已适配合入 | Windows 启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/shengjidaguai-china/BossHunter/pull/57) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
-| 15 | [@gaogao34](https://github.com/gaogao34) | **2.5%** | 部分适配合入 | BOSS 搜索筛选、筛选配置传递和人工招呼语保护 | [#104](https://github.com/shengjidaguai-china/BossHunter/pull/104) → [#125](https://github.com/shengjidaguai-china/BossHunter/pull/125) |
-| 17 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **1.5%** | 已合并 | AI 评分、招呼语与发送可靠性方案及整体验证 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
-| 18 | [@zeroTwo0617](https://github.com/zeroTwo0617) | **1%** | 已适配合入 | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
-| 18 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **1%** | 部分适配合入 | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 🥇 | [@yuppiez99999](https://github.com/yuppiez99999) | **10.0%** | 已合并/适配合入 | BOSS、51job 与猎聘采集回归；智联 API 与过滤链；三平台续采、城市快照及前端构建交付 | [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#95](https://github.com/shengjidaguai-china/BossHunter/pull/95)/[#97](https://github.com/shengjidaguai-china/BossHunter/pull/97)/[#98](https://github.com/shengjidaguai-china/BossHunter/pull/98)/[#99](https://github.com/shengjidaguai-china/BossHunter/pull/99) → [#126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130) · [#131](https://github.com/shengjidaguai-china/BossHunter/pull/131) · [#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#147](https://github.com/shengjidaguai-china/BossHunter/pull/147) · [#151](https://github.com/shengjidaguai-china/BossHunter/pull/151) · [#153](https://github.com/shengjidaguai-china/BossHunter/pull/153) · [#155](https://github.com/shengjidaguai-china/BossHunter/pull/155) · [#156](https://github.com/shengjidaguai-china/BossHunter/pull/156) · [#157](https://github.com/shengjidaguai-china/BossHunter/pull/157) · [#158](https://github.com/shengjidaguai-china/BossHunter/pull/158) · [#159](https://github.com/shengjidaguai-china/BossHunter/pull/159) · [#162](https://github.com/shengjidaguai-china/BossHunter/pull/162) · [#170](https://github.com/shengjidaguai-china/BossHunter/pull/170) |
+| 🥈 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **7.9%** | 已适配合入 | 会话送达、消息方向与招呼语约束；母版项目保留、PNG/PDF 定制简历预览和显式人工确认 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#143](https://github.com/shengjidaguai-china/BossHunter/pull/143) |
+| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **7.9%** | 已合并/适配合入 | Thinking 与多 AI 兼容；评分 JSON、错误传播、暂停恢复和凭据优先级；评分期间删除岗位不中断批次 | [#25](https://github.com/shengjidaguai-china/BossHunter/pull/25) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) · [#48](https://github.com/shengjidaguai-china/BossHunter/pull/48) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) · [#77 批次修复](https://github.com/shengjidaguai-china/BossHunter/pull/77)（[提交 db8db19](https://github.com/shengjidaguai-china/BossHunter/commit/db8db192e8356615b1674ad2fb3ad23f261294f1)） |
+| 🥈 | [@zhenian-666](https://github.com/zhenian-666) | **7.9%** | 已适配合入 | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) → [#41](https://github.com/shengjidaguai-china/BossHunter/pull/41) · [#42](https://github.com/shengjidaguai-china/BossHunter/pull/42) · [#43](https://github.com/shengjidaguai-china/BossHunter/pull/43) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 5 | [@GioiaZheng](https://github.com/GioiaZheng) | **6.8%** | 已合并 | API Key 脱敏与安全读取；PDF 依赖降级；人工确认、招呼语和发送选择修复 | [#6](https://github.com/shengjidaguai-china/BossHunter/pull/6) · [#7](https://github.com/shengjidaguai-china/BossHunter/pull/7) · [#8](https://github.com/shengjidaguai-china/BossHunter/pull/8) · [#9](https://github.com/shengjidaguai-china/BossHunter/pull/9) · [#10](https://github.com/shengjidaguai-china/BossHunter/pull/10) · [#12](https://github.com/shengjidaguai-china/BossHunter/pull/12) |
+| 6 | [@atticus-zhou](https://github.com/atticus-zhou) | **6.5%** | 已合并 | AI 评分与招呼语重试、前台浏览器交互、送达验证和防重复发送 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
+| 7 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **6.4%** | 已合并/适配合入 | 监测回复轮次、安全操作、本地凭据与面板交互；猎聘临时失败/保存失败保留断点的共同实现 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) · [#158 共同实现](https://github.com/shengjidaguai-china/BossHunter/pull/158)（[补丁范围](https://github.com/shengjidaguai-china/BossHunter/pull/158#issuecomment-5558085870)） |
+| 8 | [@haohao-fly](https://github.com/haohao-fly) | **5.4%** | 已合并 | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 9 | [@hdfhssg](https://github.com/hdfhssg) | **4.6%** | 已适配合入 | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) · [#64](https://github.com/shengjidaguai-china/BossHunter/pull/64) · [#65](https://github.com/shengjidaguai-china/BossHunter/pull/65) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 9 | [@meixiaoxie](https://github.com/meixiaoxie) | **4.6%** | 已合并 | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 11 | [@Hebuyu688](https://github.com/Hebuyu688) | **4.0%** | 已合并 | AI 诊断和模型别名解析、薪资区间过滤、招呼语正向依据与毕业届别校验 | [#172](https://github.com/shengjidaguai-china/BossHunter/pull/172) |
+| 12 | [@yuj-029](https://github.com/yuj-029) | **3.9%** | 已适配合入 | 51job 页面研究、只读采集核心、API 采样与断点续采实现 | [#58 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 13 | [@bianshilong0604](https://github.com/bianshilong0604) | **3.3%** | 已合并 | 持久化评分解释快照、只读查询 API、状态降级与隐私白名单 | [#77](https://github.com/shengjidaguai-china/BossHunter/pull/77) |
+| 14 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | **3.1%** | 已合并 | 招呼语发送队列进度、明确任务状态及生成网址白名单安全校验 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+| 15 | [@likris588-ux](https://github.com/likris588-ux) | **2.3%** | 部分适配合入 | 猎聘只读采集器、城市编码、分页与登录墙安全处理 | [#89](https://github.com/shengjidaguai-china/BossHunter/pull/89) → [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) |
+| 15 | [@Nourishman](https://github.com/Nourishman) | **2.3%** | 部分适配合入 | 带文字层 PDF 简历、模型 ID 规范化、岗位恢复与确认交接竞态修复 | [#29](https://github.com/shengjidaguai-china/BossHunter/pull/29) → [#44](https://github.com/shengjidaguai-china/BossHunter/pull/44) |
+| 15 | [@txz990](https://github.com/txz990) | **2.3%** | 已合并 | 持久化真实发送失败原因与错误码，识别已关闭或下架岗位 | [#161](https://github.com/shengjidaguai-china/BossHunter/pull/161) |
+| 18 | [@CaoJun1015](https://github.com/CaoJun1015) | **2.0%** | 已合并 | 区分 Python/HTTPX 运行环境异常与 API 配置错误，并防止诊断泄露敏感信息 | [#179](https://github.com/shengjidaguai-china/BossHunter/pull/179) |
+| 18 | [@gaogao34](https://github.com/gaogao34) | **2.0%** | 部分适配合入 | BOSS 搜索筛选、筛选配置传递和人工招呼语保护 | [#104](https://github.com/shengjidaguai-china/BossHunter/pull/104) → [#125](https://github.com/shengjidaguai-china/BossHunter/pull/125) |
+| 20 | [@Henry369-0](https://github.com/Henry369-0) | **1.9%** | 已适配合入 | Windows 启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/shengjidaguai-china/BossHunter/pull/57) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 21 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **1.1%** | 已合并 | AI 评分、招呼语与发送可靠性方案及整体验证 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
+| 21 | [@HanmmJade](https://github.com/HanmmJade) | **1.1%** | 已合并 | 工作台独立全流程预检入口与 BOSS 关键词输入提示 | [#171](https://github.com/shengjidaguai-china/BossHunter/pull/171) |
+| 21 | [@heroims](https://github.com/heroims) | **1.1%** | 已合并 | 修复 macOS TCC 下静态资源被误判为 403，恢复本地面板加载 | [#175](https://github.com/shengjidaguai-china/BossHunter/pull/175) |
+| 24 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **0.8%** | 部分适配合入 | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 24 | [@zeroTwo0617](https://github.com/zeroTwo0617) | **0.8%** | 已适配合入 | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
 
 ## 计算口径
 
@@ -60,9 +78,54 @@
 - 选择性整合必须同时链接原始 PR 和最终整合 PR，并只计算被采用的部分。
 - 同一项成果只记一次，不因拆分提交、重复提交或代码行数增加而重复加权。
 - 项目发起人、AI 工具和机器人账号不进入社区贡献榜。
-- 总榜按同一口径重新归一化为 100%；近 30 天榜使用相同维度独立排序，不直接复用历史百分比。
+- 总榜按同一口径重新归一化为 100%；近 30 天榜使用相同维度独立排序，不直接复用历史百分比。占比保留一位小数，采用最大余数法补齐至 100.0%；同分并列，以未舍入的综合分确定名次，同分展示按 GitHub ID 排序。
 - 近 30 天榜每周更新一次；每月结束后按自然月保存一次不可覆盖的历史快照。
 - 更名、账号迁移或退出社区不会删除已经核实的历史贡献。
+
+## 本次评分明细与修订说明
+
+本次按既有四个维度，对截至核对时点已经进入主线的累计成果重新评估；不是在旧百分比上追加，也不按 PR 数量计分。以下为项目负责人发布的影响评估分，属于对证据的人工判断，不是客观产出测量。四列分别为加权后的分值，上限为 40 / 25 / 20 / 15；综合分是四列之和，贡献度为个人综合分除以所有参评人的综合分总和。采纳分结合实际采用范围，不因一个小 PR 完整合并就自动获得 15 分。
+
+每行证据见上方完整榜。相近成果按整体范围评估：采集恢复与测试补齐合并看影响，简历工作流只计已合入的后端/渲染/确认接口，不把尚未发布的前端界面计入。窗口内分值只使用窗口内实际采用的成果。
+
+| 贡献者 | 产品影响 /40 | 可靠性与安全 /25 | 测试与可维护性 /20 | 采纳状态 /15 | 综合分 | 窗口内分值（同维度顺序） | 窗口分 |
+|---|---:|---:|---:|---:|---:|---|---:|
+| [@yuppiez99999](https://github.com/yuppiez99999) | 35 | 22 | 20 | 14 | 91 | 35 / 22 / 20 / 14 | 91 |
+| [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 26 | 20 | 14 | 12 | 72 | 26 / 20 / 14 / 12 | 72 |
+| [@yukinoshi](https://github.com/yukinoshi) | 25 | 19 | 16 | 12 | 72 | 21 / 18 / 14 / 11 | 64 |
+| [@zhenian-666](https://github.com/zhenian-666) | 30 | 16 | 14 | 12 | 72 | 30 / 16 / 14 / 12 | 72 |
+| [@GioiaZheng](https://github.com/GioiaZheng) | 20 | 20 | 12 | 10 | 62 | 0 / 0 / 0 / 0 | 0 |
+| [@atticus-zhou](https://github.com/atticus-zhou) | 22 | 18 | 10 | 9 | 59 | 0 / 0 / 0 / 0 | 0 |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 17 | 19 | 12 | 10 | 58 | 17 / 19 / 12 / 10 | 58 |
+| [@haohao-fly](https://github.com/haohao-fly) | 20 | 12 | 10 | 7 | 49 | 20 / 12 / 10 / 7 | 49 |
+| [@hdfhssg](https://github.com/hdfhssg) | 18 | 10 | 8 | 6 | 42 | 18 / 10 / 8 / 6 | 42 |
+| [@meixiaoxie](https://github.com/meixiaoxie) | 14 | 14 | 8 | 6 | 42 | 14 / 14 / 8 / 6 | 42 |
+| [@Hebuyu688](https://github.com/Hebuyu688) | 14 | 10 | 7 | 5 | 36 | 14 / 10 / 7 / 5 | 36 |
+| [@yuj-029](https://github.com/yuj-029) | 14 | 10 | 6 | 5 | 35 | 14 / 10 / 6 / 5 | 35 |
+| [@bianshilong0604](https://github.com/bianshilong0604) | 12 | 7 | 7 | 4 | 30 | 12 / 7 / 7 / 4 | 30 |
+| [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 9 | 10 | 5 | 4 | 28 | 9 / 10 / 5 / 4 | 28 |
+| [@likris588-ux](https://github.com/likris588-ux) | 8 | 7 | 3 | 3 | 21 | 8 / 7 / 3 / 3 | 21 |
+| [@Nourishman](https://github.com/Nourishman) | 7 | 7 | 4 | 3 | 21 | 7 / 7 / 4 / 3 | 21 |
+| [@txz990](https://github.com/txz990) | 7 | 7 | 4 | 3 | 21 | 7 / 7 / 4 / 3 | 21 |
+| [@CaoJun1015](https://github.com/CaoJun1015) | 5 | 7 | 4 | 2 | 18 | 5 / 7 / 4 / 2 | 18 |
+| [@gaogao34](https://github.com/gaogao34) | 7 | 5 | 3 | 3 | 18 | 7 / 5 / 3 / 3 | 18 |
+| [@Henry369-0](https://github.com/Henry369-0) | 7 | 3 | 4 | 3 | 17 | 7 / 3 / 4 / 3 | 17 |
+| [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | 3 | 4 | 2 | 1 | 10 | 0 / 0 / 0 / 0 | 0 |
+| [@HanmmJade](https://github.com/HanmmJade) | 4 | 2 | 2 | 2 | 10 | 4 / 2 / 2 / 2 | 10 |
+| [@heroims](https://github.com/heroims) | 4 | 3 | 1 | 2 | 10 | 4 / 3 / 1 / 2 | 10 |
+| [@Colin-Cai0318](https://github.com/Colin-Cai0318) | 2 | 2 | 2 | 1 | 7 | 2 / 2 / 2 / 1 | 7 |
+| [@zeroTwo0617](https://github.com/zeroTwo0617) | 2 | 3 | 1 | 1 | 7 | 2 / 3 / 1 / 1 | 7 |
+
+累计综合分合计：**908**；窗口分合计：**769**。
+
+本次证据修订：
+
+- 新增 @bianshilong0604、@Hebuyu688、@txz990、@CaoJun1015、@heroims、@HanmmJade 六位已合入贡献者；其中维护者提交代码也计入本榜。
+- 补入 #155（9 月 1 日榜单提交后才合并）及 #147、#151、#153、#156–#159、#162、#170，既有城市数据来源 #137/#138/#140 只按 #156 的最终采纳记一次。
+- @yuppiez99999 对 #142 的安全审核从项目贡献中剔除，只记维护贡献；#142 的采集核心仍归 @yuj-029。
+- #77 的评分解释主体归 @bianshilong0604；@yukinoshi 的批次删除保护补丁单列实际采用范围。#158 的采集增强、续采与 TTL 主体归 @yuppiez99999；@fengziliang43-cmyk 的失败保存/断点补丁计入共同实现。同一人针对这些成果的发现、修复和合并推进不再在维护榜重复评分；纯合并提交不自动增加项目分。
+- 补全 @Nourishman 的原始 #29 → 最终 #44 采纳链。早于窗口的 @GioiaZheng（6 月）及 @atticus-zhou、@elowenzhouyb-source（8 月 2 日的 #28）保留总榜，窗口分为 0；@yukinoshi 的 #25 → #28 部分同样不进入窗口分。
+- 截至核对时仍开放的 #61、#67、#69、#82、#90、#92、#139、#145、#164、#176、#181、#189、#193 不新增项目贡献；已有部分适配记录仍仅保留此前进入主线的范围。维护申请 #186 尚待补充资料，不据此变更维护者身份。
 
 ## 更新与审批
 
@@ -92,3 +155,57 @@
 | 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 | [#49/#50/#51 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
 | 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 | [#54/#55/#64/#65 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
 | 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+
+## 历次更新快照
+
+### 2026-09-01（原始记录）
+
+以下原样保留上次滚动榜与总榜，以便追溯本次重评。旧表中 #142 审核的分类错误和 #29 采纳链遗漏由本次修订说明更正，不覆盖原始快照。来源：[#149](https://github.com/shengjidaguai-china/BossHunter/pull/149)。
+
+<details>
+<summary>展开 2026-09-01 原始榜单</summary>
+
+
+当前统计窗口：**2026-08-03 00:00 至 2026-09-01 23:59（Asia/Shanghai）**。窗口按榜单更新日向前滚动 30 个自然日；同分并列，后续名次顺延。
+
+| 排名 | 贡献者 | 本期主要贡献 | 证据 |
+|:---:|---|---|---|
+| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | 可恢复岗位工具与智联统一采集架构 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | 评分 JSON 兼容、错误传播、暂停恢复和凭据优先级 | [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
+| 🥉 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测会话闭环、安全操作、本地凭据迁移和面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
+| 4 | [@yuppiez99999](https://github.com/yuppiez99999) | 平台采集回归、能力边界、注册模型和 51job API 安全复核 | [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 5 | [@yuj-029](https://github.com/yuj-029) | 51job API 只读采集、保守采样与断点续采核心 | [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、评分与投递队列 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置安全、公司屏蔽与城市查询 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+
+#### 贡献总榜
+
+数据快照：**2026-09-01**。
+
+| 排名 | 贡献者 | 贡献度 | 状态 | 主要贡献 | 证据 |
+|:---:|---|:---:|:---:|---|---|
+| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | **11%** | 已适配合入 | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 | [#40](https://github.com/shengjidaguai-china/BossHunter/pull/40) → [#41](https://github.com/shengjidaguai-china/BossHunter/pull/41) · [#42](https://github.com/shengjidaguai-china/BossHunter/pull/42) · [#43](https://github.com/shengjidaguai-china/BossHunter/pull/43) · [#45](https://github.com/shengjidaguai-china/BossHunter/pull/45) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **10%** | 已合并/适配合入 | Thinking 与多 AI 兼容；评分 JSON、错误传播、暂停恢复和凭据优先级修复 | [#25](https://github.com/shengjidaguai-china/BossHunter/pull/25) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) · [#48](https://github.com/shengjidaguai-china/BossHunter/pull/48) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#114](https://github.com/shengjidaguai-china/BossHunter/pull/114) · [#115](https://github.com/shengjidaguai-china/BossHunter/pull/115) · [#117](https://github.com/shengjidaguai-china/BossHunter/pull/117) · [#118](https://github.com/shengjidaguai-china/BossHunter/pull/118) |
+| 🥉 | [@GioiaZheng](https://github.com/GioiaZheng) | **9.5%** | 已合并 | API Key 脱敏与安全读取；PDF 依赖降级；人工确认、招呼语和发送选择修复 | [#6](https://github.com/shengjidaguai-china/BossHunter/pull/6) · [#7](https://github.com/shengjidaguai-china/BossHunter/pull/7) · [#8](https://github.com/shengjidaguai-china/BossHunter/pull/8) · [#9](https://github.com/shengjidaguai-china/BossHunter/pull/9) · [#10](https://github.com/shengjidaguai-china/BossHunter/pull/10) · [#12](https://github.com/shengjidaguai-china/BossHunter/pull/12) |
+| 4 | [@atticus-zhou](https://github.com/atticus-zhou) | **8%** | 已合并 | AI 评分与招呼语重试、前台浏览器交互、送达验证和防重复发送 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
+| 5 | [@yuppiez99999](https://github.com/yuppiez99999) | **7.5%** | 已合并/适配合入 | BOSS、51job 与猎聘采集回归；平台能力、注册模型和运行边界测试；51job API 安全复核 | [#95/#97/#98/#99 → #126](https://github.com/shengjidaguai-china/BossHunter/pull/126) · [#121 → #127](https://github.com/shengjidaguai-china/BossHunter/pull/127) · [#122](https://github.com/shengjidaguai-china/BossHunter/pull/122) · [#130](https://github.com/shengjidaguai-china/BossHunter/pull/130)–[#132](https://github.com/shengjidaguai-china/BossHunter/pull/132) · [#142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 6 | [@haohao-fly](https://github.com/haohao-fly) | **7%** | 已合并 | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 | [#38](https://github.com/shengjidaguai-china/BossHunter/pull/38) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | **6%** | 已合并 | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 | [#37](https://github.com/shengjidaguai-china/BossHunter/pull/37) → [#39](https://github.com/shengjidaguai-china/BossHunter/pull/39) |
+| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **6%** | 已适配合入 | 会话级送达确认、消息方向识别和确定性招呼语约束 | [#49](https://github.com/shengjidaguai-china/BossHunter/pull/49) · [#50](https://github.com/shengjidaguai-china/BossHunter/pull/50) · [#51](https://github.com/shengjidaguai-china/BossHunter/pull/51) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 7 | [@hdfhssg](https://github.com/hdfhssg) | **6%** | 已适配合入 | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 | [#54](https://github.com/shengjidaguai-china/BossHunter/pull/54) · [#55](https://github.com/shengjidaguai-china/BossHunter/pull/55) · [#64](https://github.com/shengjidaguai-china/BossHunter/pull/64) · [#65](https://github.com/shengjidaguai-china/BossHunter/pull/65) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 10 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **5.5%** | 已合并/适配合入 | 监测回复轮次、安全读取待处理消息、会话精确跳转、本地凭据迁移与面板交互 | [#119 → #124](https://github.com/shengjidaguai-china/BossHunter/pull/124) · [#134](https://github.com/shengjidaguai-china/BossHunter/pull/134) |
+| 11 | [@yuj-029](https://github.com/yuj-029) | **5%** | 已适配合入 | 51job 页面研究、只读采集核心、API 采样与断点续采实现 | [#58 → #62](https://github.com/shengjidaguai-china/BossHunter/pull/62) · [#81 → #142](https://github.com/shengjidaguai-china/BossHunter/pull/142) |
+| 12 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | **4%** | 已合并 | 招呼语发送队列进度、明确任务状态及生成网址白名单安全校验 | [#86](https://github.com/shengjidaguai-china/BossHunter/pull/86) · [#88](https://github.com/shengjidaguai-china/BossHunter/pull/88) |
+| 13 | [@Nourishman](https://github.com/Nourishman) | **3%** | 部分适配合入 | 带文字层 PDF 简历、模型 ID 规范化、岗位恢复与确认交接竞态修复 | [#29](https://github.com/shengjidaguai-china/BossHunter/pull/29) |
+| 13 | [@likris588-ux](https://github.com/likris588-ux) | **3%** | 部分适配合入 | 猎聘只读采集器、城市编码、分页与登录墙安全处理 | [#89](https://github.com/shengjidaguai-china/BossHunter/pull/89) → [#121](https://github.com/shengjidaguai-china/BossHunter/pull/121) → [#127](https://github.com/shengjidaguai-china/BossHunter/pull/127) |
+| 15 | [@Henry369-0](https://github.com/Henry369-0) | **2.5%** | 已适配合入 | Windows 启动器、桌面快捷方式、后台窗口隐藏与 Python 路径覆盖 | [#57](https://github.com/shengjidaguai-china/BossHunter/pull/57) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+| 15 | [@gaogao34](https://github.com/gaogao34) | **2.5%** | 部分适配合入 | BOSS 搜索筛选、筛选配置传递和人工招呼语保护 | [#104](https://github.com/shengjidaguai-china/BossHunter/pull/104) → [#125](https://github.com/shengjidaguai-china/BossHunter/pull/125) |
+| 17 | [@elowenzhouyb-source](https://github.com/elowenzhouyb-source) | **1.5%** | 已合并 | AI 评分、招呼语与发送可靠性方案及整体验证 | [#27](https://github.com/shengjidaguai-china/BossHunter/pull/27) → [#28](https://github.com/shengjidaguai-china/BossHunter/pull/28) |
+| 18 | [@zeroTwo0617](https://github.com/zeroTwo0617) | **1%** | 已适配合入 | 岗位池安全打开 BOSS 原职位链接 | [#112](https://github.com/shengjidaguai-china/BossHunter/pull/112) → [#123](https://github.com/shengjidaguai-china/BossHunter/pull/123) |
+| 18 | [@Colin-Cai0318](https://github.com/Colin-Cai0318) | **1%** | 部分适配合入 | Markdown 简历 UTF-8 校验 | [#61](https://github.com/shengjidaguai-china/BossHunter/pull/61) → [#62](https://github.com/shengjidaguai-china/BossHunter/pull/62) |
+
+
+</details>

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,11 +12,11 @@
 |---|---|---|---|---|
 | [@yuppiez99999](https://github.com/yuppiez99999) | 正式维护者 | 平台采集、城市数据与测试 | 2026-08-29 起 | 在任（Write） |
 | [@yukinoshi](https://github.com/yukinoshi) | 正式维护者 | AI、错误恢复与产品流程 | 2026-08-29 起 | 在任（Write） |
-| [@bianshilong0604](https://github.com/bianshilong0604) | 正式维护者 | Web、产品流程与隐私边界 | 2026-08-30 起 | 在任（Write） |
+| [@bianshilong0604](https://github.com/bianshilong0604) | 正式维护者 | Web、产品流程与隐私边界 | 2026-08-30 起 | 在任（Write；审核团队邀请待接受） |
 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 正式维护者 | 运行时、发送安全与监测链路 | 2026-08-30 起 | 在任（Write） |
 | [@powerycy](https://github.com/powerycy) 跑跑蹦蹦跳跳 | 项目负责人兼正式技术维护者 | 全仓技术审核、安全复核与合并；两类贡献文档与维护贡献评分 | 项目发起至今；2026-08-28 起正式建档；2026-09-06 起计入技术审核池 | 在任（Admin） |
 
-维护贡献分数、证据及历史基线试算统一记录于 [MAINTENANCE_CONTRIBUTIONS.md](MAINTENANCE_CONTRIBUTIONS.md)，由项目负责人单方面评分和定稿。本文件只管理维护者身份、职责及任期，不重复保存评分。
+维护贡献结果及证据统一记录于 [MAINTENANCE_CONTRIBUTIONS.md](MAINTENANCE_CONTRIBUTIONS.md)，由项目负责人单方面评分和定稿。本文件只管理维护者身份、职责及任期，不重复保存评分。
 
 ## 维护方式
 
@@ -33,7 +33,9 @@
 
 | GitHub | 擅长方向 | 观察期开始 | 推荐/带教人 | 状态 |
 |---|---|---|---|---|
-| — | — | — | — | 当前暂无观察期候选 |
+| [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话与消息链路、招呼语约束、定制简历与人工确认 | 2026-09-07 | 待指定 | 观察中（Triage；已接受邀请） |
+
+邀请于 **2026-09-07 08:16（北京时间）**接受，仓库 Triage 权限已生效。证据：[GitHub 成员事件](https://api.github.com/repos/shengjidaguai-china/BossHunter/events)（事件 ID：14535877238）；[已采用的项目贡献](CONTRIBUTORS.md)。
 
 ## 现任维护者贡献详情
 

--- a/MAINTENANCE_CONTRIBUTIONS.md
+++ b/MAINTENANCE_CONTRIBUTIONS.md
@@ -1,115 +1,18 @@
 # BossHunter 维护贡献记录
 
-本文件记录维护者对他人 PR 的审核、问题跟进、安全复核和治理交接等维护贡献；被主线采用的功能、修复、测试和文档等 PR 项目贡献另见 [CONTRIBUTORS.md](CONTRIBUTORS.md)。同一项成果不得在两类记录中重复计分。
-
-## 责任与决定权
-
-项目负责人 `@powerycy` 负责维护贡献评分及本文件，单方面决定分数、占比、证据采纳和发布定稿，无须其他维护者审批评分。维护者可以补充证据或提出更正，不能自行批准或合并涉及本人评分的修改。项目负责人不参评。
-
-贡献评价与技术审核分开：项目负责人同时作为正式技术维护者，可按 [GOVERNANCE.md](GOVERNANCE.md) 参与技术审核、安全复核和合并，其有效批准按一人计入；本人提交或参与编写的技术改动不得自审计票。项目负责人继续不参评，贡献评分不自动授予或撤销维护权限，也不代替技术 PR 审批。
+记录对他人工作的实质审核、安全复核、问题推进及交接。本人功能、修复、测试和文档实现计入 [项目贡献](CONTRIBUTORS.md)，同一成果不重复计入两榜。项目负责人 @powerycy 负责结果确认，不参评。
 
 ## 现任维护者贡献详情
 
-本次核对截至 **2026-09-07 14:00（Asia/Shanghai）**。以下为项目负责人本次发布的任期基线试算，替代 9 月 3 日展示值；四位参评维护者任职均未满 30 天，仍不属于正式任期核算，不用于授予或撤销权限。项目负责人 @powerycy 不参评。
+截至 **2026-09-07 14:00（Asia/Shanghai）**。以下为任职未满 30 天的试算结果，已由项目负责人确认。
 
 | 维护者 | 贡献占比 | 维护贡献摘要 | 代表证据 |
 |---|---:|---|---|
-| [@yukinoshi](https://github.com/yukinoshi) | **27.8%（试算）** | 城市快照审核发现四项陈旧测试夹具，作者修复后合入；核实 AI 运行环境异常的敏感信息边界；完成定制简历人工确认、母版与路径边界检查。 | [#156 Review](https://github.com/shengjidaguai-china/BossHunter/pull/156#pullrequestreview-5124257029) · [#179 Review](https://github.com/shengjidaguai-china/BossHunter/pull/179#pullrequestreview-5122026768) · [#143 Review](https://github.com/shengjidaguai-china/BossHunter/pull/143#pullrequestreview-5124301792) |
-| [@yuppiez99999](https://github.com/yuppiez99999) | **27.8%（试算）** | 保留 51job API 安全复核与历史协作成果；补充评分解释持久化/白名单审核和账号风险咨询分类闭环。本人采集、城市数据与构建 PR 均只计项目贡献。 | [#142 安全复核](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#77 Review](https://github.com/shengjidaguai-china/BossHunter/pull/77#pullrequestreview-5124525090) · [#168 咨询闭环](https://github.com/shengjidaguai-china/BossHunter/issues/168#issuecomment-5551623715) |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **22.9%（试算）** | 验证前端构建与 wheel 交付，并明确 sdist 等未解决限制；独立复测编排测试并纠正覆盖率基线；真实布局复现监测风险漏检，阻止有缺口的方案直接合入。 | [#147 Review](https://github.com/shengjidaguai-china/BossHunter/pull/147#pullrequestreview-5124304248) · [#151 Review](https://github.com/shengjidaguai-china/BossHunter/pull/151#pullrequestreview-5124304668) · [#73 Review](https://github.com/shengjidaguai-china/BossHunter/pull/73#pullrequestreview-5124305409) |
-| [@bianshilong0604](https://github.com/bianshilong0604) | **21.5%（试算）** | 保留招呼语网址、简历隐私、重复发送和任务并发的历史审核成果；本次未核实新增独立维护成果，不因最近几天无新增记录扣除累计成果。 | [#88 首轮](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 Review](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
+| [@yukinoshi](https://github.com/yukinoshi) | **26.2%（试算）** | 复核定制简历确认及路径边界、智联只读采集安全；完成招呼语队列产物冲突处理、验证与交接。 | [#143 Review](https://github.com/shengjidaguai-china/BossHunter/pull/143#pullrequestreview-5124301792) · [#162 Review](https://github.com/shengjidaguai-china/BossHunter/pull/162#pullrequestreview-5124275522) · [#86 验证与交接](https://github.com/shengjidaguai-china/BossHunter/pull/86#issuecomment-5466756964) |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **25.4%（试算）** | 独立验证打包与测试覆盖，真实布局复现风险停止漏检；已记录 sdist 等未修复限制，不计为修复闭环。 | [#147 Review](https://github.com/shengjidaguai-china/BossHunter/pull/147#pullrequestreview-5124304248) · [#151 Review](https://github.com/shengjidaguai-china/BossHunter/pull/151#pullrequestreview-5124304668) · [#73 Review](https://github.com/shengjidaguai-china/BossHunter/pull/73#pullrequestreview-5124305409) |
+| [@yuppiez99999](https://github.com/yuppiez99999) | **25.4%（试算）** | 复核 51job API 安全边界、评分解释持久化及白名单；完成账号风险咨询分类。 | [#142 Review](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#77 Review](https://github.com/shengjidaguai-china/BossHunter/pull/77#pullrequestreview-5124525090) · [#168 咨询闭环](https://github.com/shengjidaguai-china/BossHunter/issues/168#issuecomment-5551623715) |
+| [@bianshilong0604](https://github.com/bianshilong0604) | **23.0%（试算）** | 招呼语隐私、网址校验审核及复核；岗位状态与任务并发风险评审。 | [#88 首轮](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 评审](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
 
-### 本次任期评分明细
+@bianshilong0604 的仓库权限为 Write，审核团队邀请仍待接受，不能计入团队有效批准人数。
 
-等级按下文既有 0–5 级标准判断，不按评论或批准次数累加；对未完成的 PR 只记录已经完成的检查，不宣称交付闭环。四个等级依次为维护闭环与影响、Review 与安全质量、响应与推进成果、协作与交接。同分按 GitHub ID 排序，百分比用最大余数法保留一位小数并补齐至 100.0%。
-
-| 维护者 | 四维等级 | 四维加权得分 | 任期综合分 | 贡献占比 |
-|---|---|---|---:|---:|
-| [@yukinoshi](https://github.com/yukinoshi) | 4 / 4 / 4 / 4 | 32 / 24 / 16 / 8 | 80 | 27.8%（试算） |
-| [@yuppiez99999](https://github.com/yuppiez99999) | 4 / 4 / 4 / 4 | 32 / 24 / 16 / 8 | 80 | 27.8%（试算） |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 3 / 4 / 3 / 3 | 24 / 24 / 12 / 6 | 66 | 22.9%（试算） |
-| [@bianshilong0604](https://github.com/bianshilong0604) | 3 / 4 / 2 / 3 | 24 / 24 / 8 / 6 | 62 | 21.5%（试算） |
-
-总分 **288**。每个维度使用上表同一组最多三项代表证据，不将其拆成多条累加。等级判断依据：
-
-- @yuppiez99999：历史安全复核、跨改动兼容检查和咨询闭环形成持续协作结果，四维均为 4；新一轮分流和催办本身不追加分数。
-- @yukinoshi：城市数据回归定位后由作者修复，运行环境问题从诊断建议到独立复核闭环，简历安全检查覆盖具体边界，四维均为 4。#143 的旧批准已被新提交撤销，仅保留其检查内容作为历史工作证据，不视为当前有效批准。
-- @fengziliang43-cmyk：真实浏览器、覆盖率复测和打包验证能发现测试未覆盖的问题，审核质量为 4；已完成的审核交付、推进及交接为 3。#147 的 sdist/安装限制仍未解决，#73 关闭也不等于其问题已经修复，不按完整修复成果计分。
-- @bianshilong0604：#88 的复核闭环和隐私边界识别支持 3 / 4；#90 尚未合入，推进只计 2，协作计 3。综合分是本次按历史证据重新列明的 62 分，不从旧百分比反推。
-
-### 去重与状态核对
-
-- @yuppiez99999 对 #142 的 Review 仅计本页；其本人 #147、#151、#153、#155–#159、#162、#170 的实现、测试及相应 Issue 关闭不重复计维护分。
-- @yukinoshi 在 #77 的代码补丁及其问题发现/修复闭环归项目贡献；@fengziliang43-cmyk 在 #158 的共同实现及其发现/修复闭环也归项目贡献，本次维护评分排除这两组成果。#145 的补丁仍未合入，暂不新增项目分，其同一问题闭环也不进入本次维护评分。
-- 空白批准、已撤销批准的权限效力、参与修改后的自审、机器人输出和纯合并次数均不计分；评价有正文证据的具体检查或已验证的协作结果。
-- 维护者身份沿用 [MAINTAINERS.md](MAINTAINERS.md)。[#186](https://github.com/shengjidaguai-china/BossHunter/issues/186) 仍待申请人补齐资料与边界确认，尚未进入候选观察期。
-
-## 维护贡献评估
-
-维护贡献只衡量维护者在审核、治理、响应和交接中产生的结果，与 [项目贡献榜](CONTRIBUTORS.md) 分开。维护者自己提交的功能、修复、测试和文档属于项目贡献，不进入维护评分。
-
-维护者任职满 30 天后进行首次正式核算。每次核算都使用从任期开始至核算日的全部有效维护证据，不限定为最近 30 天，也不按 30 天周期切段或重置。任期综合得分满分 100，按以下四个维度评估：
-
-| 评估维度 | 权重 | 重点看什么 |
-|---|:---:|---|
-| 维护闭环与影响 | 40 | 全项目的风险、回归、发布或积压问题是否真正完成处理，而不是发了多少条评论 |
-| Review 与安全质量 | 30 | 对他人 PR 的判断是否准确，是否发现关键风险并完成独立验证 |
-| 响应与推进成果 | 20 | 是否对全项目的 PR/Issue 作出有效响应，并推动形成明确下一步或可验证结果 |
-| 协作与交接 | 10 | 协作认领、候选带教和交接文档是否产生可核实结果 |
-
-每个维度先按 0–5 级评分，再乘以权重：
-
-| 等级 | 判定标准 |
-|:---:|---|
-| 0 | 无可核实证据，或负责范围长期无人处理 |
-| 1 | 有回应或建议，但尚未形成可验证结果 |
-| 2 | 已推进部分工作，但闭环、验证或交接仍不完整 |
-| 3 | 完成应尽维护责任，有可追溯证据和明确结果 |
-| 4 | 产生超出常规的质量或效率改善，且经独立复核 |
-| 5 | 防止重大风险、完成重要事故/发布闭环，或形成可复用的治理改进 |
-
-单项得分计算为 `等级 ÷ 5 × 该维度权重`；任期综合得分为四项之和。贡献占比为 `个人任期综合得分 ÷ 所有参评现任维护者任期综合得分总和 × 100%`。核算看任期内成果的质量、影响和闭环程度，不把 PR、Issue 或评论数量直接累加为分数。
-
-评估与发布遵循以下规则：
-
-- 任职未满 30 天时可以公布用于校验口径的基线试算，但必须明确标记“试算”和项目负责人定稿状态；试算不作为权限、晋升或离任依据。任职满 30 天并由项目负责人定稿后，才能发布正式贡献占比。
-- 每人每个维度最多引用 3 项代表性成果；评分看结果质量、风险和持续性，不按 PR、Issue、评论或提交数量累加。
-- 同一问题、风险或交付闭环即使拆成多个 PR/Issue 也只作为一项证据；模板化评论、机械批准和 AI/机器人活动不计分。
-- 单纯接纳建议、请求更多信息或给出未落地的方向，只能作为 1–2 级过程证据，不能单独支撑“已完成”结论。
-- 每位维护者的任期评分、贡献占比和最终发布结果由项目负责人 `@powerycy` 单方面决定，无须被评维护者、其他维护者或双人复核批准。维护者可以提交事实证据和更正意见，最终采纳与评分由项目负责人定稿。
-- 贡献占比与当前活跃状态分开判断；停止活跃不会扣除已经形成的任期贡献。连续 14 天无维护活动仍按离任规则单独处理。
-- 安全证据可以隐去漏洞细节，由负责技术检查的维护者提供结果和证据链接供评分参考；评分不要求项目负责人重新审核技术代码，也不代替技术 PR 所需的安全复核。
-
-
-## 更新与发布
-
-- 本文件的记录、评分和评分口径由项目负责人决定，通过独立贡献文档 PR 留存变更依据，不要求维护者批准评分本身。
-- 项目负责人提交的评分 PR，以 PR 描述或评论中明确的定稿决定作为评分授权；维护者只核对格式、证据链接和展示同步，不重新评定或否决评分。
-- 对评分有异议时，提交具体证据和更正请求，由项目负责人决定；旧记录保留，修订说明记录日期和原因。
-- README 的维护贡献摘要由维护者依据本文件同一数据快照同步，不重新评分，也不因同步展示要求项目负责人审核整个 README。
-- 若 PR 同时包含技术改动、维护者任免、权限或技术审核规则，应拆为技术或治理 PR，按对应规则独立审核。
-
-## 历史基线
-
-### 2026-09-03（原始试算，未定稿）
-
-以下保留原始记录；当时的 Issue/PR 状态只表示历史核对结果，不代表本次状态。
-
-<details>
-<summary>展开 2026-09-03 原始试算</summary>
-
-
-以下沿用 2026-09-03 的历史基线试算，数值和证据原样迁入，尚未由项目负责人定稿；迁移不代表本次重新评分或批准已有分数。
-
-以下为截至 **2026-09-03** 已核实的维护活动摘要，仅记录对他人 PR 的 Review、Issue 治理、安全复核和交付协作，不计入本人提交的功能、修复、测试或文档。
-
-| 维护者 | 贡献占比 | 维护贡献摘要 | 代表证据 |
-|---|---:|---|---|
-| [@yuppiez99999](https://github.com/yuppiez99999) | **33.9%（试算）** | 对 51job API 采集完成只读边界、失败关闭、速率控制、断点续采和真实环境验证检查；持续梳理积压 PR 的风险、冲突与合并阻塞项，并主动让原贡献者方案承接合并。 | [#142 安全复核](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#139 Review](https://github.com/shengjidaguai-china/BossHunter/pull/139#pullrequestreview-5084448426) · [#89 协作复核](https://github.com/shengjidaguai-china/BossHunter/pull/89#pullrequestreview-5056851017) |
-| [@yukinoshi](https://github.com/yukinoshi) | **28.8%（试算）** | 对简历失败恢复 PR 完成全量测试、前端类型检查和安全红线验证并批准；为评分解释和招呼语队列改动处理冲突、补充合并方案与完整验证。 | [#92 Review](https://github.com/shengjidaguai-china/BossHunter/pull/92#pullrequestreview-5089153466) · [#77 合并分析](https://github.com/shengjidaguai-china/BossHunter/pull/77#issuecomment-5466530159) · [#86 合并验证](https://github.com/shengjidaguai-china/BossHunter/pull/86#issuecomment-5466756964) |
-| [@bianshilong0604](https://github.com/bianshilong0604) | **26.3%（试算）** | 在招呼语网址防护中识别简历隐私、可信网址来源和重复发送边界问题，并在修改后完成复核；同时审查招呼语生成流程的岗位状态与任务并发风险。 | [#88 首轮 Review](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 Review](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **11.0%（试算）** | 对安全锁是否应随账号切换重置完成风险边界研判，并对一键投递失效问题提出分层排查与复现信息要求；相关 Issue 尚未闭环。 | [#78 风险研判](https://github.com/shengjidaguai-china/BossHunter/issues/78#issuecomment-5452233325) · [#93 问题排查](https://github.com/shengjidaguai-china/BossHunter/issues/93#issuecomment-5452071152) |
-
-
-
-</details>
+[维护者身份、任期与候选记录](MAINTAINERS.md) · [治理规则](GOVERNANCE.md)

--- a/MAINTENANCE_CONTRIBUTIONS.md
+++ b/MAINTENANCE_CONTRIBUTIONS.md
@@ -10,17 +10,39 @@
 
 ## 现任维护者贡献详情
 
-以下沿用 2026-09-03 的历史基线试算，数值和证据原样迁入，尚未由项目负责人定稿；迁移不代表本次重新评分或批准已有分数。
-
-以下为截至 **2026-09-03** 已核实的维护活动摘要，仅记录对他人 PR 的 Review、Issue 治理、安全复核和交付协作，不计入本人提交的功能、修复、测试或文档。
+本次核对截至 **2026-09-07 14:00（Asia/Shanghai）**。以下为项目负责人本次发布的任期基线试算，替代 9 月 3 日展示值；四位参评维护者任职均未满 30 天，仍不属于正式任期核算，不用于授予或撤销权限。项目负责人 @powerycy 不参评。
 
 | 维护者 | 贡献占比 | 维护贡献摘要 | 代表证据 |
 |---|---:|---|---|
-| [@yuppiez99999](https://github.com/yuppiez99999) | **33.9%（试算）** | 对 51job API 采集完成只读边界、失败关闭、速率控制、断点续采和真实环境验证检查；持续梳理积压 PR 的风险、冲突与合并阻塞项，并主动让原贡献者方案承接合并。 | [#142 安全复核](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#139 Review](https://github.com/shengjidaguai-china/BossHunter/pull/139#pullrequestreview-5084448426) · [#89 协作复核](https://github.com/shengjidaguai-china/BossHunter/pull/89#pullrequestreview-5056851017) |
-| [@yukinoshi](https://github.com/yukinoshi) | **28.8%（试算）** | 对简历失败恢复 PR 完成全量测试、前端类型检查和安全红线验证并批准；为评分解释和招呼语队列改动处理冲突、补充合并方案与完整验证。 | [#92 Review](https://github.com/shengjidaguai-china/BossHunter/pull/92#pullrequestreview-5089153466) · [#77 合并分析](https://github.com/shengjidaguai-china/BossHunter/pull/77#issuecomment-5466530159) · [#86 合并验证](https://github.com/shengjidaguai-china/BossHunter/pull/86#issuecomment-5466756964) |
-| [@bianshilong0604](https://github.com/bianshilong0604) | **26.3%（试算）** | 在招呼语网址防护中识别简历隐私、可信网址来源和重复发送边界问题，并在修改后完成复核；同时审查招呼语生成流程的岗位状态与任务并发风险。 | [#88 首轮 Review](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 Review](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **11.0%（试算）** | 对安全锁是否应随账号切换重置完成风险边界研判，并对一键投递失效问题提出分层排查与复现信息要求；相关 Issue 尚未闭环。 | [#78 风险研判](https://github.com/shengjidaguai-china/BossHunter/issues/78#issuecomment-5452233325) · [#93 问题排查](https://github.com/shengjidaguai-china/BossHunter/issues/93#issuecomment-5452071152) |
+| [@yukinoshi](https://github.com/yukinoshi) | **27.8%（试算）** | 城市快照审核发现四项陈旧测试夹具，作者修复后合入；核实 AI 运行环境异常的敏感信息边界；完成定制简历人工确认、母版与路径边界检查。 | [#156 Review](https://github.com/shengjidaguai-china/BossHunter/pull/156#pullrequestreview-5124257029) · [#179 Review](https://github.com/shengjidaguai-china/BossHunter/pull/179#pullrequestreview-5122026768) · [#143 Review](https://github.com/shengjidaguai-china/BossHunter/pull/143#pullrequestreview-5124301792) |
+| [@yuppiez99999](https://github.com/yuppiez99999) | **27.8%（试算）** | 保留 51job API 安全复核与历史协作成果；补充评分解释持久化/白名单审核和账号风险咨询分类闭环。本人采集、城市数据与构建 PR 均只计项目贡献。 | [#142 安全复核](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#77 Review](https://github.com/shengjidaguai-china/BossHunter/pull/77#pullrequestreview-5124525090) · [#168 咨询闭环](https://github.com/shengjidaguai-china/BossHunter/issues/168#issuecomment-5551623715) |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **22.9%（试算）** | 验证前端构建与 wheel 交付，并明确 sdist 等未解决限制；独立复测编排测试并纠正覆盖率基线；真实布局复现监测风险漏检，阻止有缺口的方案直接合入。 | [#147 Review](https://github.com/shengjidaguai-china/BossHunter/pull/147#pullrequestreview-5124304248) · [#151 Review](https://github.com/shengjidaguai-china/BossHunter/pull/151#pullrequestreview-5124304668) · [#73 Review](https://github.com/shengjidaguai-china/BossHunter/pull/73#pullrequestreview-5124305409) |
+| [@bianshilong0604](https://github.com/bianshilong0604) | **21.5%（试算）** | 保留招呼语网址、简历隐私、重复发送和任务并发的历史审核成果；本次未核实新增独立维护成果，不因最近几天无新增记录扣除累计成果。 | [#88 首轮](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 Review](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
 
+### 本次任期评分明细
+
+等级按下文既有 0–5 级标准判断，不按评论或批准次数累加；对未完成的 PR 只记录已经完成的检查，不宣称交付闭环。四个等级依次为维护闭环与影响、Review 与安全质量、响应与推进成果、协作与交接。同分按 GitHub ID 排序，百分比用最大余数法保留一位小数并补齐至 100.0%。
+
+| 维护者 | 四维等级 | 四维加权得分 | 任期综合分 | 贡献占比 |
+|---|---|---|---:|---:|
+| [@yukinoshi](https://github.com/yukinoshi) | 4 / 4 / 4 / 4 | 32 / 24 / 16 / 8 | 80 | 27.8%（试算） |
+| [@yuppiez99999](https://github.com/yuppiez99999) | 4 / 4 / 4 / 4 | 32 / 24 / 16 / 8 | 80 | 27.8%（试算） |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 3 / 4 / 3 / 3 | 24 / 24 / 12 / 6 | 66 | 22.9%（试算） |
+| [@bianshilong0604](https://github.com/bianshilong0604) | 3 / 4 / 2 / 3 | 24 / 24 / 8 / 6 | 62 | 21.5%（试算） |
+
+总分 **288**。每个维度使用上表同一组最多三项代表证据，不将其拆成多条累加。等级判断依据：
+
+- @yuppiez99999：历史安全复核、跨改动兼容检查和咨询闭环形成持续协作结果，四维均为 4；新一轮分流和催办本身不追加分数。
+- @yukinoshi：城市数据回归定位后由作者修复，运行环境问题从诊断建议到独立复核闭环，简历安全检查覆盖具体边界，四维均为 4。#143 的旧批准已被新提交撤销，仅保留其检查内容作为历史工作证据，不视为当前有效批准。
+- @fengziliang43-cmyk：真实浏览器、覆盖率复测和打包验证能发现测试未覆盖的问题，审核质量为 4；已完成的审核交付、推进及交接为 3。#147 的 sdist/安装限制仍未解决，#73 关闭也不等于其问题已经修复，不按完整修复成果计分。
+- @bianshilong0604：#88 的复核闭环和隐私边界识别支持 3 / 4；#90 尚未合入，推进只计 2，协作计 3。综合分是本次按历史证据重新列明的 62 分，不从旧百分比反推。
+
+### 去重与状态核对
+
+- @yuppiez99999 对 #142 的 Review 仅计本页；其本人 #147、#151、#153、#155–#159、#162、#170 的实现、测试及相应 Issue 关闭不重复计维护分。
+- @yukinoshi 在 #77 的代码补丁及其问题发现/修复闭环归项目贡献；@fengziliang43-cmyk 在 #158 的共同实现及其发现/修复闭环也归项目贡献，本次维护评分排除这两组成果。#145 的补丁仍未合入，暂不新增项目分，其同一问题闭环也不进入本次维护评分。
+- 空白批准、已撤销批准的权限效力、参与修改后的自审、机器人输出和纯合并次数均不计分；评价有正文证据的具体检查或已验证的协作结果。
+- 维护者身份沿用 [MAINTAINERS.md](MAINTAINERS.md)。[#186](https://github.com/shengjidaguai-china/BossHunter/issues/186) 仍待申请人补齐资料与边界确认，尚未进入候选观察期。
 
 ## 维护贡献评估
 
@@ -66,3 +88,28 @@
 - 对评分有异议时，提交具体证据和更正请求，由项目负责人决定；旧记录保留，修订说明记录日期和原因。
 - README 的维护贡献摘要由维护者依据本文件同一数据快照同步，不重新评分，也不因同步展示要求项目负责人审核整个 README。
 - 若 PR 同时包含技术改动、维护者任免、权限或技术审核规则，应拆为技术或治理 PR，按对应规则独立审核。
+
+## 历史基线
+
+### 2026-09-03（原始试算，未定稿）
+
+以下保留原始记录；当时的 Issue/PR 状态只表示历史核对结果，不代表本次状态。
+
+<details>
+<summary>展开 2026-09-03 原始试算</summary>
+
+
+以下沿用 2026-09-03 的历史基线试算，数值和证据原样迁入，尚未由项目负责人定稿；迁移不代表本次重新评分或批准已有分数。
+
+以下为截至 **2026-09-03** 已核实的维护活动摘要，仅记录对他人 PR 的 Review、Issue 治理、安全复核和交付协作，不计入本人提交的功能、修复、测试或文档。
+
+| 维护者 | 贡献占比 | 维护贡献摘要 | 代表证据 |
+|---|---:|---|---|
+| [@yuppiez99999](https://github.com/yuppiez99999) | **33.9%（试算）** | 对 51job API 采集完成只读边界、失败关闭、速率控制、断点续采和真实环境验证检查；持续梳理积压 PR 的风险、冲突与合并阻塞项，并主动让原贡献者方案承接合并。 | [#142 安全复核](https://github.com/shengjidaguai-china/BossHunter/pull/142#pullrequestreview-5074202801) · [#139 Review](https://github.com/shengjidaguai-china/BossHunter/pull/139#pullrequestreview-5084448426) · [#89 协作复核](https://github.com/shengjidaguai-china/BossHunter/pull/89#pullrequestreview-5056851017) |
+| [@yukinoshi](https://github.com/yukinoshi) | **28.8%（试算）** | 对简历失败恢复 PR 完成全量测试、前端类型检查和安全红线验证并批准；为评分解释和招呼语队列改动处理冲突、补充合并方案与完整验证。 | [#92 Review](https://github.com/shengjidaguai-china/BossHunter/pull/92#pullrequestreview-5089153466) · [#77 合并分析](https://github.com/shengjidaguai-china/BossHunter/pull/77#issuecomment-5466530159) · [#86 合并验证](https://github.com/shengjidaguai-china/BossHunter/pull/86#issuecomment-5466756964) |
+| [@bianshilong0604](https://github.com/bianshilong0604) | **26.3%（试算）** | 在招呼语网址防护中识别简历隐私、可信网址来源和重复发送边界问题，并在修改后完成复核；同时审查招呼语生成流程的岗位状态与任务并发风险。 | [#88 首轮 Review](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5463732307) · [#88 复核](https://github.com/shengjidaguai-china/BossHunter/pull/88#issuecomment-5466342761) · [#90 Review](https://github.com/shengjidaguai-china/BossHunter/pull/90#issuecomment-5463882496) |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **11.0%（试算）** | 对安全锁是否应随账号切换重置完成风险边界研判，并对一键投递失效问题提出分层排查与复现信息要求；相关 Issue 尚未闭环。 | [#78 风险研判](https://github.com/shengjidaguai-china/BossHunter/issues/78#issuecomment-5452233325) · [#93 问题排查](https://github.com/shengjidaguai-china/BossHunter/issues/93#issuecomment-5452071152) |
+
+
+
+</details>

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ bosshunter run
 
 | GitHub | 身份 | 贡献占比 | 擅长方向 | 任期 |
 |---|---|---|---|---|
-| [@yuppiez99999](https://github.com/yuppiez99999) | 正式维护者（Write） | 33.9%（试算） | 平台采集、城市数据与测试 | 2026-08-29 起 |
-| [@yukinoshi](https://github.com/yukinoshi) | 正式维护者（Write） | 28.8%（试算） | AI、错误恢复与产品流程 | 2026-08-29 起 |
-| [@bianshilong0604](https://github.com/bianshilong0604) | 正式维护者（Write） | 26.3%（试算） | Web、产品流程与隐私边界 | 2026-08-30 起 |
-| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 正式维护者（Write） | 11.0%（试算） | 运行时、发送安全与监测链路 | 2026-08-30 起 |
+| [@yukinoshi](https://github.com/yukinoshi) | 正式维护者（Write） | 26.2%（试算） | AI、错误恢复与产品流程 | 2026-08-29 起 |
+| [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 正式维护者（Write） | 25.4%（试算） | 运行时、发送安全与监测链路 | 2026-08-30 起 |
+| [@yuppiez99999](https://github.com/yuppiez99999) | 正式维护者（Write） | 25.4%（试算） | 平台采集、城市数据与测试 | 2026-08-29 起 |
+| [@bianshilong0604](https://github.com/bianshilong0604) | 正式维护者（Write） | 23.0%（试算） | Web、产品流程与隐私边界 | 2026-08-30 起 |
 | [@powerycy](https://github.com/powerycy) 跑跑蹦蹦跳跳 | 项目负责人兼正式技术维护者（Admin） | 不参评 | 全仓技术审核、安全复核与合并；贡献文档与评分 | 项目发起至今；2026-09-06 起计入技术审核池 |
 
-以上为截至 **2026-09-03**、尚未由项目负责人定稿的历史基线试算。维护者任职满 30 天后，按任期开始至核算日的全部维护成果计算正式贡献占比；不是只计算最近 30 天，也不会每 30 天重置。维护贡献只计算 Review、问题闭环、安全复核、发布验证和治理交接，不计算本人提交的功能或修复。
+截至 **2026-09-07 14:00（Asia/Shanghai）**，以上为经项目负责人确认的试算结果。维护贡献与项目贡献分别记录；0604 的审核团队邀请尚待接受。
 
 [查看维护者任期](MAINTAINERS.md) · [查看维护贡献及评分](MAINTENANCE_CONTRIBUTIONS.md) · [查看技术审核规则](GOVERNANCE.md)
 
@@ -133,37 +133,37 @@ bosshunter run
 
 ## 🔥 近 30 天贡献榜 Top 10
 
-统计窗口：**2026-08-03 至 2026-09-01（Asia/Shanghai）**。采用与总榜相同的影响维度，只计算该窗口内被主线采纳的部分。
+统计窗口：**2026-08-09 至 2026-09-07（Asia/Shanghai）**；实际核对截至 **9 月 7 日 14:00**。只计算该窗口内被主线采纳的部分，同分并列。
 
 | 排名 | 贡献者 | 本期主要贡献 |
 |:---:|---|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | 可恢复岗位工具与智联统一采集架构 |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | 评分 JSON 兼容、错误传播、暂停恢复与凭据优先级 |
-| 🥉 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测会话闭环、安全操作、本地凭据迁移与面板交互 |
-| 4 | [@yuppiez99999](https://github.com/yuppiez99999) | 平台采集回归、能力边界、注册模型与 51job API 安全复核 |
-| 5 | [@yuj-029](https://github.com/yuj-029) | 51job API 只读采集、保守采样与断点续采核心 |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、评分与投递队列 |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置安全、公司屏蔽与城市查询 |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束 |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历、招聘类型与岗位池增强 |
-| 10 | [@zepengfan145-netizen](https://github.com/zepengfan145-netizen) | 招呼语队列体验与虚构网址防护 |
+| 🥇 | [@yuppiez99999](https://github.com/yuppiez99999) | BOSS、51job 与猎聘采集回归；智联 API 与过滤链；三平台续采、城市快照及前端构建交付 |
+| 🥈 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | 会话送达、消息方向与招呼语约束；母版项目保留、PNG/PDF 定制简历预览和显式人工确认 |
+| 🥈 | [@zhenian-666](https://github.com/zhenian-666) | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 |
+| 4 | [@yukinoshi](https://github.com/yukinoshi) | 多 AI 兼容、评分 JSON、错误恢复、凭据优先级与批次删除保护 |
+| 5 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | 监测回复轮次、安全操作、本地凭据与面板交互；猎聘临时失败/保存失败保留断点的共同实现 |
+| 6 | [@haohao-fly](https://github.com/haohao-fly) | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 |
+| 7 | [@hdfhssg](https://github.com/hdfhssg) | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 |
+| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 |
+| 9 | [@Hebuyu688](https://github.com/Hebuyu688) | AI 诊断和模型别名解析、薪资区间过滤、招呼语正向依据与毕业届别校验 |
+| 10 | [@yuj-029](https://github.com/yuj-029) | 51job 页面研究、只读采集核心、API 采样与断点续采实现 |
 
 ## 🏆 贡献总榜 Top 10
 
-只统计实际进入主线的外部人类贡献，不按提交次数或代码行数排名。
+数据快照：**2026-09-07 14:00（Asia/Shanghai）**。只统计实际进入主线的外部人类贡献，按完整榜的四维影响评分归一化；同分并列，不按提交次数或代码行数排名。
 
 | 排名 | 贡献者 | 贡献度 | 主要贡献方向 |
 |:---:|---|:---:|---|
-| 🥇 | [@zhenian-666](https://github.com/zhenian-666) | **11%** | 岗位导出、城市目录、回收站、独立 AI 评分与多平台采集架构 |
-| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **10%** | AI 兼容、评分恢复、错误传播与凭据优先级 |
-| 🥉 | [@GioiaZheng](https://github.com/GioiaZheng) | **9.5%** | API Key 安全、PDF 依赖降级与人工确认流程修复 |
-| 4 | [@atticus-zhou](https://github.com/atticus-zhou) | **8%** | AI 重试、浏览器交互、送达验证与防重复发送 |
-| 5 | [@yuppiez99999](https://github.com/yuppiez99999) | **7.5%** | 平台采集回归、能力边界、注册模型与 51job API 安全复核 |
-| 6 | [@haohao-fly](https://github.com/haohao-fly) | **7%** | 岗位筛选、评分重试、投递队列与任务保护 |
-| 7 | [@meixiaoxie](https://github.com/meixiaoxie) | **6%** | 配置安全、公司屏蔽、城市查询与 Windows 回归测试 |
-| 7 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **6%** | 送达确认、消息方向识别与招呼语约束 |
-| 7 | [@hdfhssg](https://github.com/hdfhssg) | **6%** | 学历与招聘类型筛选、岗位池与投递队列 |
-| 10 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **5.5%** | 监测会话闭环、安全操作、本地凭据迁移与面板交互 |
+| 🥇 | [@yuppiez99999](https://github.com/yuppiez99999) | **10.0%** | BOSS、51job 与猎聘采集回归；智联 API 与过滤链；三平台续采、城市快照及前端构建交付 |
+| 🥈 | [@shuaigechz-cloud](https://github.com/shuaigechz-cloud) | **7.9%** | 会话送达、消息方向与招呼语约束；母版项目保留、PNG/PDF 定制简历预览和显式人工确认 |
+| 🥈 | [@yukinoshi](https://github.com/yukinoshi) | **7.9%** | Thinking 与多 AI 兼容；评分 JSON、错误传播、暂停恢复和凭据优先级；评分期间删除岗位不中断批次 |
+| 🥈 | [@zhenian-666](https://github.com/zhenian-666) | **7.9%** | 多范围岗位导出、城市目录、回收站与独立 AI 评分；统一平台采集架构和智联只读采集 |
+| 5 | [@GioiaZheng](https://github.com/GioiaZheng) | **6.8%** | API Key 脱敏与安全读取；PDF 依赖降级；人工确认、招呼语和发送选择修复 |
+| 6 | [@atticus-zhou](https://github.com/atticus-zhou) | **6.5%** | AI 评分与招呼语重试、前台浏览器交互、送达验证和防重复发送 |
+| 7 | [@fengziliang43-cmyk](https://github.com/fengziliang43-cmyk) | **6.4%** | 监测回复轮次、安全操作、本地凭据与面板交互；猎聘临时失败/保存失败保留断点的共同实现 |
+| 8 | [@haohao-fly](https://github.com/haohao-fly) | **5.4%** | 岗位筛选、分页与统计；结构化评分、失败重试、投递队列和任务保护 |
+| 9 | [@hdfhssg](https://github.com/hdfhssg) | **4.6%** | 学历与招聘类型筛选、评分上下文、岗位池排序、投递队列和额度提示 |
+| 9 | [@meixiaoxie](https://github.com/meixiaoxie) | **4.6%** | 配置原子写入与无凭据下载；公司屏蔽、城市查询与 Windows 回归测试 |
 
 [查看完整榜单、证据链接、历月快照与计算口径](CONTRIBUTORS.md)
 


### PR DESCRIPTION
更新截至 2026-09-07 14:00（Asia/Shanghai）的项目贡献榜和任期维护贡献结果，首页与详情统一展示贡献摘要、占比及证据。同一成果不重复计入两榜，项目实现与对他人工作的审核、复核、推进和交接分别记录。

项目负责人已确认本次结果并授权合并。维护贡献因任职未满 30 天继续标记为试算；发布页面移除逐维评分、计算过程、修订说明和旧试算章节，保留原有 8 月历史榜单。

首页将 bianshilong0604 统一标为“正式维护者（Write）”，候选只在维护者详情中登记 shuaigechz-cloud 的 Triage 状态与接受邀请证据。首页不展示候选，不展示待补资料的申请进度。

验证：文档格式检查通过；项目总榜 25 人、项目和维护占比各合计 100%；首页与详情数字一致；8 月历史快照保持原样。仅修改 README.md、CONTRIBUTORS.md、MAINTENANCE_CONTRIBUTIONS.md、MAINTAINERS.md。
