### PR TITLE
fix(web): 运行/采集启动弹窗防抖+loading，成功即关、失败在弹窗内提示 (#177)

### DIFF
--- a/src/bosshunter/web/frontend/src/components/dashboard/CollectJobsDialog.tsx
+++ b/src/bosshunter/web/frontend/src/components/dashboard/CollectJobsDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ArrowDown, ArrowUp, X } from 'lucide-react'
+import { ArrowDown, ArrowUp, RefreshCw, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
@@ -38,7 +38,8 @@ interface CollectJobsDialogProps {
   mode?: 'collect' | 'full'
   activeTask: WorkbenchTask | null
   onClose: () => void
-  onStart: (options: Record<string, unknown>) => void
+  /** 返回启动结果：成功返回 ok:true（弹窗自动关闭），失败返回错误信息（弹窗保留并展示）。 */
+  onStart: (options: Record<string, unknown>) => Promise<{ ok: boolean; error?: string }>
 }
 
 const initialDrafts: Record<PlatformId, PlatformDraft> = {
@@ -105,6 +106,7 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
   const [order, setOrder] = useState<PlatformId[]>(['boss'])
   const [autoScore, setAutoScore] = useState(false)
   const [error, setError] = useState('')
+  const [starting, setStarting] = useState(false)
   const [resumableRuns, setResumableRuns] = useState<ResumableRun[]>([])
   const [resumeRunId, setResumeRunId] = useState('')
   const [zhilianCities, setZhilianCities] = useState<PlatformCityOption[]>([])
@@ -221,6 +223,7 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
   }
 
   const start = () => {
+    if (starting) return
     if (!enabledOrder.length) {
       setError('至少勾选一个平台。')
       return
@@ -252,7 +255,25 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
         sort: draft.sort,
       }
     }
-    onStart({ platform_order: enabledOrder, auto_score: mode === 'full' ? true : autoScore, platforms })
+    void submit({ platform_order: enabledOrder, auto_score: mode === 'full' ? true : autoScore, platforms })
+  }
+
+  const submit = async (options: Record<string, unknown>) => {
+    if (starting) return
+    setStarting(true)
+    setError('')
+    try {
+      const result = await onStart(options)
+      if (result.ok) {
+        onClose()
+        return
+      }
+      setError(result.error || '启动失败，请稍后重试。')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '启动失败，请稍后重试。')
+    } finally {
+      setStarting(false)
+    }
   }
 
   return (
@@ -264,7 +285,7 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
             <h2 className="mt-1 text-2xl font-black">{mode === 'full' ? '全流程采集设置' : '岗位采集'}</h2>
             <p className="mt-1 text-sm leading-6 text-muted">平台会按队列严格串行执行；每个平台只设置最大页数和排序。</p>
           </div>
-          <Button variant="ghost" size="sm" onClick={onClose} aria-label="关闭"><X className="h-5 w-5" /></Button>
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={starting} aria-label="关闭"><X className="h-5 w-5" /></Button>
         </div>
 
         {mode === 'collect' && <div className="mt-4 rounded-2xl border border-card-border bg-[#FFFCFA] p-4">
@@ -277,7 +298,7 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
                   {new Date(run.created_at.replace(' ', 'T') + 'Z').toLocaleString()} · {run.options.platforms.boss.cities.join('、')} · {run.options.platforms.boss.keywords.join('、')} · 每组 {run.options.platforms.boss.max_pages} 页
                 </option>)}
               </Select>
-              <Button variant="secondary" disabled={Boolean(activeTask) || !resumeRunId} onClick={() => onStart({ resume_run_id: resumeRunId })}>继续采集</Button>
+              <Button variant="secondary" disabled={Boolean(activeTask) || !resumeRunId || starting} onClick={() => void submit({ resume_run_id: resumeRunId })}>继续采集</Button>
             </div>
             <p className="mt-2 text-xs text-muted">{resumableRuns.find(run => run.id === resumeRunId)?.options.auto_score ? '原任务已开启采集后自动评分，继续采集后也会执行评分。' : '原任务未开启自动评分，继续采集后结束。'}</p>
           </> : <p className="mt-2 text-xs text-muted">暂无可恢复任务。新版本开始的 BOSS 单平台采集会保存进度；旧版本记录需重新采集。</p>}
