### PR TITLE
fix(tests): 修复 Python 3.10 下 datetime.UTC 导致测试套件无法运行

### DIFF
--- a/tests/test_web_api_routes.py
+++ b/tests/test_web_api_routes.py
@@ -4,7 +4,7 @@ import tempfile
 import time
 import unittest
 from socketserver import ThreadingMixIn
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.parse import quote
 from unittest.mock import MagicMock, patch
@@ -37,6 +37,14 @@ from threading import Event, Lock
 from bosshunter.scoring_run_store import create_scoring_run, get_scoring_run, update_scoring_run
 from bosshunter.collection_run_store import create_collection_run, update_collection_run
 from bosshunter.web.tasks import TaskAlreadyRunningError, WorkbenchTask, WorkbenchTaskRunner
+
+# datetime.UTC 自 Python 3.11 才提供，而 pyproject.toml 声明支持 >=3.10
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone as _timezone
+
+    UTC = _timezone.utc
 
 
 def _job(job_id: str) -> dict:


### PR DESCRIPTION
## 改动内容

`tests/test_web_api_routes.py` 导入了 `datetime.UTC`（Python 3.11 才提供），而 `pyproject.toml` 声明 `requires-python = ">=3.10"`。在 Python 3.10（例如 Ubuntu 22.04 自带的默认 Python）上执行 `pytest` 会在**收集阶段**报：

```text
ImportError: cannot import name 'UTC' from 'datetime'
1 error during collection
```

整套测试完全无法运行，与贡献指南「运行相关测试」的要求相悖，也会劝退在 3.10 环境下按 CONTRIBUTING 走流程的新贡献者。

本 PR 改为 `try/except` 回退到 `timezone.utc`（`datetime.UTC` 自 3.11 起就是 `timezone.utc` 的别名），对 3.11+ 的行为零影响；回退块放在全部 import 之后，避免把原有的 import 块拆开引入新的 ruff I001。

## 验证（Ubuntu 22.04 实测）

| 环境 | 修复前 | 修复后 |
|---|---|---|
| Python 3.10.12 | `1 error during collection`，任何测试都无法运行 | `tests/test_web_api_routes.py` **114 passed + 4 subtests** |
| Python 3.12.13（~/bhenv） | 该文件 114 passed + 4 subtests | 相同结果，无回归 |

唯一失败的 `test_run_server_uses_threaded_wsgi_server` 需要先构建前端 `dist` 才能运行（`server.py` 的启动检查），与本改动无关，修复前后、3.10 与 3.12 上行为一致。

`ruff check tests/test_web_api_routes.py`：修复前后均为 15 条存量发现，零新增（CI 仅执行 `ruff check src/`，tests/ 不在 lint 范围内）。

## 关联

无对应 issue；属于「Bug 修复」类贡献，影响面仅为测试文件，不触及采集、发送与人工确认逻辑。
