### PR TITLE
fix(test): Mock() 替换为 MagicMock() 防止 sqlite magic method TypeError (#191)

### DIFF
--- a/tests/test_collection_safety.py
+++ b/tests/test_collection_safety.py
@@ -3,7 +3,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 from bosshunter.config import DEFAULTS, load_config
 from bosshunter.db import (
@@ -118,12 +118,12 @@ platforms:
             reopened.close()
 
     def test_collection_risk_stops_and_records_safe_reason(self):
-        db = Mock()
-        progress = Mock()
+        db = MagicMock()
+        progress = MagicMock()
         progress.add_task.return_value = "task"
-        context = Mock()
-        context.__enter__ = Mock(return_value=progress)
-        context.__exit__ = Mock(return_value=False)
+        context = MagicMock()
+        context.__enter__ = MagicMock(return_value=progress)
+        context.__exit__ = MagicMock(return_value=False)
         config = {
             "profile": {"target_cities": ["北京"]},
             "search": {"max_pages": 1},
@@ -148,12 +148,12 @@ platforms:
         self.assertLessEqual(lock_call.kwargs["minutes"], 10)
 
     def test_transient_collection_risk_is_ignored_without_locking(self):
-        db = Mock()
-        progress = Mock()
+        db = MagicMock()
+        progress = MagicMock()
         progress.add_task.return_value = "task"
-        context = Mock()
-        context.__enter__ = Mock(return_value=progress)
-        context.__exit__ = Mock(return_value=False)
+        context = MagicMock()
+        context.__enter__ = MagicMock(return_value=progress)
+        context.__exit__ = MagicMock(return_value=False)
         config = {
             "profile": {"target_cities": ["北京"]},
             "search": {"max_pages": 1},
@@ -183,12 +183,12 @@ platforms:
         guard_cls.return_value.lock.assert_not_called()
 
     def test_consecutive_page_failures_end_collection_without_risk_lock(self):
-        db = Mock()
-        progress = Mock()
+        db = MagicMock()
+        progress = MagicMock()
         progress.add_task.return_value = "task"
-        context = Mock()
-        context.__enter__ = Mock(return_value=progress)
-        context.__exit__ = Mock(return_value=False)
+        context = MagicMock()
+        context.__enter__ = MagicMock(return_value=progress)
+        context.__exit__ = MagicMock(return_value=False)
         config = {
             "profile": {"target_cities": ["北京"]},
             "search": {"max_pages": 3},

--- a/tests/test_scraper_background.py
+++ b/tests/test_scraper_background.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from threading import Event
-from unittest.mock import Mock, call, patch
+from unittest.mock import MagicMock, call, patch
 
 from bosshunter.scraper.jobs import scrape_jobs
 from bosshunter.web.server import _execute_collect
@@ -29,7 +29,7 @@ class ScraperBackgroundTests(unittest.TestCase):
                 hooks.on_candidate(candidate)
             return PlatformCollectionResult("boss", "completed", "search_exhausted", "采集结束")
 
-        registry = CollectorRegistry({"boss": lambda: Mock(collect=collect)})
+        registry = CollectorRegistry({"boss": lambda: MagicMock(collect=collect)})
 
         def score_with_progress(score_config, **options):
             self.assertEqual(options["job_ids"], ["new-scoring-job"])
@@ -60,7 +60,7 @@ class ScraperBackgroundTests(unittest.TestCase):
         self.assertIn("评分结果已保存", task.logs)
 
     def test_stopped_collection_does_not_open_a_search_page(self):
-        db = Mock()
+        db = MagicMock()
         stop_event = Event()
         stop_event.set()
         config = {
@@ -111,12 +111,12 @@ class ScraperBackgroundTests(unittest.TestCase):
         self.assertEqual(task.snapshot()["metrics"], task.metrics)
 
     def test_scraper_reports_seen_new_and_duplicate_counts(self):
-        db = Mock()
-        progress = Mock()
+        db = MagicMock()
+        progress = MagicMock()
         progress.add_task.return_value = "task-1"
-        progress_context = Mock()
-        progress_context.__enter__ = Mock(return_value=progress)
-        progress_context.__exit__ = Mock(return_value=False)
+        progress_context = MagicMock()
+        progress_context.__enter__ = MagicMock(return_value=progress)
+        progress_context.__exit__ = MagicMock(return_value=False)
         updates = []
         collected_job_ids = []
         jobs = [
@@ -159,12 +159,12 @@ class ScraperBackgroundTests(unittest.TestCase):
         })
 
     def test_search_and_detail_pages_reuse_one_background_worker_tab(self):
-        db = Mock()
-        progress = Mock()
+        db = MagicMock()
+        progress = MagicMock()
         progress.add_task.return_value = "task-1"
-        progress_context = Mock()
-        progress_context.__enter__ = Mock(return_value=progress)
-        progress_context.__exit__ = Mock(return_value=False)
+        progress_context = MagicMock()
+        progress_context.__enter__ = MagicMock(return_value=progress)
+        progress_context.__exit__ = MagicMock(return_value=False)
 
         jobs = [{
             "title": "AI Product Manager",


### PR DESCRIPTION
## 这次改变了什么

将 `tests/test_collection_safety.py` 和 `tests/test_scraper_background.py` 中冒充 sqlite 连接的测试替身从 `Mock()` 统一替换为 `MagicMock()`。

`Mock()` 不实现 magic method（`__int__`、`__enter__`、`__exit__` 等），当被测代码路径走到 `int(cursor.rowcount)` 或上下文管理器协议时，Mock 占位会抛 `TypeError`。`MagicMock` 实现了全部 magic method，后续新增任何 magic method 用法都不会再回归。

## 证据与影响范围

- 关联 Issue：Fixes #191
- 影响的项目或规则：仅测试文件，不改变生产代码
- 是否涉及许可证、资金、权限或个人信息：否

## 根因

`db.py` 中以下函数使用 `int(cursor.rowcount or 0)`：
- `clear_collected_combos` (L1183)
- `prune_collected_combos` (L1200)
- `clear_page_progress` (L1272)
- `delete_page_progress` (L1282)
- `prune_page_progress` (L1295)

当测试用 `Mock()` 冒充 sqlite 连接且代码路径经过这些函数时，`Mock().rowcount` 返回 Mock 对象，`int(Mock_object)` 抛 `TypeError`。

## 修复

将两个测试文件中的 `Mock()` → `MagicMock()`（共 29 处），import 语句同步更新。`MagicMock` 的 `__int__` 默认返回 1，`rowcount` 不会再触发 `TypeError`。

## 验证

```bash
py -3.11 -m pytest tests/test_collection_safety.py tests/test_scraper_background.py -q
# 17 passed in 2.34s
```

## 自检

- [x] `pytest -q tests/test_collection_safety.py tests/test_scraper_background.py` 通过（17 passed）
- [x] `git diff --check` 通过
- [x] 未修改 API Key、发送限额、冷却时间或平台安全配置
- [x] 不在 `db.py` 做 `int(...)` 静默兜底——那会把真实连接的 rowcount 取值异常也一起吞掉