@@ -342,7 +363,7 @@ export function CollectJobsDialog({ open, mode = 'collect', activeTask, onClose,
 
         <label className="mt-4 flex items-center justify-between rounded-2xl border border-card-border bg-white p-4"><div><div className="text-sm font-black">{mode === 'full' ? '全流程自动评分' : '采集后自动评分'}</div><p className="mt-1 text-xs leading-5 text-muted">{mode === 'full' ? '全流程必须先评分；评分后进入人工确认，再按平台适配器执行招呼和监测。' : '默认关闭；开启后只评分本轮新增岗位，评分结束即停止，不发送消息、不投递、不监测。'}</p></div><Switch checked={mode === 'full' || autoScore} onChange={mode === 'full' ? () => undefined : setAutoScore} disabled={mode === 'full'} /></label>
         {error && <div className="mt-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
-        <div className="mt-5 flex justify-end gap-2"><Button variant="secondary" onClick={onClose}>取消</Button><Button onClick={start} disabled={Boolean(activeTask)}>{mode === 'full' ? '开始全流程' : '重新采集'}</Button></div>
+        <div className="mt-5 flex justify-end gap-2"><Button variant="secondary" onClick={onClose} disabled={starting}>取消</Button><Button onClick={() => void start()} disabled={Boolean(activeTask) || starting}>{starting ? <span className="inline-flex items-center gap-2"><RefreshCw className="h-4 w-4 animate-spin" />启动中…</span> : mode === 'full' ? '开始全流程' : '重新采集'}</Button></div>
       </div>
     </div>
   )

--- a/src/bosshunter/web/frontend/src/pages/DashboardPage.tsx
+++ b/src/bosshunter/web/frontend/src/pages/DashboardPage.tsx
@@ -579,17 +579,23 @@ export default function DashboardPage({ view = 'workbench' }: DashboardPageProps
     }
   }
 
-  const startCollection = async (options: Record<string, unknown>) => {
+  const startCollection = async (options: Record<string, unknown>): Promise<{ ok: boolean; error?: string }> => {
     const mode = collectDialogMode
     setModePending(mode)
     setNotice(mode === 'full' ? '全流程启动前预检中...' : '岗位采集启动前预检中...')
     try {
-      if (!(await runPreflight(mode, options))) return
+      if (!(await runPreflight(mode, options))) {
+        setNotice('启动前预检未通过：请按下方检查提示修复后，再重新启动。')
+        return { ok: false, error: '启动前预检未通过：请关闭弹窗后按检查提示修复，再重新启动。' }
+      }
+      setNotice('启动前预检通过，正在启动任务...')
       await startTask(mode, options)
-      setCollectDialogOpen(false)
       setNotice(mode === 'full' ? '全流程已启动，进度会在下方更新。' : '岗位采集已启动，进度会在下方更新。')
+      return { ok: true }
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : '岗位采集启动失败')
+      const message = err instanceof Error ? err.message : '岗位采集启动失败'
+      setNotice(message)
+      return { ok: false, error: message }
     } finally {
       setModePending(null)
     }
@@ -1195,7 +1201,7 @@ export default function DashboardPage({ view = 'workbench' }: DashboardPageProps
         mode={collectDialogMode}
         activeTask={activeTask && (activeTask.mode === 'collect' || activeTask.mode === 'full') ? activeTask : null}
         onClose={() => setCollectDialogOpen(false)}
-        onStart={options => void startCollection(options)}
+        onStart={startCollection}
       />
     </div>
   )


### PR DESCRIPTION
Fix #177

## 根因
首页「运行全流程/岗位采集」的 `CollectJobsDialog` 启动链路存在两处与 #177 期望不符的问题：
1. 点击「开始全流程/重新采集/继续采集」后进入父级预检+启动（数秒），弹窗无 loading、按钮不防抖，可重复提交；预检失败时错误只写入弹窗背后的页面 notice，被遮罩挡住，用户只看到「确认后弹窗不自动关闭、无任何提示」。
2. 成功路径由父级强制关闭、失败不关闭，但失败原因对用户不可见，与 Issue 期望的「成功关闭 + 失败留在弹窗并提示」不一致。

## 修改
- `CollectJobsDialog.tsx`
  - `onStart` 改为返回 `Promise<{ ok, error? }>`，新增 `starting` 状态与统一 `submit()`：
    - 成功 → `onClose()` 自动关闭；
    - 失败 → 弹窗保留并把错误显示在弹窗内（不再只藏在背后 notice）。
  - 启动期间：开始按钮显示 spinner「启动中…」并禁用；取消 / 右上角 X / 继续采集均禁用，防重复提交（防抖）。
  - 对齐同仓 `ScoreJobsDialog` 既有范式。
- `DashboardPage.tsx`
  - `startCollection` 返回 `{ ok, error? }`（预检失败 / 启动异常给出可展示错误），删除父级直接关闭逻辑，改由弹窗按结果自关。

## 验证
- `cd src/bosshunter/web/frontend && npm run build`（tsc + vite build）通过。
- 未做浏览器人工复现；改动为纯前端状态机调整，后端接口无变更。

> 说明：当前首页第三按钮为「单独监测」（直接预检启动、无确认弹窗），与 Issue 描述的 v2.3.2 三按钮弹窗已有差异；本 PR 修复的是现行 UI 中仍存在对应症状的两个弹窗入口（运行/采集）。
